### PR TITLE
fix(deps): pin mcp<2 — 2.0.0 deleted `mcp.server.fastmcp` (#95)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,7 +51,13 @@ openai = ["openai>=1.40"]
 # The SDK requires Python >=3.10, so the dep is gated by an environment marker:
 # on 3.9 the extra resolves to nothing (the CLI stays 3.9-compatible; only this
 # one optional command needs 3.10+). Imported lazily, like the openai extra.
-mcp = ["mcp>=1.2; python_version>='3.10'"]
+# Upper-bounded as of 2026-07-29 (#95): mcp 2.0.0, published 2026-07-28, deletes
+# `mcp.server.fastmcp` -- `mcp.server` now exposes `mcpserver` instead. The old
+# unbounded `mcp>=1.2` turned that into a red CI on every branch within the hour,
+# on 3.10-3.13 only (2.0 declares requires-python >=3.10, so the 3.9 job kept
+# resolving 1.x and stayed green). 1.29.0 is the current 1.x and still ships
+# FastMCP. Lift this when `mcp_serve.py` is ported to the 2.x server API.
+mcp = ["mcp>=1.2,<2; python_version>='3.10'"]
 # Test-only: `pexpect` drives the real CLI on a pty in tests/test_drive_cli.py.
 # Deliberately NOT in `all` -- `all` is a *runtime* install, and the CI `package`
 # job's "a base install pulls in nothing third-party" proof must stay meaningful.


### PR DESCRIPTION
Closes #95. Unblocks #93 and anything else open.

## What happened

`mcp 2.0.0` hit PyPI **2026-07-28 13:45 UTC**. The last green `master` run (`10fded3`) was
**12:27 UTC**. `pyproject.toml` had `mcp>=1.2` with no upper bound, so every job since
resolves 2.0.0 and dies at import:

```
ModuleNotFoundError: No module named 'mcp.server.fastmcp'
```

`test_mcp_serve` and `test_mcp_client` go down wholesale.

## Why only 3.10–3.13 went red

mcp 2.0.0 declares `requires-python >=3.10`. The 3.9 job can't resolve it, keeps a 1.x
release, and stays green. That asymmetry is the tell — no code change produces a failure
pattern shaped like a resolver outcome.

## Verified, not inferred

Checked in a throwaway venv rather than trusting the traceback:

| version | `from mcp.server.fastmcp import FastMCP` |
|---|---|
| 1.29.0 | OK |
| 2.0.0 | `ModuleNotFoundError` |

In 2.0, `mcp.server` exposes `mcpserver` where `fastmcp` used to be — so this is a rename
to port to, not a package that disappeared.

## Pin, don't port

`venice mcp-serve` is the only consumer, but it advertises 9 tools and the rail/pin
invariants mean the 2.x port needs its own verification pass. Landing it as a side effect of
unbreaking the build is how you get a quiet regression in the tool surface. #95 stays open to
track the port; the comment on the pin says what to do when it's lifted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)