### PR TITLE
test(drive): honor effective user-site configuration (#107)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -56,6 +56,9 @@ It exists because patching `builtins.input` proves a *branch* runs; it can't
 prove the prompt reached a terminal in a usable order. Read the rules in
 `tests/_drive.py`'s docstring before adding a case — each one (pty CRLF, echoed
 input, the agent spinner) is a flake source already paid for once.
+The child's import path mirrors the parent's effective site configuration:
+user-site packages are included only when the parent interpreter has user-site
+imports enabled, and the child disables HOME-derived user-site discovery.
 
 ## House style
 

--- a/tests/_drive.py
+++ b/tests/_drive.py
@@ -100,7 +100,7 @@ def _python_path() -> str:
     candidates = []
     if hasattr(site, "getsitepackages"):  # absent under some virtualenvs
         candidates.extend(site.getsitepackages())
-    if hasattr(site, "getusersitepackages"):
+    if site.ENABLE_USER_SITE and hasattr(site, "getusersitepackages"):
         candidates.append(site.getusersitepackages())
     for entry in candidates:
         if entry and os.path.isdir(entry) and entry not in parts:
@@ -131,6 +131,10 @@ def build_env(home, *, base_url=None, api_key="test-fake-key") -> dict:
         "PYTHONUTF8": "1",
         "PYTHONIOENCODING": "utf-8",
         "PYTHONDONTWRITEBYTECODE": "1",
+        # The user's effective site configuration is already represented in
+        # PYTHONPATH above. Do not let the child's redirected HOME re-enable a
+        # user site that the parent interpreter deliberately disabled.
+        "PYTHONNOUSERSITE": "1",
         "TERM": "dumb",
         "COLUMNS": "200",
         "LINES": "24",

--- a/tests/test_drive_cli.py
+++ b/tests/test_drive_cli.py
@@ -23,11 +23,13 @@ import importlib.util
 import json
 import os
 import shutil
+import site
 import stat
 import subprocess
 import tempfile
 import unittest
 from pathlib import Path
+from unittest import mock
 
 import venice
 from tests import _drive
@@ -37,6 +39,23 @@ _HAS_OPENAI = importlib.util.find_spec("openai") is not None
 
 needs_pty = unittest.skipUnless(_drive.HAS_PEXPECT, _drive.SKIP_REASON)
 needs_openai = unittest.skipUnless(_HAS_OPENAI, "openai SDK not installed")
+
+
+class TestDrivePythonPath(unittest.TestCase):
+    def test_user_site_follows_parent_effective_configuration(self):
+        with tempfile.TemporaryDirectory() as user_site:
+            with mock.patch.object(site, "getusersitepackages", return_value=user_site):
+                with mock.patch.object(site, "ENABLE_USER_SITE", False):
+                    disabled = _drive._python_path().split(os.pathsep)
+                with mock.patch.object(site, "ENABLE_USER_SITE", True):
+                    enabled = _drive._python_path().split(os.pathsep)
+
+        self.assertNotIn(user_site, disabled)
+        self.assertIn(user_site, enabled)
+
+    def test_child_disables_home_derived_user_site(self):
+        with tempfile.TemporaryDirectory() as home:
+            self.assertEqual(_drive.build_env(home)["PYTHONNOUSERSITE"], "1")
 
 
 class _DriveCase(unittest.TestCase):


### PR DESCRIPTION
Fixes #107

## Reproduction
In a Python 3.9 virtualenv, `site.ENABLE_USER_SITE` is `False`, but the pre-fix `tests/_drive.py:_python_path()` still appended `site.getusersitepackages()`. That gave the child a mixed import path containing a directory the parent intentionally ignored.

## Root cause
The harness treated the user-site path as available based on the path helper existing, rather than the interpreter flag that controls whether user-site imports are enabled. The child could also re-derive a user site from the redirected HOME.

## Fix
- Append the user-site directory only when `site.ENABLE_USER_SITE` is true.
- Set `PYTHONNOUSERSITE=1` in the child environment so HOME redirection cannot silently re-enable user-site discovery.
- Add regression coverage for both effective flag states and the child environment.
- Document the effective-site contract for contributors.

## Validation
- `TMPDIR=/private/tmp make test` — 1,399 passed, 11 skipped.
- `make drive` — 33 passed.
- `make lint` — syntax OK.
- Focused `TestDrivePythonPath` — 2 passed.
- `git diff --check` — clean.

Assisted-by: OpenAI Codex