### PR TITLE
feat(scan): reject invisible-Unicode payloads that survive a diff-read (#109)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -50,6 +50,12 @@ jobs:
       - name: Lint
         run: make lint
 
+      # Its own step rather than only a unittest: `make test` covers it too,
+      # but a named check that goes red on its own line is the difference
+      # between "a test failed" and "someone pushed a hidden character."
+      - name: Scan for invisible characters
+        run: make scan
+
       - name: Test
         run: make test
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -31,14 +31,28 @@ without pip. Don't mix the two: both own `~/.local/bin/venice`.
 ```sh
 make test    # unittest, no network, no API key required
 make lint    # compileall syntax check
+make scan    # invisible-character scan over every tracked file
 make drive   # the drive suite + its fake-API fixture (a subset of `make test`)
 ```
 
-`make test` and `make lint` must be green. Tests are hermetic: `urlopen` is
+`make test`, `make lint` and `make scan` must be green. Tests are hermetic: `urlopen` is
 mocked, `subprocess` and `shutil.which` are patched, `HOME` is redirected to a
 tmpdir, and the OpenAI SDK is mocked. **No test should ever make a real API call
 or need a real key.** If you find yourself wanting to hit the live API in a test,
 that's a sign the seam is in the wrong place.
+
+### The invisible-character scan
+
+`make scan` (and a regression test that runs it under `make test`) rejects
+source containing characters a reviewer cannot see: zero-width joiners, the
+bidi overrides behind "Trojan Source", Unicode tag characters, variation
+selectors, private-use codepoints, and non-ASCII identifiers such as a Cyrillic
+`a` in `api_key`. Reading the diff is how PRs here get reviewed, and a diff is
+exactly what this class of payload is built to survive.
+
+**Visible punctuation is fine** -- em dashes, arrows, `…`, `≤` and friends are
+all in use already. The rule is drawn at invisibility, not at non-ASCII, so if
+the scan ever flags something with a glyph, that's a bug in the scan.
 
 ### The drive suite
 

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: install uninstall test drive lint build clean
+.PHONY: install uninstall test drive lint scan build clean
 
 install:
 	@./install.sh
@@ -25,6 +25,14 @@ drive:
 lint:
 	@python3 -m compileall -q src tests
 	@echo "syntax OK"
+
+# Invisible-character scan (#109) -- the review pass a human diff-read can't
+# do. `make test` runs the same scan as a regression test and *skips* it
+# outside a git checkout; this target hard-fails there instead. A security
+# guard that silently scans nothing is worse than no guard, because it prints
+# OK. Same split as test/drive: the suite degrades, the explicit target won't.
+scan:
+	@python3 -m tests._hygiene
 
 build:
 	@rm -rf dist

--- a/tests/_hygiene.py
+++ b/tests/_hygiene.py
@@ -1,0 +1,205 @@
+"""Reject source characters that are invisible to a diff (#109).
+
+Every other guard in this suite asks whether the code is *correct*. This one
+asks whether the code a reviewer read is the code the interpreter runs.
+
+The GlassWorm class of supply-chain payload hides executable source inside
+codepoints that render as nothing in an editor, in `git diff`, and in the
+GitHub review UI: zero-width joiners, the bidi overrides behind "Trojan
+Source", Unicode tag characters (a full ASCII alphabet with no glyphs), and
+variation selectors. A homoglyph identifier -- Cyrillic `a` in `api_key` --
+is the same attack wearing a visible costume: the reviewer sees the right
+word and the parser binds a different name.
+
+Reading the diff cannot catch any of this, and reading the diff is how every
+PR here is reviewed. That was tolerable while every PR came from `gobha-me`;
+#108 was the first one that didn't.
+
+**Visible punctuation is deliberately legal.** The repo already contains 181
+em dashes, plus arrows, ellipses and `<=`/`>=` glyphs in prose and CLI output.
+A guard that flagged those would be turned off the first week, so the rule is
+drawn at *invisibility*, not at non-ASCII: if it has a glyph, it passes.
+
+The identifier pass tokenizes rather than pattern-matches for the same reason
+-- it is what keeps a horizontal ellipsis legal inside a docstring while
+rejecting one spliced into a variable name.
+
+Scanning `git ls-files` rather than walking the tree is deliberate: the
+authoritative set is what is actually committed and shipped, not whatever
+happens to be sitting in a working copy. Without git (an unpacked sdist) there
+is no such set -- `scan_repo` returns `None` and callers decide, exactly as
+`make test` skips the pty suite without pexpect while `make drive` hard-fails.
+"""
+import io
+import subprocess
+import sys
+import tokenize
+import unicodedata
+from collections import namedtuple
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+
+Finding = namedtuple("Finding", "path line col label detail")
+
+# Variation selectors report as Mn (a combining mark), not Cf, so the category
+# sweep below genuinely cannot see them -- hence the explicit ranges. Private
+# use needs no such range: `unicodedata.category` returns Co across the BMP
+# block and both supplementary planes, which the Co branch already covers.
+_VARIATION_SELECTORS = ((0xFE00, 0xFE0F), (0xE0100, 0xE01EF))
+
+# The only whitespace that may appear literally. Tabs are load-bearing in the
+# Makefile; CR is tolerated so a CRLF checkout is not a security finding.
+_ALLOWED_CONTROLS = "\n\r\t"
+
+
+def classify(ch: str):
+    """The suspect class of `ch`, or None if it is legitimate.
+
+    Anything with a visible glyph returns None -- see the module docstring on
+    why the line is drawn at invisibility rather than at non-ASCII.
+    """
+    code = ord(ch)
+    category = unicodedata.category(ch)
+    if any(lo <= code <= hi for lo, hi in _VARIATION_SELECTORS):
+        return "VARIATION_SELECTOR"
+    if category == "Cf":
+        # Zero-width joiners, U+FEFF, the bidi overrides, and the U+E0000 tag
+        # alphabet all land here. This is the main event.
+        return "INVISIBLE_FORMAT"
+    if category == "Co":
+        return "PRIVATE_USE"
+    if category == "Cc" and ch not in _ALLOWED_CONTROLS:
+        return "CONTROL"
+    if category == "Zs" and ch != " ":
+        # Non-breaking and en/em spaces: indistinguishable from a space on
+        # screen, distinct to the parser.
+        return "UNUSUAL_SPACE"
+    if category in ("Zl", "Zp"):
+        return "LINE_SEPARATOR"
+    return None
+
+
+def scan_text(path, text):
+    """Findings for one file's decoded text."""
+    findings = []
+    for line_no, line in enumerate(text.splitlines(), 1):
+        for col, ch in enumerate(line, 1):
+            if ch.isascii():
+                continue
+            label = classify(ch)
+            if label:
+                try:
+                    name = unicodedata.name(ch)
+                except ValueError:
+                    name = "<unnamed>"
+                findings.append(
+                    Finding(path, line_no, col, label, f"U+{ord(ch):04X} {name}")
+                )
+    return findings
+
+
+def scan_identifiers(path, data):
+    """Findings for non-ASCII NAME tokens -- the homoglyph half.
+
+    A file that will not tokenize is *not* reported here: `make lint` compiles
+    every source in the repo and CI does it on five interpreters, so a genuine
+    syntax error is already caught, loudly, somewhere that explains itself. The
+    character sweep above still runs on the file either way, so nothing is
+    hidden by declining to guess here.
+    """
+    findings = []
+    try:
+        for token in tokenize.tokenize(io.BytesIO(data).readline):
+            if token.type == tokenize.NAME and not token.string.isascii():
+                findings.append(
+                    Finding(
+                        path,
+                        token.start[0],
+                        token.start[1] + 1,
+                        "NON_ASCII_IDENTIFIER",
+                        repr(token.string),
+                    )
+                )
+    except (tokenize.TokenError, SyntaxError, IndentationError, UnicodeDecodeError):
+        pass
+    return findings
+
+
+def scan_file(path, data):
+    """Findings for one file, given its raw bytes."""
+    if data.startswith(b"\xef\xbb\xbf"):
+        return [Finding(path, 1, 1, "UTF8_BOM", "byte-order mark")]
+    try:
+        text = data.decode("utf-8")
+    except UnicodeDecodeError as exc:
+        return [Finding(path, 0, 0, "NOT_UTF8", str(exc))]
+    findings = scan_text(path, text)
+    if path.endswith(".py"):
+        findings.extend(scan_identifiers(path, data))
+    # The two passes overlap on one input: `tokenize` reports a bare zero-width
+    # character as a NAME token, so the sweep and the identifier pass both flag
+    # it. They are otherwise complementary -- a Cyrillic `a` is a perfectly
+    # visible letter the sweep ignores by design. Collapse by position, keeping
+    # the sweep's label, so one character is never two findings.
+    seen = set()
+    unique = []
+    for finding in findings:
+        if (finding.line, finding.col) in seen:
+            continue
+        seen.add((finding.line, finding.col))
+        unique.append(finding)
+    return unique
+
+
+def tracked_files(root=REPO_ROOT):
+    """Every file git is tracking, or None when this is not a git checkout."""
+    try:
+        out = subprocess.run(
+            ["git", "-C", str(root), "ls-files", "-z"],
+            capture_output=True,
+            check=True,
+        ).stdout
+    except (OSError, subprocess.CalledProcessError):
+        return None
+    return [name for name in out.decode("utf-8").split("\0") if name]
+
+
+def scan_repo(root=REPO_ROOT):
+    """All findings across the tracked set, or None without git."""
+    names = tracked_files(root)
+    if names is None:
+        return None
+    findings = []
+    for name in names:
+        path = Path(root) / name
+        if not path.is_file():
+            continue  # tracked but deleted in the working tree
+        findings.extend(scan_file(name, path.read_bytes()))
+    return findings
+
+
+def format_findings(findings):
+    return "\n".join(
+        f"  {f.path}:{f.line}:{f.col}  {f.label}  {f.detail}" for f in findings
+    )
+
+
+def main():
+    findings = scan_repo()
+    if findings is None:
+        print("scan: not a git checkout -- nothing to scan", file=sys.stderr)
+        return 1
+    if findings:
+        print(
+            f"scan: {len(findings)} invisible-character finding(s):\n"
+            + format_findings(findings),
+            file=sys.stderr,
+        )
+        return 1
+    print("scan: clean")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/test_source_hygiene.py
+++ b/tests/test_source_hygiene.py
@@ -1,0 +1,149 @@
+"""Guard for the invisible-character scanner (#109).
+
+The scan itself lives in `tests/_hygiene.py`; this asserts it actually bites.
+
+Two halves, and the second matters as much as the first:
+
+* every invisible class is caught -- otherwise the guard is decoration;
+* every *visible* punctuation mark already in the repo stays legal -- otherwise
+  the guard is noise, and a noisy guard gets deleted the first time someone
+  types an em dash.
+
+No literal suspect character appears in this file. They are all built with
+`chr()` at runtime, so this source stays plain ASCII and is scanned by
+`test_the_repository_is_clean` on the same terms as everything else. A guard
+that has to exempt itself from its own rule is not a guard.
+"""
+import subprocess
+import tempfile
+import unittest
+from pathlib import Path
+
+from tests import _hygiene
+
+# (codepoint, expected label) -- one representative per class the scanner
+# claims to cover. Named rather than inlined so a failure says which attack
+# slipped through.
+SUSPECT = [
+    (0x200B, "INVISIBLE_FORMAT"),  # zero width space
+    (0x200D, "INVISIBLE_FORMAT"),  # zero width joiner
+    (0xFEFF, "INVISIBLE_FORMAT"),  # BOM used mid-file
+    (0x202E, "INVISIBLE_FORMAT"),  # right-to-left override (Trojan Source)
+    (0x2066, "INVISIBLE_FORMAT"),  # left-to-right isolate
+    (0xE0041, "INVISIBLE_FORMAT"),  # tag capital A -- the glyphless alphabet
+    (0xFE0F, "VARIATION_SELECTOR"),
+    (0xE0101, "VARIATION_SELECTOR"),
+    (0xE000, "PRIVATE_USE"),
+    (0xF0001, "PRIVATE_USE"),
+    (0x0007, "CONTROL"),  # bell
+    (0x00A0, "UNUSUAL_SPACE"),  # non-breaking space
+    (0x2003, "UNUSUAL_SPACE"),  # em space
+    (0x2028, "LINE_SEPARATOR"),
+]
+
+# Everything the repo legitimately uses today. If a change to `classify` starts
+# flagging these, the scan has become unusable and this test says so.
+LEGITIMATE = [0x2014, 0x2192, 0x2026, 0x00B7, 0x2264, 0x2265, 0x00D7, 0x2022]
+
+
+class TestClassify(unittest.TestCase):
+    def test_every_suspect_class_is_caught(self):
+        for code, label in SUSPECT:
+            with self.subTest(codepoint=f"U+{code:04X}"):
+                self.assertEqual(_hygiene.classify(chr(code)), label)
+
+    def test_visible_punctuation_stays_legal(self):
+        for code in LEGITIMATE:
+            with self.subTest(codepoint=f"U+{code:04X}"):
+                self.assertIsNone(_hygiene.classify(chr(code)))
+
+    def test_plain_ascii_is_legal(self):
+        for ch in " \t\n\rabcXYZ0189_-#\"'()[]{}<>=/\\|@$%&*+~`^!?.,;:":
+            with self.subTest(char=repr(ch)):
+                self.assertIsNone(_hygiene.classify(ch))
+
+
+class TestScanFile(unittest.TestCase):
+    def test_reports_position_and_codepoint(self):
+        text = "alpha = 1\nbeta =" + chr(0x200B) + " 2\n"
+        findings = _hygiene.scan_file("x.py", text.encode("utf-8"))
+        self.assertEqual(len(findings), 1)
+        found = findings[0]
+        self.assertEqual((found.path, found.line, found.col), ("x.py", 2, 7))
+        self.assertEqual(found.label, "INVISIBLE_FORMAT")
+        self.assertIn("U+200B", found.detail)
+
+    def test_clean_source_yields_nothing(self):
+        source = '"""Doc with an em dash ' + chr(0x2014) + ' and ok."""\nx = 1\n'
+        self.assertEqual(_hygiene.scan_file("x.py", source.encode("utf-8")), [])
+
+    def test_leading_bom_is_a_finding(self):
+        findings = _hygiene.scan_file("x.py", b"\xef\xbb\xbfx = 1\n")
+        self.assertEqual([f.label for f in findings], ["UTF8_BOM"])
+
+    def test_invalid_utf8_is_a_finding(self):
+        findings = _hygiene.scan_file("x.py", b"x = '\xff\xfe'\n")
+        self.assertEqual([f.label for f in findings], ["NOT_UTF8"])
+
+    def test_homoglyph_identifier_is_caught(self):
+        # Cyrillic 'a' (U+0430) inside an otherwise ordinary name.
+        source = "api_key = 1\n" + chr(0x0430) + "pi_key = 2\n"
+        findings = _hygiene.scan_file("x.py", source.encode("utf-8"))
+        self.assertEqual([f.label for f in findings], ["NON_ASCII_IDENTIFIER"])
+        self.assertEqual(findings[0].line, 2)
+
+    def test_visible_punctuation_in_a_docstring_is_not_an_identifier_finding(self):
+        # The reason the identifier pass tokenizes instead of pattern-matching.
+        source = '"""Ellipsis ' + chr(0x2026) + ' and arrow ' + chr(0x2192) + '."""\n'
+        self.assertEqual(_hygiene.scan_file("x.py", source.encode("utf-8")), [])
+
+    def test_identifier_pass_is_python_only(self):
+        source = chr(0x0430) + "pi_key: not python\n"
+        self.assertEqual(_hygiene.scan_file("notes.md", source.encode("utf-8")), [])
+
+    def test_unparseable_python_still_gets_the_character_sweep(self):
+        # `make lint` owns syntax errors; the character sweep must not be
+        # skippable by handing the tokenizer something it cannot read.
+        source = "def broken(\n" + chr(0x200B) + "\n"
+        labels = [f.label for f in _hygiene.scan_file("x.py", source.encode("utf-8"))]
+        self.assertIn("INVISIBLE_FORMAT", labels)
+
+
+class TestScanRepo(unittest.TestCase):
+    def test_the_repository_is_clean(self):
+        findings = _hygiene.scan_repo()
+        if findings is None:
+            self.skipTest("not a git checkout")
+        self.assertEqual(findings, [], "\n" + _hygiene.format_findings(findings))
+
+    def test_the_scan_covers_the_whole_tracked_set(self):
+        # A scan that silently looked at nothing would pass the test above.
+        names = _hygiene.tracked_files()
+        if names is None:
+            self.skipTest("not a git checkout")
+        self.assertIn("src/venice/__init__.py", names)
+        self.assertIn("tests/_hygiene.py", names)
+        self.assertIn(".github/workflows/test.yml", names)
+        self.assertGreater(len(names), 100)
+
+    def test_a_planted_payload_is_found_end_to_end(self):
+        # Proves the git-driven path reports, not just `scan_file`.
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            subprocess.run(["git", "init", "-q", str(root)], check=True)
+            payload = root / "payload.py"
+            payload.write_text("x = 1  #" + chr(0xE0041) + "\n", encoding="utf-8")
+            subprocess.run(
+                ["git", "-C", str(root), "add", "payload.py"], check=True
+            )
+            findings = _hygiene.scan_repo(root)
+        self.assertEqual([f.path for f in findings], ["payload.py"])
+        self.assertEqual(findings[0].label, "INVISIBLE_FORMAT")
+
+    def test_without_git_the_scan_says_so_rather_than_passing(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            self.assertIsNone(_hygiene.scan_repo(Path(tmp)))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Fixes #109.

Adds the one review pass a human diff-read cannot do.

## Why

#108 was the first pull request from outside `gobha-me`. It was reviewed the way
every PR here is reviewed -- by reading the diff -- and a diff is precisely the
artifact this class of payload is built to survive. Nothing in the repo looked
for hidden characters: no CodeQL, no secret scanning, no Dependabot, no
invisible-character check.

## What it catches

| class | example | why a reviewer misses it |
| --- | --- | --- |
| `Cf` format | `U+200B`, `U+200D`, `U+FEFF` | zero glyph |
| bidi override | `U+202E`, `U+2066` | reorders the *display*, not the parse ("Trojan Source") |
| Unicode tags | `U+E0000`-`U+E007F` | a full ASCII alphabet with no glyphs |
| variation selectors | `U+FE00`-`U+FE0F` | category `Mn`, so a `Cf` filter alone misses them |
| private use | `U+E000`, planes 15-16 | tofu or nothing, font-dependent |
| unusual spaces | `U+00A0`, `U+2003` | indistinguishable from a space |
| homoglyph identifiers | Cyrillic `а` in `api_key` | *visible*, and still wrong |
| BOM / non-UTF-8 | | invisible by construction |

## Design notes

- **The rule is invisibility, not non-ASCII.** The repo already has 181 em dashes
  plus arrows, ellipses and `≤`/`≥`/`×`. A guard that flagged those would be
  disabled within a week, so anything with a glyph passes — and
  `test_visible_punctuation_stays_legal` pins that direction too.
- **`git ls-files`, not a tree walk.** The authoritative set is what is actually
  committed and shipped, not what happens to be in a working copy.
- **`tokenize`, not a regex,** for the homoglyph pass. That is what keeps `…` legal
  inside a docstring while rejecting one spliced into an identifier.
- **`make scan` hard-fails where the unittest skips**, including when there is no git
  checkout to scan. A security guard that silently scans nothing is worse than no
  guard, because it prints OK. Same split as `make drive` vs `make test`.
- **The guard does not exempt itself.** No literal suspect character appears in the
  test file; they are all built with `chr()` at runtime, so
  `tests/test_source_hygiene.py` is scanned on the same terms as everything else.
- Stdlib only, per the house rule. No new dependency.
- Its own CI step as well as a unittest: a named check going red on its own line is
  the difference between "a test failed" and "someone pushed a hidden character."

## Validation

- `make test` — 1414 passed (1399 + 15 new). `make drive` — 33 passed. `make lint`, `make scan` — clean.
- **Mutation-tested, 11/11 caught.** Each detector class dropped individually, plus
  "classify always returns clean", "scan nothing at all", and "treat a missing git
  checkout as clean" — every one turns the guard red. Over-flagging an em dash also
  fails, so the guard cannot drift into noise.
- **End-to-end:** planting a real `U+200B` in `src/venice/config.py` gives

  ```
  scan: 1 invisible-character finding(s):
    src/venice/config.py:1:63  INVISIBLE_FORMAT  U+200B ZERO WIDTH SPACE
  ```

  while `git diff --stat` reports only `1 insertion(+), 1 deletion(-)` and the diff
  shows nothing visibly changed. That contrast is the whole argument for the feature.

## Note

Baseline is clean — zero findings across all 122 tracked files. The guard lands green
on purpose; the value is the day it doesn't.
