### PR TITLE
docs(drive): record the effective-site contract where it is actually read (#107)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -70,9 +70,12 @@ It exists because patching `builtins.input` proves a *branch* runs; it can't
 prove the prompt reached a terminal in a usable order. Read the rules in
 `tests/_drive.py`'s docstring before adding a case — each one (pty CRLF, echoed
 input, the agent spinner) is a flake source already paid for once.
+
 The child's import path mirrors the parent's effective site configuration:
 user-site packages are included only when the parent interpreter has user-site
-imports enabled, and the child disables HOME-derived user-site discovery.
+imports enabled, and the child disables HOME-derived user-site discovery. That
+distinction is invisible until you run the suite from a venv, where
+`site.ENABLE_USER_SITE` is `False` (#107).
 
 ## House style
 

--- a/tests/_drive.py
+++ b/tests/_drive.py
@@ -84,6 +84,14 @@ def _python_path() -> str:
       with ``pip install --user``, and `venice chat` dies with "needs the openai
       package" instead of running the test.
 
+      The user site dir is included only when this interpreter actually honours
+      it (``site.ENABLE_USER_SITE``), which is **False** inside a venv -- the
+      setup CONTRIBUTING.md tells contributors to use. Appending it regardless
+      inverts the contract in the line above: the child would get *more* than
+      the parent, out of a directory the parent deliberately opted out of, and
+      resolve half a package from one interpreter's worldview and half from
+      another's (#107).
+
     Deliberately **not** the whole of ``sys.path``: under ``make test`` that
     includes the repo root and ``tests/``, and PYTHONPATH precedes the stdlib on
     the child's path -- so a future fixture named after a stdlib module

--- a/tests/test_drive_cli.py
+++ b/tests/test_drive_cli.py
@@ -42,6 +42,8 @@ needs_openai = unittest.skipUnless(_HAS_OPENAI, "openai SDK not installed")
 
 
 class TestDrivePythonPath(unittest.TestCase):
+    """The child's import path, and the two things that keep it coherent (#107)."""
+
     def test_user_site_follows_parent_effective_configuration(self):
         with tempfile.TemporaryDirectory() as user_site:
             with mock.patch.object(site, "getusersitepackages", return_value=user_site):
@@ -54,6 +56,11 @@ class TestDrivePythonPath(unittest.TestCase):
         self.assertIn(user_site, enabled)
 
     def test_child_disables_home_derived_user_site(self):
+        # Defense in depth, and deliberately so: the tmp $HOME has no `.local`,
+        # so the child derives no user site today with or without this. It
+        # pins the *intent* -- membership in the user site dir stays something
+        # the parent states through PYTHONPATH, never something $HOME implies
+        # the day a fixture starts writing into the redirected home.
         with tempfile.TemporaryDirectory() as home:
             self.assertEqual(_drive.build_env(home)["PYTHONNOUSERSITE"], "1")
 


### PR DESCRIPTION
Follow-up polish on #108 — the three review nits I flagged there but did not want to round-trip with an outside contributor over.

- **`tests/_drive.py`** — `_python_path`'s docstring still described the user-site append as unconditional. #107 quoted that docstring as *"its stated contract"*, and it is what a maintainer reads before touching this function, so the `ENABLE_USER_SITE` clause belongs there and not only in CONTRIBUTING.
- **`CONTRIBUTING.md`** — the note added in #108 had no blank line before it, so it rendered as part of the preceding paragraph about pty flake sources. Split, and says where the distinction becomes visible (a venv).
- **`tests/test_drive_cli.py`** — records that `PYTHONNOUSERSITE` is defense-in-depth: the tmp `$HOME` has no `.local`, so it changes nothing today. Without that note the next reader sees a guard with no live failure mode and deletes it.

No behavior change. `make test` 1414, `make drive` 33, `make lint` and `make scan` clean.