### PR TITLE
feat(usage): meter the four subagent rails into the parent ledger (#117)

### DIFF
--- a/README.md
+++ b/README.md
@@ -819,10 +819,14 @@ Details and safety:
   auto-compaction's summarization calls are now counted toward the total, and are
   skipped when the cap has already tripped and no turn will follow — but a forced
   final answer still compacts if it must (shipping the full history would fail the
-  turn outright), and an explicit `/compact` still runs. It does **not** yet count
-  subagent turns (`--scout`, `--spawn`, `--review`, `--web-search`), which still
-  build their own throwaway ledgers — that half is tracked separately, so on a
-  rail-heavy run the cap bounds less than its name suggests. Config-backable via
+  turn outright), and an explicit `/compact` still runs. As of #117 it counts
+  **every API call the CLI makes** — the main loop, auto-compaction, and all four
+  subagent rails (`--scout`, `--spawn`, `--review`, `--web-search`). Each rail is
+  priced against **its own** model's catalog rate, so a `--review-model` costlier
+  than the coding model is billed as what it actually is, and each lands in its own
+  off-loop bucket so the main loop's cache-hit signal stays uncontaminated (a
+  subagent starts a fresh prefix every time, and averaging that in would fabricate a
+  cache cliff). Config-backable via
   `defaults.chat.session_max_spend` /
   `defaults.code.session_max_spend`. Distinct from `--max-spend` (the per-call
   tool cap). A model with unknown pricing is counted (tokens) but not charged.
@@ -1340,8 +1344,11 @@ API calls:
     #12             18,800 in   58% cached      174 out      3.6s
     #13             19,900 in   58% cached      182 out      3.8s
     #14             19,880 in   91% cached      210 out      3.4s
-  off-loop      2.4s  across 1 API call(s)  [not in the trace above]
+  off-loop     36.1s  across 9 API call(s)  [not in the trace above]
     compaction  1 call(s)     88,110 in      420 out     $0.0031
+    review      3 call(s)     12,000 in    1,800 out     $0.0090
+    scout       4 call(s)      6,200 in      900 out     $0.0038
+    web_search  1 call(s)        800 in      120 out     $0.0008
 ```
 
 Cold-from-#1, a mid-run cliff and a compaction sawtooth each have a distinct shape
@@ -1351,12 +1358,20 @@ seconds, exactly as the session-wide rate refuses to print a fabricated `0.0%`.
 Compaction markers are never elided, and the elided span carries its own totals so
 the rows still add back up to the header.
 
-The `off-loop` block is the calls this CLI made that were **not** conversation turns
-— today just compaction's own summarization call. They are billed and shown, but kept
-out of the trace above on purpose: each one is a fresh prefix that reads ~0% cached,
-so averaging it in would manufacture exactly the cliff the trace exists to detect.
-`[+1 off-loop]` on the header is what stops the smaller `across 14` reading as the
-whole story.
+The `off-loop` block is the calls this CLI made that were **not** conversation turns:
+compaction's own summarization call, plus one row per subagent rail (`scout`, `spawn`,
+`review`, `web_search`). They are billed and shown, but kept out of the trace above on
+purpose: each one is a fresh prefix that reads ~0% cached, so averaging it in would
+manufacture exactly the cliff the trace exists to detect. `[+1 off-loop]` on the header
+is what stops the smaller `across 14` reading as the whole story.
+
+Each rail is priced against **its own** model — `--review-model` is deliberately a
+different model from the one authoring, and billing its tokens at the author's rate
+would be a fabricated number. Rail seconds are a *subset* of the wall clock and are not
+disjoint from the `tools` block: a rail's API time sits inside the `venice_scout` /
+`venice_spawn` / `venice_review` tool window containing it, and under `--parallel`
+several rails overlap each other, so the block says `[concurrent -- exceeds wall]`
+rather than quietly summing past the wall clock.
 
 Note that **one API call is not one turn**: `usage.turns` counts the times the CLI
 made you wait (one whole `code` run, one REPL turn), while a single turn that
@@ -1375,16 +1390,22 @@ Rows are capped at the first 50 plus the most recent 200, so a long session keep
 both its cold-start evidence and its current state; each row carries its `n`, so a
 jump in the sequence is itself the drop marker.
 
-Compaction's own summarization call **is** metered, into a separate `usage.buckets`
-partition rather than into the rows above — it is a fresh prefix, so it reads ~0%
-cached every time and would fabricate a cache cliff if it were averaged in with the
-conversation. The event row carries what that one compaction cost; the bucket carries
-the running total. `usage.api_calls_total` therefore counts **main-loop** calls only,
-and the `calls` header names the difference (`[+2 off-loop]`).
+Compaction's summarization call and every subagent rail **are** metered, each into its
+own `usage.buckets` partition rather than into the rows above — they are fresh prefixes,
+so they read ~0% cached every time and would fabricate a cache cliff if averaged in with
+the conversation. The event row carries what one compaction cost; the bucket carries the
+running total. `usage.api_calls_total` therefore counts **main-loop** calls only, and the
+`calls` header names the difference (`[+2 off-loop]`).
+
+The run footer names the off-loop share too, but stays short: one or two buckets are
+listed (`[incl. $0.0031 compaction]`), and past that it collapses to
+`[incl. $0.0180 off-loop]` and defers to `/usage` for the per-rail breakdown.
 
 ```bash
 # what has compaction cost this session?
 jq '.usage.buckets.compaction' ~/.config/venice/sessions/<id>.json
+# what did the rails cost -- which one is eating the budget?
+jq '.usage.buckets' ~/.config/venice/sessions/<id>.json
 # the whole bill, main loop + off-loop
 jq '.usage.billed_total' ~/.config/venice/sessions/<id>.json
 ```

--- a/src/venice/commands/_agent.py
+++ b/src/venice/commands/_agent.py
@@ -337,7 +337,7 @@ class CostLedger:
     _CALLS_TAIL = 200
 
     def __init__(self, max_spend: Optional[float] = None,
-                 max_tokens: Optional[int] = None):
+                 max_tokens: Optional[int] = None, *, mirror=None):
         # A non-positive cap means "uncapped" (mirrors --max-tool-calls 0).
         cap = float(max_spend) if max_spend is not None else None
         self.max_spend = cap if (cap is not None and cap > 0) else None
@@ -422,9 +422,9 @@ class CostLedger:
         # WHICH SPEND PARTITION a call belongs to. They are not the same question and
         # must not share a name.
         self.context_events: List[dict] = []
-        # #101: off-loop spend, partitioned by bucket name ("compaction" today;
-        # "subagent" when the rails slice lands). name -> {calls, cost, prompt_tokens,
-        # completion_tokens, seconds, unpriced}.
+        # #101: off-loop spend, partitioned by bucket name -- "compaction", plus one per
+        # subagent rail as of #117 ("scout"/"spawn"/"review"/"web_search"). name ->
+        # {calls, cost, prompt_tokens, completion_tokens, seconds, unpriced, unreported}.
         #
         # A SEPARATE partition rather than more weight on the counters above, because
         # merging would corrupt the one signal the main-loop numbers exist to carry:
@@ -436,10 +436,24 @@ class CostLedger:
         # "cache buckets" (the `cache_read`/`cache_write` split above) is an unrelated
         # use of the word; it is never a `bucket=` argument and never a key in here.
         self.buckets: Dict[str, dict] = {}
-        # No lock here, unlike `tools` above, and the absence is deliberate rather than an
-        # oversight: `record_tool` is called from pool workers, but `record()` only ever
-        # runs on the thread that owns the ledger (parallel dispatch touches `on_tool`
-        # alone, and every subagent gets its own fresh ledger).
+        # #117: this DID go unlocked, on the reasoning that `record()` only ever ran on
+        # the thread owning the ledger. The rails slice ends that: a mirrored child
+        # (below) writes its parent's row from whatever pool worker ran the subagent, and
+        # under `--parallel` up to `_MAX_PARALLEL` scouts/spawns do it at once. Same
+        # read-modify-write shape as `_tools_lock`, same GIL caveat -- see that comment.
+        # Held around the row mutation ONLY (never the cost arithmetic), and never nested
+        # with `_tools_lock`, so the two cannot deadlock.
+        self._buckets_lock = threading.Lock()
+        # #117: `(parent_ledger, bucket_name)`, or None for every main-loop ledger. Set on
+        # a SUBAGENT ledger so each of its API calls is also banked into the parent's
+        # off-loop bucket -- see `record`. Bound here rather than passed per call because
+        # `record()` is the one chokepoint every rail's usage already flows through, so no
+        # call site *can* forget it (the two rails that call the API outside `run_loop`,
+        # `_review._retry_for_verdict` and `run_web_search`, are covered for free).
+        if mirror is not None and mirror[0] is self:
+            # Would double-count the ledger into its own bucket on every record.
+            raise ValueError("CostLedger: a ledger cannot mirror into itself")
+        self._mirror = mirror
         self._in = None          # per-token input rate (USD)
         self._out = None         # per-token output rate (USD)
         self._cache_in = None    # per-token cache-read rate (USD); None -> use _in
@@ -745,17 +759,63 @@ class CostLedger:
             **row,
         ))
 
+    def record_bucket(self, name: str, *, cost: float = 0.0,
+                      prompt_tokens: int = 0, completion_tokens: int = 0,
+                      seconds=None, unpriced: bool = False,
+                      unreported: bool = False) -> None:
+        """Accumulate one off-loop API call into the `name` bucket (#101/#117).
+
+        A PURE accumulator, like `record_turn`/`record_tool`: it takes numbers that have
+        already been costed and never reads a `usage` block, so `record()` below remains
+        the one and only place any API usage is parsed. That split is what lets a
+        mirrored child (#117) hand its parent an already-priced row without the parent
+        re-reading -- and re-mis-pricing, at the wrong model's rate -- the same usage.
+
+        The ONE live writer of a bucket row: `record()`'s off-loop branch delegates here
+        rather than keeping a second copy of these seven lines (`restore()` is the other
+        writer, and `new_bucket_row` already exists because that duplication drifts).
+
+        Callers must not hold `_buckets_lock`; this takes it, and takes it around the
+        mutation only.
+        """
+        with self._buckets_lock:
+            row = self.buckets.setdefault(name, self.new_bucket_row())
+            row["calls"] += 1
+            # #98's rule, one partition over: a response with no usage block leaves the
+            # tokens and the cost UNKNOWN, not zero. The main loop can say so per-row
+            # (the trace stores null) and dodges it in aggregate by having a
+            # "(no tokens reported)" branch; a bucket has neither, so it needs its own
+            # sticky marker or `0 in  0 out  $0.0000` would read as a measurement.
+            if unreported:
+                row["unreported"] = True
+            row["cost"] += cost
+            row["prompt_tokens"] += _as_int(prompt_tokens)
+            row["completion_tokens"] += _as_int(completion_tokens)
+            # Rounded on the way in like `record_turn`'s; an unstamped window adds 0.
+            row["seconds"] = round(row["seconds"] + _as_float(seconds), 3)
+            # Sticky-OR, mirroring the top-level `unpriced` -- one uncosted call in the
+            # bucket taints the bucket's total, and a later priced one must not clear it.
+            row["unpriced"] = row["unpriced"] or unpriced
+
     def bucket_cost(self, name=None) -> float:
         """Off-loop spend (#101): one bucket's cost, or every bucket's when `name` is None."""
         if name is not None:
             return float(self.buckets.get(name, {}).get("cost", 0.0))
-        return sum(float(b.get("cost", 0.0)) for b in self.buckets.values())
+        # #117: snapshot under the lock. A mirrored child adds a NEW KEY on a pool
+        # worker, and iterating a dict while another thread inserts into it raises
+        # outright. Reads happen on the main thread while workers are joined today, so
+        # this is insurance rather than a live fix -- but it is two lines.
+        with self._buckets_lock:
+            rows = list(self.buckets.values())
+        return sum(float(b.get("cost", 0.0)) for b in rows)
 
     def bucket_calls(self, name=None) -> int:
         """Off-loop API calls (#101) -- deliberately NOT part of `api_calls_total`."""
         if name is not None:
             return int(self.buckets.get(name, {}).get("calls", 0))
-        return sum(int(b.get("calls", 0)) for b in self.buckets.values())
+        with self._buckets_lock:      # #117: see `bucket_cost`
+            rows = list(self.buckets.values())
+        return sum(int(b.get("calls", 0)) for b in rows)
 
     @staticmethod
     def new_bucket_row() -> dict:
@@ -865,7 +925,14 @@ class CostLedger:
         This stays the ONE place any API usage is read. `bucket=` is a parameter rather
         than a second method for that reason: a `record_offloop()` sibling would be a
         second read site to keep in agreement with this one, which is how the
-        bookkeeping #86/#92/#99 kept centralizing gets scattered again.
+        bookkeeping #86/#92/#99 kept centralizing gets scattered again. `record_bucket`
+        is not a counter-example -- it takes already-costed numbers and never parses a
+        usage block, which is exactly why the #117 mirror below can route through it.
+
+        #117: if this ledger was built with a `mirror`, the call is ALSO banked into the
+        parent's bucket, at the tail. Everything above is unchanged by that -- a mirrored
+        child keeps its own full main-loop accounting, which is what `over_tokens()` and
+        so `--subagent-max-tokens` read.
         """
         # FIRST, ahead of everything below: `record(None)` dumping `usage-raw: null`
         # is exactly the diagnostic that was missing -- it separates "the response had
@@ -944,23 +1011,11 @@ class CostLedger:
             # is `api_calls_total - head - tail`, so counting a call that never appended
             # a row would make `/usage` report phantom dropped rows; and the trace is a
             # PREFIX-cache diagnostic that a fresh-prefix call would only pollute.
-            row = self.buckets.setdefault(bucket, self.new_bucket_row())
-            row["calls"] += 1
-            # #98's rule, one partition over: a response with no usage block leaves the
-            # tokens and the cost UNKNOWN, not zero. The main loop can say so per-row
-            # (the trace stores null) and dodges it in aggregate by having a
-            # "(no tokens reported)" branch; a bucket has neither, so it needs its own
-            # sticky marker or `0 in  0 out  $0.0000` would read as a measurement.
-            if usage is None:
-                row["unreported"] = True
-            row["cost"] += cost
-            row["prompt_tokens"] += _as_int(pt)
-            row["completion_tokens"] += _as_int(ct)
-            # Rounded on the way in like `record_turn`'s; an unstamped window adds 0.
-            row["seconds"] = round(row["seconds"] + _as_float(seconds), 3)
-            # Sticky-OR, mirroring the top-level `unpriced` -- one uncosted call in the
-            # bucket taints the bucket's total, and a later priced one must not clear it.
-            row["unpriced"] = row["unpriced"] or unpriced_turn
+            self.record_bucket(
+                bucket, cost=cost, prompt_tokens=_as_int(pt),
+                completion_tokens=_as_int(ct), seconds=seconds,
+                unpriced=unpriced_turn, unreported=usage is None,
+            )
         else:
             self._append_call({
                 "prompt_tokens": pt,
@@ -975,6 +1030,34 @@ class CostLedger:
                 # None stays None -- an unstamped window is unknown, not instant.
                 "seconds": None if seconds is None else round(_as_float(seconds), 3),
             })
+        # #117: a SUBAGENT ledger also banks this call into its parent's off-loop bucket.
+        # Placed at the one chokepoint every rail's usage already flows through, so the
+        # two rails that call the API outside `run_loop` (`_review._retry_for_verdict`,
+        # `run_web_search`) are covered without either site knowing a parent exists.
+        #
+        # `record_bucket`, NOT `parent.record(usage, bucket=...)`, and all three reasons
+        # are load-bearing:
+        #   - PRICING. `cost` above was computed at THIS ledger's rate. `--review-model`
+        #     and `--web-search-model` are deliberately a different model from the
+        #     parent's, so re-costing the same usage over there would quietly bill the
+        #     reviewer's tokens at the author's rate -- a fabricated number, which is the
+        #     one thing this ledger refuses to print.
+        #   - ONE RAW DUMP. `_dump_raw_usage` fires at the top of this method; routing
+        #     through `record()` again would emit a second `usage-raw:` line for one API
+        #     call, interleaved with other workers' lines under `--parallel`.
+        #   - NO RECURSION. `record_bucket` is a leaf, so a mirror does not propagate to
+        #     a grandparent. That is also the correct arithmetic: a grandparent bucket
+        #     would double-count spend a parent bucket has already banked.
+        # `usage is None` (not `pt is None`) is the unreported test, evaluated after
+        # `_usage_dict` above, so an SDK object that normalized to nothing counts as
+        # unreported rather than as a measured zero.
+        if self._mirror is not None:
+            parent, name = self._mirror
+            parent.record_bucket(
+                name, cost=cost, prompt_tokens=_as_int(pt),
+                completion_tokens=_as_int(ct), seconds=seconds,
+                unpriced=unpriced_turn, unreported=usage is None,
+            )
         return cost
 
     def over(self) -> bool:
@@ -1055,12 +1138,17 @@ class CostLedger:
         on the one surface that cannot afford to. The `[incl. ...]` clause names the
         off-loop share, gated on there being one.
 
-        The three sites that can receive a SUBAGENT ledger are byte-identical today,
-        and by structure rather than luck: `run_scout`/`run_spawn`/`run_review` never
-        pass a `budget`, `maybe_compact` short-circuits without one, so a subagent
-        ledger can never acquire a bucket. **The rails slice of #101 deletes exactly
-        that invariant** -- when subagent spend starts landing in a bucket, re-walk
-        these six call sites.
+        The three sites that can receive a SUBAGENT ledger are byte-identical, and by
+        structure rather than luck: `run_scout`/`run_spawn`/`run_review` never pass a
+        `budget`, `maybe_compact` short-circuits without one, so a subagent ledger can
+        never acquire a bucket.
+
+        #117 was expected to delete that invariant and did NOT -- worth stating, because
+        the issue predicted the opposite and the next reader will assume it landed. A
+        mirrored subagent ledger writes its parent's `buckets`, never its own, so these
+        messages still render `cost: $X (tokens ...)` with no clause. What DID change is
+        that the parent now has more bucket NAMES, which is why the clause below is
+        bounded instead of joining an unbounded list.
         """
         # Built once so the clause reaches BOTH branches below: the command-level tests
         # all render the unpriced one (the catalog fake carries no `pricing`), which is
@@ -1078,11 +1166,12 @@ class CostLedger:
         billed = self.billed_total()
         unpriced = self.any_unpriced()
         off = self.bucket_cost()
-        # #101: `billed`, not `total`, in the GUARD too. Today they agree whenever this
-        # branch is reachable (one model, one set of rates, so unpriced main implies
-        # unpriced bucket). The rails slice breaks that -- a differently-priced subagent
-        # would leave `total == 0.0` next to a real bucket cost, and this branch would
-        # print "(unpriced — model rate unknown)" over the top of it.
+        # #101: `billed`, not `total`, in the GUARD too, and as of #117 that is no longer
+        # a precaution. The rails made mixed pricing REACHABLE: `--review-model` can be a
+        # priced model while the author's is not, leaving `total == 0.0` beside a real
+        # `review` bucket cost. Guarding on `total` would print
+        # "(unpriced — model rate unknown)" straight over the top of money we did measure.
+        # `any_unpriced()` still flags the half we could not price, below.
         if unpriced and billed == 0.0:
             return f"cost: (unpriced — model rate unknown) {toks}"
         s = f"cost: ${billed:.4f}"
@@ -1101,10 +1190,18 @@ class CostLedger:
         # non-zero but formats as `$0.0000`, and `[incl. $0.0000 compaction]` names a
         # share of nothing -- #98's fabricated zero wearing a clause.
         if off > 0 and f"{off:.4f}" != "0.0000":
-            names = "/".join(sorted(
+            names = sorted(
                 k for k, v in self.buckets.items() if _as_float(v.get("cost")) > 0
-            ))
-            s += f" [incl. ${off:.4f} {names}]"
+            )
+            # #117: BOUNDED. One or two names are the useful case and read well; five
+            # (`compaction/review/scout/spawn/web_search`, reachable with
+            # `--planner --review --web-search`) is 44 characters of clause on a footer
+            # that is also two stop-reason messages, and it grows again with every future
+            # bucket. Past two, defer to `/usage`, which breaks the same partition down
+            # per row -- and reuse ITS word for the whole partition rather than coining a
+            # third, so `[incl. $X off-loop]` and the `off-loop` block name one thing.
+            label = "/".join(names) if len(names) <= 2 else "off-loop"
+            s += f" [incl. ${off:.4f} {label}]"
         return s
 
     def usage_report(self) -> str:
@@ -1416,8 +1513,15 @@ class CostLedger:
 
         These calls are deliberately absent from the `calls` trace above, so without
         this block the money would be in `to_dict()` and on no human surface at all.
-        Sorted by NAME, like `to_dict`: one row today, two after the rails slice, so
-        the stable order matters more than a by-cost ranking would.
+        Sorted by NAME, like `to_dict`: `compaction` plus one row per subagent rail as
+        of #117, so the stable order matters more than a by-cost ranking would.
+
+        The seconds here are a SUBSET of `elapsed_seconds`, never a partition of it, and
+        as of #117 they are not even disjoint from `self.tools`: a rail's API time sits
+        inside the `venice_scout`/`venice_spawn`/`venice_review` tool window that
+        contains it. Under `--parallel` several rails' windows also overlap each other,
+        so the sum can exceed wall outright -- labelled below rather than hidden, exactly
+        as `_tool_lines` labels the same state for tools.
         """
         if not self.buckets:
             return []
@@ -1428,8 +1532,14 @@ class CostLedger:
         # explicitly rather than by luck -- "off-loop" happens to be 8 characters, and
         # renaming it would otherwise slide the duration out of the shared grid.
         dur = "n/a" if (not secs and self.bucket_calls()) else format_duration(secs)
-        lines = [f"  {'off-loop':<8}{dur:>10}  "
-                 f"across {self.bucket_calls()} API call(s)  [not in the trace above]"]
+        head = (f"  {'off-loop':<8}{dur:>10}  "
+                f"across {self.bucket_calls()} API call(s)  [not in the trace above]")
+        # #117: same predicate and same wording as `_tool_lines`/`tools_fragment`. One
+        # state must not grow two vocabularies across two blocks of one report -- an
+        # operator reading `/usage` top to bottom would take them for two states.
+        if self.turns and secs > self.elapsed_seconds + 0.001:
+            head += "  [concurrent -- exceeds wall]"
+        lines = [head]
         for name in sorted(self.buckets):
             row = self.buckets[name]
             pt = _as_int(row.get("prompt_tokens"))
@@ -1513,9 +1623,15 @@ def _pricing_for(models, model_id):
     return None
 
 
-def _build_ledger(cap, models, model_id) -> CostLedger:
-    """A CostLedger bound to `model_id`'s catalog pricing (cap may be None)."""
-    ledger = CostLedger(max_spend=cap)
+def _build_ledger(cap, models, model_id, *, max_tokens=None,
+                  mirror=None) -> CostLedger:
+    """A CostLedger bound to `model_id`'s catalog pricing (cap may be None).
+
+    The ONLY caller of `bind_pricing`, deliberately: pricing a ledger is exactly
+    "look this model up in the catalog", and a second site would be a second place
+    to forget the lookup (which is how every rail ended up unpriced before #117).
+    """
+    ledger = CostLedger(max_spend=cap, max_tokens=max_tokens, mirror=mirror)
     pricing = _pricing_for(models, model_id)
     if pricing is not None:
         ledger.bind_pricing(pricing)
@@ -1547,6 +1663,30 @@ def usage_ledger(args, models, model_id) -> CostLedger:
     ledger meters usage without gating (`over()` is None-safe).
     """
     return _build_ledger(getattr(args, "session_max_spend", None), models, model_id)
+
+
+def subagent_ledger(models, model_id, *, max_tokens=None,
+                    mirror=None) -> CostLedger:
+    """The per-invoke ledger for one subagent rail (#117).
+
+    ONE constructor for all four rails (scout/spawn/review/web search), so a fifth
+    gets both halves for free and cannot ship with either missing:
+
+    - PRICED against `model_id`'s own catalog entry. The rails used to build a bare
+      `CostLedger(max_tokens=...)` on the reasoning that token counting needs no
+      catalog -- true while the tokens went nowhere, false the moment they are billed
+      to a parent. `--review-model` and `--web-search-model` are deliberately NOT the
+      parent's model, so the rate has to be looked up per rail, here.
+    - MIRRORED into the parent's off-loop bucket when a parent exists (`mirror`), and
+      standalone when it does not -- `venice review` has no parent ledger and must
+      keep working, so `mirror=None` is a supported state rather than an oversight.
+
+    `max_tokens` is #52's per-worker ceiling and still meters this ledger's OWN
+    main-loop counters, so `--subagent-max-tokens` is unchanged by the mirror.
+    Uncapped in USD (`cap=None`): the parent's `--session-max-spend` is the money gate,
+    and it now sees this spend through the bucket.
+    """
+    return _build_ledger(None, models, model_id, max_tokens=max_tokens, mirror=mirror)
 
 
 def dispatch_map(tools: List[Tool]) -> Dict[str, Tool]:
@@ -1597,7 +1737,7 @@ def _web_citations(venice_params) -> List[dict]:
 
 
 def run_web_search(oai, model: str, query: str, *, mode: str = "on",
-                   models=None) -> dict:
+                   models=None, mirror=None) -> dict:
     """Make ONE Venice web-search completion and return its answer + citations (#77).
 
     Rides `/chat/completions` with `venice_parameters.enable_web_search` (`mode`: "on"
@@ -1628,11 +1768,21 @@ def run_web_search(oai, model: str, query: str, *, mode: str = "on",
     msg = getattr(choices[0], "message", None) if choices else None
     answer = (getattr(msg, "content", None) or "").strip() if msg is not None else ""
     citations = _web_citations(getattr(resp, "venice_parameters", None))
-    led = _build_ledger(None, models, model)
+    # #117: still this call's OWN ledger -- priced against `model`, which is the resolved
+    # web-search model and NOT necessarily the caller's. `mirror` (when the rail was built
+    # with a parent) also banks the call into the parent's `web_search` bucket, which is
+    # what finally puts these tokens on the books: pre-#117 only `cost_estimate_usd`
+    # survived and every token count died here.
+    led = subagent_ledger(models, model, mirror=mirror)
     cost = led.record(getattr(resp, "usage", None), seconds=time.monotonic() - _t0)
     # Best-effort: report None (unknown) -- not $0.00 -- when we can't estimate, i.e. the
     # model price is unknown OR the response carried no usage tokens. A billed feature that
     # reports 0.0 reads as "free", which is worse than an honest "unknown".
+    #
+    # NOT made redundant by the bucket above, and the two must both stay: this field is
+    # MODEL-visible handoff provenance (the agent reads it to decide whether to search
+    # again), the bucket is OPERATOR accounting. Deleting either to "de-duplicate" loses
+    # a different audience.
     known = not led.unpriced and (led.prompt_tokens or led.completion_tokens)
     return {
         "status": "ok",

--- a/src/venice/commands/_code.py
+++ b/src/venice/commands/_code.py
@@ -1040,7 +1040,8 @@ def scout_tool(oai, model, root: str, client, base_kwargs, *,
                default_max_tool_calls: int = _SCOUT_MAX_TOOL_CALLS,
                hard_cap: int = _SCOUT_HARD_CAP,
                max_tokens: Optional[int] = None,
-               dispatches: Optional[list] = None) -> _agent.Tool:
+               dispatches: Optional[list] = None,
+               models=None, parent_ledger=None) -> _agent.Tool:
     """Build the `venice_scout` Tool: delegate a read-only investigation to a
     disposable subagent (context firewall, #52).
 
@@ -1063,11 +1064,18 @@ def scout_tool(oai, model, root: str, client, base_kwargs, *,
     appended for the `venice_merge` rollup. `None` (the default) records nothing.
 
     Per-subagent token cap: `max_tokens` (`--subagent-max-tokens`, None = uncapped) bounds
-    the scout's cumulative prompt+completion tokens. A fresh per-invoke `CostLedger` (built
-    for every call, so `tokens` is always reported) meters the nested loop; `run_loop`'s
-    token gate forces a final answer once the ceiling is crossed. The ledger is unpriced
-    (token counting needs no catalog) and per-invoke, so it stays thread-safe under
-    `--parallel`. The report carries `tokens`/`token_cap` for handoff provenance.
+    the scout's cumulative prompt+completion tokens. A fresh per-invoke ledger (built for
+    every call, so `tokens` is always reported) meters the nested loop; `run_loop`'s token
+    gate forces a final answer once the ceiling is crossed. Per-invoke, so it stays
+    thread-safe under `--parallel`. The report carries `tokens`/`token_cap` for handoff
+    provenance.
+
+    `models`/`parent_ledger` (#117): the ledger is now PRICED (`_agent.subagent_ledger`)
+    and mirrored into the parent's `scout` bucket, so a scout's turns reach the footer,
+    `/usage` and `--session-max-spend` instead of dying with the call. It was unpriced
+    before on the reasoning that token counting needs no catalog -- true only while the
+    tokens went nowhere. The mirror is a SIDE CHANNEL: nothing about it may ride `out`
+    below, which is the tool result the MODEL reads (see #99's containment pin).
     """
     root = os.path.realpath(root)
 
@@ -1084,7 +1092,11 @@ def scout_tool(oai, model, root: str, client, base_kwargs, *,
         inner = read_only_tools(root, client, include_search=include_search)
         if web_tool is not None:
             inner.append(web_tool)  # #77 "docs scout": read-only + web discovery
-        led = _agent.CostLedger(max_tokens=max_tokens)  # per-invoke -> --parallel-safe
+        # per-invoke -> --parallel-safe; priced + mirrored to the parent's bucket (#117)
+        led = _agent.subagent_ledger(
+            models, model, max_tokens=max_tokens,
+            mirror=(parent_ledger, "scout") if parent_ledger is not None else None,
+        )
         try:
             out = _agent.run_scout(
                 oai, model, task, inner, base_kwargs,
@@ -1118,7 +1130,7 @@ def scout_tool(oai, model, root: str, client, base_kwargs, *,
 
 
 def web_search_tool(oai, model: str, *, models=None, search_model=None,
-                    mode: str = "on") -> _agent.Tool:
+                    mode: str = "on", parent_ledger=None) -> _agent.Tool:
     """Build the `venice_web_search` rail Tool (#77): DISCOVER docs on the web.
 
     Makes one Venice web-search completion (via `_agent.run_web_search`) against a
@@ -1138,8 +1150,16 @@ def web_search_tool(oai, model: str, *, models=None, search_model=None,
 
     Model choice is operator-controlled (`search_model` / the coding `model`), resolved
     once here and never model-facing, so the model can't escalate to a costlier model.
+
+    `parent_ledger` (#117) banks each search into the parent's `web_search` bucket. Note
+    this ONE Tool object is handed both to the parent's tool list and to the scout's inner
+    set (`code.py` builds it once), so the mirror is bound here, once: a search bills the
+    same bucket whoever called it, and a search made INSIDE a scout is billed exactly once
+    (to `web_search`) while the scout's own turns bill `scout`. Rolling child ledgers up
+    into their caller instead would have double-counted precisely this shared object.
     """
     resolved = _agent.resolve_web_search_model(models, search_model, model)
+    mirror = (parent_ledger, "web_search") if parent_ledger is not None else None
 
     def invoke(arguments, *, confirm: bool = False):
         query = (_clean(arguments).get("query") or "").strip()
@@ -1152,7 +1172,8 @@ def web_search_tool(oai, model: str, *, models=None, search_model=None,
                 "supportsWebSearch"
             )
         try:
-            return _agent.run_web_search(oai, resolved, query, mode=mode, models=models)
+            return _agent.run_web_search(oai, resolved, query, mode=mode,
+                                         models=models, mirror=mirror)
         except Exception as e:  # incl. openai.OpenAIError from the completion
             return _err(f"web_search failed: {e}")
 
@@ -1203,7 +1224,8 @@ def spawn_tool(oai, model, base_kwargs, parent_tools, *,
                hard_cap: int = _SPAWN_HARD_CAP,
                max_spend: Optional[float] = None,
                max_tokens: Optional[int] = None,
-               dispatches: Optional[list] = None) -> _agent.Tool:
+               dispatches: Optional[list] = None,
+               models=None, parent_ledger=None) -> _agent.Tool:
     """Build the `venice_spawn` Tool: delegate a bounded task to a disposable, write/
     paid-capable WORKER subagent (#52 slice 2).
 
@@ -1242,9 +1264,16 @@ def spawn_tool(oai, model, base_kwargs, parent_tools, *,
     Per-subagent token cap: `max_tokens` (`--subagent-max-tokens`, None = uncapped) bounds
     the worker's cumulative prompt+completion tokens over its turns -- orthogonal to the USD
     media cap (that meters paid-tool spend; this meters the model turns). Enforced via a
-    fresh per-invoke `CostLedger` and `run_loop`'s token gate; the report carries
+    fresh per-invoke ledger and `run_loop`'s token gate; the report carries
     `tokens`/`token_cap`. `tokens` can slightly exceed the cap (the crossing turn completes,
     like `spent_usd` vs the media cap).
+
+    `models`/`parent_ledger` (#117): that ledger is now PRICED and mirrored into the
+    parent's `spawn` bucket, so a worker's model turns reach the footer, `/usage` and
+    `--session-max-spend`. Note the THIRD money axis this adds, all deliberately separate:
+    `max_spend`/`spent_usd` above meters paid MEDIA the worker bought; the bucket meters
+    the worker's own COMPLETIONS. They are different purchases and must not be summed.
+    The mirror is a side channel and must never ride `out` (#99's containment pin).
     """
     def invoke(arguments, *, confirm: bool = False):
         args = _clean(arguments)
@@ -1295,9 +1324,12 @@ def spawn_tool(oai, model, base_kwargs, parent_tools, *,
         # Per-subagent token cap: a fresh per-invoke ledger meters the worker's own LLM
         # turns (prompt+completion). Distinct from the USD media meter above (that gates
         # paid *tool calls*; this gates the *next model turn*). Built always so `tokens` is
-        # reported even uncapped; per-invoke so it's --parallel-safe; unpriced (token
-        # counting needs no catalog).
-        led = _agent.CostLedger(max_tokens=max_tokens)
+        # reported even uncapped; per-invoke so it's --parallel-safe; priced + mirrored to
+        # the parent's `spawn` bucket (#117).
+        led = _agent.subagent_ledger(
+            models, model, max_tokens=max_tokens,
+            mirror=(parent_ledger, "spawn") if parent_ledger is not None else None,
+        )
         try:
             out = _agent.run_spawn(
                 oai, model, task, granted, base_kwargs,

--- a/src/venice/commands/_repl.py
+++ b/src/venice/commands/_repl.py
@@ -608,7 +608,7 @@ def _dispatch_slash(line, messages, state, args, models, oai=None, gen_kwargs=No
 def run(args, oai, openai, client, models, model, initial=None, *,
         tools_session=None, gen_kwargs=None, label="venice chat",
         max_tool_calls=8, session=None, ephemeral=False, root=None,
-        system_reseed=False) -> int:
+        system_reseed=False, ledger=None) -> int:
     """Drive the interactive REPL until `/exit`, `/quit`, or EOF (Ctrl-D).
 
     `initial` is an already-resolved first message (e.g. `venice chat -i "hi"`);
@@ -695,7 +695,14 @@ def run(args, oai, openai, client, models, model, initial=None, *,
         state["budget"] = _compact.budget_from_args(args)
         # Usage + spend ledger: always-on in the REPL so `/usage` and `/cost`
         # work in any session (#75); `--session-max-spend` (#66) only adds a cap.
-        state["ledger"] = _agent.usage_ledger(args, models, model)
+        #
+        # #117: ADOPTED when the caller already built one (`venice code` must, because
+        # its subagent rails mirror into it at factory time, before this runs). Adopted
+        # by identity, not copied: `_save_session` persists `state["ledger"].to_dict()`,
+        # so a copy here would write the wrong object's totals to the session file.
+        # `venice chat` passes nothing and keeps building its own.
+        state["ledger"] = (ledger if ledger is not None
+                           else _agent.usage_ledger(args, models, model))
         # Carry usage across resume (#47/#75): seed the fresh, currently-priced
         # ledger with the saved totals so `/usage` and `/cost` are cumulative.
         if session is not None and session.usage:

--- a/src/venice/commands/_review.py
+++ b/src/venice/commands/_review.py
@@ -608,7 +608,8 @@ def run_cycle(oai, model: str, collected: dict, base_kwargs: dict, *,
               root: str, client=None, rounds: int = REVIEW_DEFAULT_ROUNDS,
               max_tool_calls: int = REVIEW_MAX_TOOL_CALLS,
               max_tokens: Optional[int] = None, focus: Optional[str] = None,
-              include_search: bool = False) -> dict:
+              include_search: bool = False,
+              models=None, parent_ledger=None) -> dict:
     """Run the until-dry review loop over an already-collected diff.
 
     Rounds are re-passes over the SAME diff: each one is told what earlier passes
@@ -619,12 +620,27 @@ def run_cycle(oai, model: str, collected: dict, base_kwargs: dict, *,
 
     ONE ledger spans the whole cycle, so `--subagent-max-tokens` bounds the review
     rather than each round of it; a cycle that crosses the ceiling stops looping
-    instead of buying another round it cannot afford.
+    instead of buying another round it cannot afford. (If rounds ever get their own
+    per-round ledgers, each needs its own mirror -- see below.)
+
+    `models`/`parent_ledger` (#117): the ledger is PRICED against `model` -- the
+    REVIEWER's model, which `--review-model` makes deliberately different from the
+    author's, so pricing it anywhere but here would bill the reviewer's tokens at the
+    author's rate -- and mirrored into the parent's `review` bucket. Both default to
+    None because `venice review` (the standalone CLI) has no parent ledger and must
+    keep working unchanged; there the cycle simply meters itself as before.
+
+    The mirror lives on the ledger rather than at the call sites, which matters here
+    more than on any other rail: this cycle makes an API call OUTSIDE `run_loop` (the
+    verdict re-prompt), and a `run_loop`-level callback would have silently missed it.
     """
     rounds = max(1, min(int(rounds or 1), REVIEW_HARD_ROUNDS))
     calls = max(1, min(int(max_tool_calls or REVIEW_MAX_TOOL_CALLS), REVIEW_HARD_CAP))
     inner = _code.read_only_tools(root, client, include_search=include_search)
-    ledger = _agent.CostLedger(max_tokens=max_tokens)
+    ledger = _agent.subagent_ledger(
+        models, model, max_tokens=max_tokens,
+        mirror=(parent_ledger, "review") if parent_ledger is not None else None,
+    )
 
     findings: List[dict] = []
     outside: List[dict] = []
@@ -814,7 +830,8 @@ def review_tool(oai, model: str, root: str, client, base_kwargs, *,
                 max_invocations: int = REVIEW_MAX_INVOCATIONS,
                 max_tokens: Optional[int] = None,
                 exec_timeout: int = DEFAULT_EXEC_TIMEOUT,
-                decorrelated: bool = True) -> _agent.Tool:
+                decorrelated: bool = True,
+                models=None, parent_ledger=None) -> _agent.Tool:
     """Build the `venice_review` Tool: a cold-context review of the session's own diff.
 
     `paid=False` mirrors `venice_scout`: a bounded nested model call, not a media
@@ -869,6 +886,7 @@ def review_tool(oai, model: str, root: str, client, base_kwargs, *,
                 oai, model, collected, base_kwargs, root=root, client=client,
                 rounds=rounds, max_tool_calls=calls, max_tokens=max_tokens,
                 focus=args.get("focus") or None, include_search=include_search,
+                models=models, parent_ledger=parent_ledger,  # #117
             )
         except Exception as e:  # incl. openai.OpenAIError from the nested loop
             return _err(f"review failed: {e}")

--- a/src/venice/commands/code.py
+++ b/src/venice/commands/code.py
@@ -494,11 +494,15 @@ def _finish(ledger, t0, human, *, json_out: bool) -> None:
     as "code: aborted" and the acceptance report, not a redraw surface like
     `_Spinner`, so gating it would only hide the number from logs and pipelines.
 
-    Idempotent via `ledger.turns`: a one-shot ledger is built fresh in `_run_oneshot`
-    and never `restore()`d, so a non-zero turn count means "already stamped". That
-    coupling is load-bearing -- if a future `--resume` ever seeds this ledger from a
-    prior session's usage, this guard silently stops stamping and needs replacing
-    with an explicit flag.
+    Idempotent via `ledger.turns`: the one-shot ledger is built fresh (in `_run` as of
+    #117, and handed down) and never `restore()`d on this path, so a non-zero turn count
+    means "already stamped". That coupling is load-bearing -- if a future `--resume` ever
+    seeds this ledger from a prior session's usage, this guard silently stops stamping
+    and needs replacing with an explicit flag. #117's hoist deliberately did NOT add a
+    restore here; only the REPL restores, on its own path.
+
+    Subagent rails do not disturb this: a mirrored child banks into `buckets` via
+    `record_bucket`, which never touches `turns`.
     """
     if ledger is None or ledger.turns:
         return
@@ -714,6 +718,18 @@ def _run(args) -> int:
     # #52 planner slice: the session's shared dispatch record list. scout/spawn append
     # every launched dispatch to it; venice_merge (and the --json envelope) roll it up.
     dispatches = [] if planner else None
+    # #117: the session ledger, HOISTED above the factory block below because every rail
+    # needs it at factory time -- a subagent mirrors its usage into this object's off-loop
+    # buckets, and the tools are built long before `_run_oneshot`/`_repl.run` would have
+    # constructed one. It reads only `args.session_max_spend`, `models` and `model`, all
+    # resolved well above here, so the hoist inverts no dependency.
+    #
+    # There must be exactly ONE of these per run: both entry points below ADOPT this
+    # object rather than building their own, and a second ledger would silently orphan
+    # every rail's spend with no error and no failing assertion. `_finish`'s
+    # already-stamped guard also assumes this ledger reaches `_run_oneshot` un-restored
+    # (see its docstring) -- true here, since only the REPL restores, on its own path.
+    ledger = _agent.usage_ledger(args, models, model)
     # #77: opt-in web-discovery rail. Built once (root-independent) and shared between the
     # parent tool list and the scout's read-only inner set (a "docs scout"); workers never
     # get it (category "web" is in no spawn role). `models` is in scope from the guard above.
@@ -722,6 +738,7 @@ def _run(args) -> int:
         ws_tool = _code.web_search_tool(
             oai, model, models=models,
             search_model=getattr(args, "web_search_model", None),
+            parent_ledger=ledger,  # #117: bills the `web_search` bucket
         )
     # #52: per-subagent cumulative-token ceiling (None = uncapped); applies to BOTH the
     # read-only scout and the write/paid worker -- token burn is universal to both.
@@ -730,7 +747,8 @@ def _run(args) -> int:
         tools.append(_code.scout_tool(oai, model, root, client, gen_kwargs,
                                       include_search=True, web_tool=ws_tool,
                                       max_tokens=subagent_max_tokens,
-                                      dispatches=dispatches))
+                                      dispatches=dispatches,
+                                      models=models, parent_ledger=ledger))  # #117
     if bool(getattr(args, "spawn", None)):  # #52 slice 2: write-capable worker subagent
         # Passes the live `tools` list: the worker draws a role-scoped subset of these
         # (the agent category -- scout/spawn -- is filtered out, so no nested subagents).
@@ -738,7 +756,8 @@ def _run(args) -> int:
         tools.append(_code.spawn_tool(oai, model, gen_kwargs, tools,
                                       max_spend=getattr(args, "spawn_max_spend", None),
                                       max_tokens=subagent_max_tokens,
-                                      dispatches=dispatches))
+                                      dispatches=dispatches,
+                                      models=models, parent_ledger=ledger))  # #117
     if bool(getattr(args, "review", None)):  # #80 part 1a: cold-context reviewer rail
         # The reviewer's model is resolved ONCE here and never advertised in the tool
         # schema (mirroring web_search_tool), so the agent cannot escalate itself onto
@@ -758,6 +777,9 @@ def _run(args) -> int:
             max_tokens=subagent_max_tokens,
             exec_timeout=args.exec_timeout or _code.DEFAULT_EXEC_TIMEOUT,
             decorrelated=decorrelated,
+            # #117: `review_model`, not `model` -- the reviewer is deliberately a
+            # different (often costlier) model, and its bucket must be priced as such.
+            models=models, parent_ledger=ledger,
         ))
     if ws_tool is not None:  # #77: parent (planner included) gets web discovery directly
         tools.append(ws_tool)
@@ -783,15 +805,17 @@ def _run(args) -> int:
             label=PROFILE.label, max_tool_calls=PROFILE.default_max_tool_calls,
             session=session, ephemeral=bool(getattr(args, "ephemeral", None)),
             root=root, system_reseed=PROFILE.system_reseed,
+            ledger=ledger,  # #117: the rails already hold this one
         )
 
     return _run_oneshot(args, oai, openai, model, tools, system, gen_kwargs, root, task,
                         models, dispatches=dispatches,
-                        ephemeral=bool(getattr(args, "ephemeral", None)))
+                        ephemeral=bool(getattr(args, "ephemeral", None)),
+                        ledger=ledger)  # #117
 
 
 def _run_oneshot(args, oai, openai, model, tools, system, gen_kwargs, root, task,
-                 models=None, *, dispatches=None, ephemeral=False) -> int:
+                 models=None, *, dispatches=None, ephemeral=False, ledger=None) -> int:
     messages: List[dict] = [
         {"role": "system", "content": system},
         {"role": "user", "content": task},
@@ -806,7 +830,12 @@ def _run_oneshot(args, oai, openai, model, tools, system, gen_kwargs, root, task
     # uncapped, this meters without gating (`over()`/`over_tokens()` are both None-safe).
     # Hoisted above the plan block so the plan turn -- a real API call, and a real wait --
     # is inside the accounting rather than outside it.
-    ledger = _agent.usage_ledger(args, models, model)
+    #
+    # #117: `_run` hoisted it further still (the rails need it at factory time) and passes
+    # it in. Building a second one here would leave every rail mirroring into an orphan.
+    # The fallback keeps this function callable on its own, as the tests do.
+    if ledger is None:
+        ledger = _agent.usage_ledger(args, models, model)
     t0 = time.monotonic()   # #81: the whole run is the window; see `_finish`
     human = [0.0]           # seconds spent waiting on *you* at a prompt, excluded
 

--- a/tests/test_agent.py
+++ b/tests/test_agent.py
@@ -1334,8 +1334,13 @@ class TestOffLoopBuckets(unittest.TestCase):
     def test_summary_is_unchanged_without_a_bucket(self):
         # The subagent-safety pin. `run_loop`'s two stop-reason messages render this on
         # subagent ledgers, which can never acquire a bucket (they are never passed a
-        # `budget`, so `maybe_compact` short-circuits). The rails slice of #101 deletes
-        # that invariant -- when it does, this expectation is what should fail first.
+        # `budget`, so `maybe_compact` short-circuits).
+        #
+        # #117 was predicted to delete that invariant and did NOT -- stated here because
+        # the issue said the opposite and a later reader will assume it landed. A
+        # mirrored subagent ledger writes its PARENT's buckets and never its own, so
+        # these two messages still render with no clause. See
+        # `test_a_mirrored_child_never_grows_a_bucket_of_its_own`, which pins the reason.
         L = self._led()
         L.record({"prompt_tokens": 1000, "completion_tokens": 500})
         self.assertEqual(
@@ -1595,6 +1600,343 @@ class TestOffLoopBuckets(unittest.TestCase):
         R.restore({"total": 0.5, "prompt_tokens": 10})
         self.assertEqual(R.buckets, {})
         self.assertAlmostEqual(R.billed_total(), 0.5)
+
+    # -- #117: more than one bucket ------------------------------------------
+
+    def test_summary_lists_two_bucket_names(self):
+        L = self._bucketed()
+        L.record({"prompt_tokens": 1000, "completion_tokens": 0}, bucket="scout")
+        self.assertEqual(
+            L.summary(),
+            "cost: $0.0074 (tokens prompt=1000 completion=500)"
+            " [incl. $0.0054 compaction/scout]")
+
+    def test_summary_collapses_more_than_two_bucket_names(self):
+        # The bound. Unbounded, `--planner --review --web-search` renders
+        # `compaction/review/scout/spawn/web_search` onto a footer that is also two
+        # stop-reason messages -- and grows again with every future bucket.
+        L = self._bucketed()
+        for name in ("scout", "spawn", "review", "web_search"):
+            L.record({"prompt_tokens": 1000, "completion_tokens": 0}, bucket=name)
+        self.assertEqual(
+            L.summary(),
+            "cost: $0.0104 (tokens prompt=1000 completion=500)"
+            " [incl. $0.0084 off-loop]")
+
+    def test_a_zero_cost_bucket_does_not_count_toward_the_name_bound(self):
+        # The bound counts the names that will actually PRINT. Three buckets of which
+        # one is free is a two-name render, not a collapse -- otherwise an unpriced
+        # rail silently degrades the other two into "off-loop".
+        L = self._bucketed()
+        L.record({"prompt_tokens": 1000, "completion_tokens": 0}, bucket="scout")
+        L.record(None, bucket="spawn")           # no usage -> no cost
+        self.assertIn("[incl. $0.0054 compaction/scout]", L.summary())
+
+    def test_the_bucket_block_renders_a_row_per_rail(self):
+        # Pin the whole block: the column width is data-driven (`max(len(k))`), so a
+        # longer bucket name shifts every row and should shift in a diff, not in prod.
+        L = self._led()
+        L.record({"prompt_tokens": 1000, "completion_tokens": 500}, seconds=2.0)
+        L.record_turn(2.0)
+        L.record({"prompt_tokens": 4000, "completion_tokens": 200}, seconds=1.5,
+                 bucket="compaction")
+        L.record({"prompt_tokens": 800, "completion_tokens": 120}, seconds=0.4,
+                 bucket="web_search")
+        out = L.usage_report()
+        self.assertIn(
+            "  off-loop      1.9s  across 2 API call(s)  [not in the trace above]", out)
+        self.assertIn(
+            "    compaction  1 call(s)      4,000 in      200 out     $0.0044", out)
+        self.assertIn(
+            "    web_search  1 call(s)        800 in      120 out     $0.0010", out)
+
+    def test_the_bucket_block_labels_overlapping_rail_windows(self):
+        # Under `--parallel` several rails' API windows overlap, so the summed seconds
+        # can exceed the wall clock. Say so, in `_tool_lines`' exact words -- one state
+        # must not grow two vocabularies inside one report.
+        L = self._led()
+        L.record_turn(2.0)                       # 2s of wall
+        L.record({"prompt_tokens": 100, "completion_tokens": 10}, seconds=5.0,
+                 bucket="scout")
+        L.record({"prompt_tokens": 100, "completion_tokens": 10}, seconds=5.0,
+                 bucket="spawn")
+        self.assertIn("[concurrent -- exceeds wall]", L.usage_report())
+
+    def test_the_bucket_block_stays_unlabelled_within_the_wall(self):
+        L = self._led()
+        L.record_turn(60.0)
+        L.record({"prompt_tokens": 100, "completion_tokens": 10}, seconds=5.0,
+                 bucket="scout")
+        self.assertNotIn("[concurrent", L.usage_report())
+
+    def test_restore_round_trips_several_buckets_additively(self):
+        # `restore` is field-by-field per name precisely because a naive `cur[k] += v`
+        # evaluates `False + True` to 1 and turns a sticky flag into a count. Exercise
+        # it with more than the one name that existed when it was written.
+        L = self._bucketed()
+        for name in ("scout", "review"):
+            L.record({"prompt_tokens": 1000, "completion_tokens": 0}, bucket=name)
+        R = self._led()
+        R.restore(L.to_dict())
+        R.restore(L.to_dict())                   # additive, twice over
+        self.assertEqual(sorted(R.buckets), ["compaction", "review", "scout"])
+        self.assertEqual(R.buckets["scout"]["calls"], 2)
+        self.assertEqual(R.buckets["scout"]["prompt_tokens"], 2000)
+        self.assertIs(R.buckets["scout"]["unpriced"], False)
+        self.assertAlmostEqual(R.bucket_cost(), L.bucket_cost() * 2)
+
+
+class TestMirroredSubagentLedgers(unittest.TestCase):
+    """#117: a subagent ledger banks each API call into its PARENT's bucket.
+
+    The mirror sits at `record()` -- the one place any usage is read -- rather than at
+    the call sites, so the two rails that call the API outside `run_loop`
+    (`_review._retry_for_verdict`, `run_web_search`) are covered without either site
+    knowing a parent exists. These tests pin that, and pin that the isolation #101 built
+    for compaction survives a SECOND writer arriving from a pool worker.
+    """
+
+    P = {"input": {"usd": 1.0}, "output": {"usd": 2.0}}
+    #: A deliberately DIFFERENT rate, standing in for `--review-model`.
+    P10 = {"input": {"usd": 10.0}, "output": {"usd": 20.0}}
+
+    U = {"prompt_tokens": 1000, "completion_tokens": 500}
+
+    def _parent(self, cap=None):
+        L = _agent.CostLedger(max_spend=cap)
+        L.bind_pricing(self.P)
+        return L
+
+    def _child(self, parent, name="scout", pricing=None):
+        C = _agent.CostLedger(mirror=(parent, name))
+        C.bind_pricing(pricing or self.P)
+        return C
+
+    # -- the seam ------------------------------------------------------------
+
+    def test_a_mirrored_child_lands_in_the_parent_bucket(self):
+        P = self._parent()
+        self._child(P).record(self.U, seconds=1.5)
+        row = P.buckets["scout"]
+        self.assertEqual((row["calls"], row["prompt_tokens"],
+                          row["completion_tokens"], row["seconds"]),
+                         (1, 1000, 500, 1.5))
+        self.assertAlmostEqual(row["cost"], 0.0020)
+
+    def test_an_unmirrored_child_leaves_the_parent_empty(self):
+        # The control. Without this, every assertion above could be passing because
+        # something else populates the bucket -- and a bucket that is always written
+        # is not evidence that the MIRROR wrote it.
+        P = self._parent()
+        C = _agent.CostLedger()
+        C.bind_pricing(self.P)
+        C.record(self.U, seconds=1.5)
+        self.assertEqual(P.buckets, {})
+        self.assertEqual(P.billed_total(), 0.0)
+
+    def test_a_mirrored_child_never_grows_a_bucket_of_its_own(self):
+        # Why `test_summary_is_unchanged_without_a_bucket` still passes: the child
+        # writes the PARENT's partition. `run_loop`'s stop-reason messages render
+        # `summary()` on this object and must not sprout an `[incl. ...]` clause.
+        P = self._parent()
+        C = self._child(P)
+        C.record(self.U, seconds=1.5)
+        self.assertEqual(C.buckets, {})
+        self.assertEqual(C.summary(),
+                         "cost: $0.0020 (tokens prompt=1000 completion=500)")
+
+    def test_the_child_keeps_its_own_main_loop_accounting(self):
+        # `--subagent-max-tokens` reads these, so mirroring must be purely additive.
+        P = self._parent()
+        C = self._child(P)
+        C.record(self.U)
+        self.assertEqual((C.prompt_tokens, C.completion_tokens), (1000, 500))
+        self.assertEqual(C.api_calls_total, 1)
+        self.assertEqual(len(C.api_calls()), 1)
+
+    def test_a_mirrored_record_leaves_the_parent_main_counters_untouched(self):
+        # THE isolation property. A mirror that recorded into the parent's MAIN loop
+        # would fold a fresh ~0%-cached prefix into the conversation's cache rate --
+        # fabricating exactly the cliff #99's trace exists to detect.
+        P = self._parent()
+        self._child(P).record(self.U, seconds=1.5)
+        self.assertEqual((P.prompt_tokens, P.completion_tokens, P.total), (0, 0, 0.0))
+        self.assertEqual((P.cache_read_unreported, P.cache_write_unreported),
+                         (False, False))
+        self.assertIsNone(P.cache_hit_percent())
+
+    def test_a_mirrored_record_appends_no_parent_trace_row(self):
+        # `calls_dropped()` is `api_calls_total - head - tail`; bumping the counter
+        # without a row would make `/usage` report phantom dropped rows.
+        P = self._parent()
+        self._child(P).record(self.U)
+        self.assertEqual((P.api_calls(), P.api_calls_total, P.calls_dropped()),
+                         ([], 0, 0))
+        self.assertEqual(P.bucket_calls("scout"), 1)
+
+    # -- pricing (the load-bearing correction to #117's own design) -----------
+
+    def test_the_child_is_priced_at_its_own_rate_not_the_parents(self):
+        # `--review-model` is deliberately a different model. Re-costing the child's
+        # usage on the parent would bill the reviewer's tokens at the author's rate --
+        # a fabricated number wearing a measurement's name.
+        P = self._parent()
+        self._child(P, "review", pricing=self.P10).record(self.U)
+        self.assertAlmostEqual(P.buckets["review"]["cost"], 0.0200)   # 10x, not 0.0020
+        self.assertAlmostEqual(P.billed_total(), 0.0200)
+
+    def test_an_unpriced_child_taints_only_the_bucket(self):
+        P = self._parent()
+        C = _agent.CostLedger(mirror=(P, "scout"))    # no pricing bound
+        C.record(self.U)
+        self.assertIs(P.buckets["scout"]["unpriced"], True)
+        self.assertIs(P.unpriced, False)             # stays main-loop-only
+        self.assertTrue(P.any_unpriced())
+
+    def test_a_usage_less_child_call_marks_the_bucket_unreported(self):
+        # #98's rule one partition over: absent is UNKNOWN, never a measured zero.
+        P = self._parent()
+        self._child(P).record(None, seconds=0.5)
+        row = P.buckets["scout"]
+        self.assertIs(row["unreported"], True)
+        self.assertEqual((row["calls"], row["prompt_tokens"]), (1, 0))
+        self.assertEqual(_agent.CostLedger.bucket_money(row), "n/a")
+        self.assertTrue(P.any_unreported())
+
+    # -- bounds --------------------------------------------------------------
+
+    def test_the_mirror_does_not_reach_a_grandparent(self):
+        # `record_bucket` is a leaf on purpose. Propagating would double-count spend
+        # the parent's bucket has already banked.
+        G = self._parent()
+        P = _agent.CostLedger(mirror=(G, "spawn"))
+        P.bind_pricing(self.P)
+        self._child(P, "scout").record(self.U)
+        self.assertEqual(P.buckets["scout"]["calls"], 1)
+        self.assertEqual(G.buckets, {})
+
+    def test_a_self_mirror_is_rejected(self):
+        # Honest scope: a self-mirror is not reachable from `__init__`'s own call (you
+        # cannot name the object being constructed), so re-init is the only way to
+        # express it. The guard is cheap and states the invariant -- a ledger that
+        # mirrored into itself would bank every call BOTH into its main counters and
+        # into its own bucket, double-counting inside one object.
+        P = self._parent()
+        with self.assertRaises(ValueError):
+            P.__init__(mirror=(P, "scout"))
+
+    def test_the_raw_usage_dump_fires_once_per_api_call(self):
+        # One API call must produce ONE `usage-raw:` line. Routing the mirror through
+        # `record()` instead of `record_bucket()` emits two -- interleaved with other
+        # workers' lines under `--parallel`, which is what the single-print contract
+        # exists to prevent.
+        P = self._parent()
+        C = self._child(P)
+        err = io.StringIO()
+        with mock.patch.dict(os.environ, {"VENICE_USAGE_RAW": "1"}), \
+             mock.patch.object(sys, "stderr", err):
+            C.record(self.U)
+        self.assertEqual(err.getvalue().count("usage-raw:"), 1)
+
+    # -- the #117 ask --------------------------------------------------------
+
+    def test_the_session_cap_counts_rail_spend(self):
+        # THE point of the slice: `--session-max-spend` bounds a rail-heavy run.
+        P = self._parent(cap=0.001)
+        self.assertFalse(P.over())
+        self._child(P).record(self.U)
+        self.assertEqual(P.total, 0.0)               # nothing in the main loop at all
+        self.assertTrue(P.over())
+
+    def test_bucket_tokens_stay_out_of_the_parent_token_gate(self):
+        # `over_tokens()` is #52's ceiling on a WORKER's own conversation, and the
+        # parent's is not the worker's. Deliberately unchanged by this slice.
+        P = _agent.CostLedger(max_tokens=100)
+        P.bind_pricing(self.P)
+        self._child(P).record(self.U)
+        self.assertFalse(P.over_tokens())
+
+    def test_the_child_token_cap_is_unaffected_by_mirroring(self):
+        P = self._parent()
+        C = _agent.CostLedger(max_tokens=100, mirror=(P, "scout"))
+        C.bind_pricing(self.P)
+        C.record(self.U)
+        self.assertTrue(C.over_tokens())             # the worker's own ceiling still bites
+
+    # -- concurrency ---------------------------------------------------------
+
+    def test_record_bucket_mutates_under_the_lock(self):
+        # Structural, exactly like `test_record_tool_mutates_under_the_lock`: CPython's
+        # GIL does not actually lose these increments, so a hammer-and-count test would
+        # pass with the lock DELETED and be a vacuous guard. Pin instead that the
+        # mutation happens while the lock is held.
+        L = _agent.CostLedger()
+        held = []
+        real = L._buckets_lock
+
+        class Watched:
+            def __enter__(self):
+                real.acquire()
+                held.append("in")
+                return self
+
+            def __exit__(self, *exc):
+                held.append("out")
+                real.release()
+                return False
+
+        L._buckets_lock = Watched()
+        L.record_bucket("scout", cost=0.1)
+        L.record_bucket("scout", cost=0.1)
+        self.assertEqual(held, ["in", "out", "in", "out"])
+
+    def test_mirrored_children_are_correct_under_real_threads(self):
+        # Not a race detector -- a smoke test for how `--parallel` actually calls this:
+        # up to `_MAX_PARALLEL` scouts mirroring into one parent row at once.
+        P = self._parent()
+        old = sys.getswitchinterval()
+        sys.setswitchinterval(1e-6)
+        self.addCleanup(sys.setswitchinterval, old)
+
+        def hammer():
+            C = self._child(P)
+            for _ in range(200):
+                C.record(self.U)
+
+        threads = [threading.Thread(target=hammer) for _ in range(8)]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join()
+        self.assertEqual(P.buckets["scout"]["calls"], 1600)
+        self.assertEqual(P.buckets["scout"]["prompt_tokens"], 1600 * 1000)
+
+    # -- the constructor -----------------------------------------------------
+
+    def test_subagent_ledger_binds_the_childs_own_pricing(self):
+        models = [{"id": "reviewer", "model_spec": {"pricing": self.P10}},
+                  {"id": "author", "model_spec": {"pricing": self.P}}]
+        P = self._parent()
+        C = _agent.subagent_ledger(models, "reviewer", max_tokens=50,
+                                   mirror=(P, "review"))
+        self.assertEqual(C.max_tokens, 50)
+        self.assertIsNone(C.max_spend)               # the parent owns the money gate
+        C.record(self.U)
+        self.assertAlmostEqual(P.buckets["review"]["cost"], 0.0200)
+
+    def test_subagent_ledger_without_a_parent_is_standalone(self):
+        # `venice review` (the standalone CLI) has no parent ledger and must keep
+        # working -- `mirror=None` is a supported state, not an oversight.
+        C = _agent.subagent_ledger([], "m")
+        C.record(self.U)
+        self.assertEqual(C.prompt_tokens, 1000)
+        self.assertEqual(C.buckets, {})
+
+    def test_an_unknown_model_still_meters_tokens(self):
+        C = _agent.subagent_ledger([], "not-in-catalog")
+        C.record(self.U)
+        self.assertTrue(C.unpriced)
+        self.assertEqual(C.prompt_tokens + C.completion_tokens, 1500)
 
 
 class TestCallTrace(unittest.TestCase):

--- a/tests/test_code_command.py
+++ b/tests/test_code_command.py
@@ -17,6 +17,7 @@ from unittest import mock
 from tests.test_chat import (
     FakeToolCompletion, _FnCall, _fake_openai_seq, _urlopen_ok,
 )
+from venice.commands import _agent, _code
 
 
 # Auto-save is on by default (#47): keep this module hermetic (belt-and-suspenders
@@ -474,16 +475,19 @@ class TestCodeCommand(unittest.TestCase):
     def test_interactive_delegates_to_repl_with_tools_session(self):
         captured = {}
 
+        # `**kw`: a rigid stub here breaks on every new keyword-only factory kwarg
+        # `_run` learns to forward, which is a failure of the stub and not of the code.
         def _fake_repl_run(args, oai, openai, client, models, model,
                            initial=None, *, tools_session=None, gen_kwargs=None,
                            label="venice chat", max_tool_calls=8, session=None,
-                           ephemeral=False, root=None, system_reseed=False):
+                           ephemeral=False, root=None, system_reseed=False, **kw):
             captured["tools_session"] = tools_session
             captured["label"] = label
             captured["initial"] = initial
             captured["max_tool_calls"] = max_tool_calls
             captured["root"] = root
             captured["system_reseed"] = system_reseed
+            captured["ledger"] = kw.get("ledger")
             return 0
 
         stdin = mock.MagicMock()
@@ -506,6 +510,9 @@ class TestCodeCommand(unittest.TestCase):
         self.assertEqual(captured["max_tool_calls"], code._DEFAULT_MAX_TOOL_CALLS)
         self.assertTrue(captured["system_reseed"])       # code always reseeds (#47)
         self.assertEqual(captured["root"], self.root)
+        # #117: the REPL is HANDED the hoisted ledger rather than building its own,
+        # because the rails already mirror into that object.
+        self.assertIsNotNone(captured["ledger"])
 
     # --- session resume (#47) ---
     def _mk_zone(self):
@@ -1075,6 +1082,84 @@ class TestCodeUsageSurface(unittest.TestCase):
         self.assertEqual(envelope["api_calls"], persisted["api_calls"])
         self.assertEqual(envelope["api_calls_total"], persisted["api_calls_total"])
         self.assertEqual(envelope["context_events"], persisted["context_events"])
+        self.assertEqual(envelope["buckets"], persisted["buckets"])   # #117
+
+    # --- #117: the hoisted ledger is the one that gets reported -------------
+
+    def test_a_run_without_rails_reports_no_buckets(self):
+        # The canary, and the control for the two tests below: an over-eager bucket
+        # write would show up here, where nothing off-loop happened at all.
+        rc, _ = self._run(
+            _code_args(task="x", root=self.root, auto=True), self._full_seq())
+        self.assertEqual(rc, 0)
+        with open(self._sessions()[0]) as f:
+            self.assertEqual(json.load(f)["usage"]["buckets"], {})
+
+    def test_scout_spend_reaches_the_reported_usage(self):
+        # END TO END for the hoist: the rails are handed a ledger built in `_run`,
+        # long before `_run_oneshot` would have made one. If `_run_oneshot` built its
+        # own instead of adopting, every rail would mirror into an orphan and this
+        # bucket would simply be missing -- no error, no other failing test.
+        def _run_scout(oai, model, task, tools, base_kwargs, *, max_tool_calls,
+                       ledger=None, **kw):
+            ledger.record({"prompt_tokens": 4321, "completion_tokens": 21})
+            return {"status": "ok", "report": "r", "tool_calls": 1, "truncated": False}
+
+        seq = [
+            FakeToolCompletion("plan text", usage=self._usage(1)),
+            FakeToolCompletion(None, tool_calls=[_FnCall(
+                "c1", "venice_scout", json.dumps({"task": "look"}))],
+                usage=self._usage(2)),
+            FakeToolCompletion("done", usage=self._usage(3)),
+            FakeToolCompletion("ACCEPTANCE: PASS", usage=self._usage(4)),
+        ]
+        with mock.patch.object(_agent, "run_scout", _run_scout):
+            rc, _ = self._run(
+                _code_args(task="x", root=self.root, auto=True, scout=True), seq)
+        self.assertEqual(rc, 0)
+        with open(self._sessions()[0]) as f:
+            usage = json.load(f)["usage"]
+        # Membership FIRST: if the bucket is missing (the mirror dropped, or a second
+        # ledger built downstream), a bare subscript raises KeyError and the run reports
+        # an ERROR, which reads like a broken test rather than a caught regression.
+        self.assertIn("scout", usage["buckets"])
+        self.assertEqual(usage["buckets"]["scout"]["calls"], 1)
+        self.assertEqual(usage["buckets"]["scout"]["prompt_tokens"], 4321)
+        # ...and it stayed OUT of the main-loop trace, which is the whole partition.
+        self.assertEqual(usage["api_calls_total"], len(usage["api_calls"]))
+        self.assertNotIn(4321, [r["prompt_tokens"] for r in usage["api_calls"]])
+
+    def test_the_rails_and_the_reporter_share_one_ledger_object(self):
+        # The one-object rule, by IDENTITY rather than by value: two ledgers with
+        # equal contents would satisfy a value assertion while still losing every
+        # subsequent rail write to whichever object is not reported.
+        seen = {}
+        real = _code.scout_tool
+
+        def _capture(*a, **kw):
+            seen["rails"] = kw.get("parent_ledger")
+            return real(*a, **kw)
+
+        def _fake_repl_run(*a, **kw):
+            seen["repl"] = kw.get("ledger")
+            return 0
+
+        with mock.patch.object(_code, "scout_tool", _capture), \
+             mock.patch("venice.commands._repl.run", _fake_repl_run):
+            stdin = mock.MagicMock()
+            stdin.isatty.return_value = True
+            fake, _calls = _fake_openai_seq([])
+            with mock.patch.dict(os.environ, {"VENICE_API_KEY": "fake"}), \
+                 mock.patch("venice.client.urllib.request.urlopen", _urlopen_ok()), \
+                 mock.patch("openai.OpenAI", return_value=fake), \
+                 mock.patch.object(sys, "stdin", stdin), \
+                 mock.patch.object(sys, "stdout", io.StringIO()), \
+                 mock.patch.object(sys, "stderr", io.StringIO()):
+                from venice.commands import code
+                code._run(_code_args(task="hi", root=self.root, interactive=True,
+                                     scout=True))
+        self.assertIsNotNone(seen["rails"])
+        self.assertIs(seen["rails"], seen["repl"])
 
     def test_ctrlc_run_reports_time_and_persists_usage(self):
         # The run an operator most wants a cost readout for: they sat through it and

--- a/tests/test_planner.py
+++ b/tests/test_planner.py
@@ -314,18 +314,94 @@ class TestSubagentTokenCap(_ProjBase):
         # report IS model-visible (it comes back as a tool result), and today it
         # deliberately carries SCALARS only. Pin that: a future `out.update(
         # led.to_dict())` would quietly push per-call rows into the prompt.
+        #
+        # #117 runs it BOTH ways. The parent-ledger configuration is the one where the
+        # temptation actually lives -- "hand the worker's spend back to the parent" reads
+        # like a job for the return value -- so a pin that only ever ran without a parent
+        # would not have been guarding the case that could break it.
         def _run(oai, model, task, tools, base_kwargs, *, max_tool_calls,
                  ledger=None, **kw):
             ledger.record({"prompt_tokens": 10, "completion_tokens": 5})
             return {"status": "ok", "report": "r", "tool_calls": 1, "truncated": False}
 
-        with mock.patch.object(_agent, "run_spawn", _run):
+        for parent in (None, _agent.CostLedger()):
+            with self.subTest(parent=parent is not None):
+                with mock.patch.object(_agent, "run_spawn", _run):
+                    out = _code.spawn_tool(
+                        None, "m", {}, [self._paid()], max_tokens=500,
+                        parent_ledger=parent).invoke({"task": "a", "role": "code"})
+                for leaked in ("api_calls", "api_calls_total", "context_events",
+                               "buckets", "billed_total", "cost", "spend"):
+                    self.assertNotIn(leaked, out)
+                self.assertEqual(out["tokens"], 15)  # the scalar provenance stays
+        # ...and the spend still reached the parent, by the side channel.
+        self.assertEqual(parent.bucket_calls("spawn"), 1)
+
+    # --- #117: rail spend reaches the parent ledger -------------------------
+
+    def test_spawn_turns_land_in_the_parent_spawn_bucket(self):
+        P = _agent.CostLedger()
+        P.bind_pricing({"input": {"usd": 1.0}, "output": {"usd": 2.0}})
+        models = [{"id": "m", "model_spec": {
+            "pricing": {"input": {"usd": 1.0}, "output": {"usd": 2.0}}}}]
+        with mock.patch.object(_agent, "run_spawn", self._run_that_spends(1000, 500)):
+            _code.spawn_tool(None, "m", {}, [self._paid()], models=models,
+                             parent_ledger=P).invoke({"task": "a", "role": "code"})
+        row = P.buckets["spawn"]
+        self.assertEqual((row["calls"], row["prompt_tokens"]), (1, 1000))
+        self.assertAlmostEqual(row["cost"], 0.0020)
+        self.assertEqual(P.total, 0.0)               # never the parent's main loop
+
+    def test_scout_turns_land_in_the_parent_scout_bucket(self):
+        P = _agent.CostLedger()
+        models = [{"id": "m", "model_spec": {
+            "pricing": {"input": {"usd": 1.0}, "output": {"usd": 2.0}}}}]
+        with mock.patch.object(_agent, "run_scout", self._run_that_spends(300, 40)):
+            out = _code.scout_tool(None, "m", self.root, None, {}, max_tokens=250,
+                                   models=models,
+                                   parent_ledger=P).invoke({"task": "where is f?"})
+        self.assertEqual(P.buckets["scout"]["prompt_tokens"], 300)
+        self.assertNotIn("spawn", P.buckets)
+        self.assertEqual(out["tokens"], 340)         # the report is unchanged
+        self.assertEqual(out["token_cap"], 250)
+
+    def test_a_rail_without_a_parent_ledger_still_works(self):
+        # Every `parent_ledger` is defaulted: `venice review` and every existing test
+        # construct these factories with no parent at all.
+        with mock.patch.object(_agent, "run_scout", self._run_that_spends(300, 40)):
+            out = _code.scout_tool(None, "m", self.root, None, {}).invoke(
+                {"task": "q"})
+        self.assertEqual(out["tokens"], 340)
+
+    def test_a_crashed_rail_still_bills_what_it_spent(self):
+        # The provenance rule one level over: a worker that spent tokens and then threw
+        # still owes the parent that money. `run_spawn` raising must not roll it back.
+        P = _agent.CostLedger()
+
+        def _boom(oai, model, task, tools, base_kwargs, *, max_tool_calls,
+                  ledger=None, **kw):
+            ledger.record({"prompt_tokens": 900, "completion_tokens": 100})
+            raise RuntimeError("nested loop died")
+
+        with mock.patch.object(_agent, "run_spawn", _boom):
             out = _code.spawn_tool(None, "m", {}, [self._paid()],
-                                   max_tokens=500).invoke({"task": "a", "role": "code"})
-        for leaked in ("api_calls", "api_calls_total", "context_events",
-                       "buckets", "billed_total"):
-            self.assertNotIn(leaked, out)
-        self.assertEqual(out["tokens"], 15)  # the scalar provenance stays
+                                   parent_ledger=P).invoke({"task": "a", "role": "code"})
+        self.assertEqual(out["status"], "error")
+        self.assertEqual(P.buckets["spawn"]["prompt_tokens"], 900)
+
+    def test_the_media_spend_meter_and_the_bucket_are_separate_money(self):
+        # Three money axes, deliberately not summed: `spent_usd` is paid MEDIA the
+        # worker bought; the bucket is the worker's own COMPLETIONS. Folding either
+        # into the other would double-count one and misname both.
+        P = _agent.CostLedger()
+        models = [{"id": "m", "model_spec": {
+            "pricing": {"input": {"usd": 1.0}, "output": {"usd": 2.0}}}}]
+        with mock.patch.object(_agent, "run_spawn", self._run_that_spends(1000, 500)):
+            out = _code.spawn_tool(None, "m", {}, [self._paid()], max_spend=5.0,
+                                   models=models,
+                                   parent_ledger=P).invoke({"task": "a", "role": "code"})
+        self.assertEqual(out["spent_usd"], 0.0)          # no media bought
+        self.assertAlmostEqual(P.buckets["spawn"]["cost"], 0.0020)   # but tokens spent
 
     def test_scout_is_metered_too(self):
         # Scope proof: the cap applies to the READ-ONLY scout as well, not just spawn.

--- a/tests/test_repl.py
+++ b/tests/test_repl.py
@@ -28,7 +28,7 @@ from tests.test_chat import (
     _args,
 )
 
-from venice.commands import _compact, _repl  # noqa: E402
+from venice.commands import _agent, _compact, _repl  # noqa: E402
 
 _EMPTY_CFG = {"version": 1, "mcpServers": {}, "defaults": {}}
 
@@ -1486,6 +1486,66 @@ class TestReplMultiline(unittest.TestCase):
         self.assertEqual(rc, 0)
         self.assertEqual(len(calls), 0)
         self.assertIn("editor", err.getvalue().lower())
+
+
+class TestReplLedgerAdoption(unittest.TestCase):
+    """#117: `_repl.run(ledger=...)` ADOPTS the caller's ledger by identity.
+
+    `venice code` must hand this in: its subagent rails were bound to that object at
+    tool-factory time, long before the REPL starts. If `run` built its own instead,
+    every rail would mirror into an orphan -- no error, no crash, just money silently
+    missing from `/usage` and the session file.
+
+    Driving the REAL `_repl.run` is the point. The `code.py` side is covered by an
+    `assertIs` test that mocks `_repl.run` away, which by construction cannot see what
+    happens INSIDE it -- a mutation making this line build a fresh ledger survived the
+    entire suite until this class existed.
+    """
+
+    def _drive(self, ledger):
+        fake, calls = _fake_openai_seq([[FakeChunk(
+            "hi", usage={"prompt_tokens": 40, "completion_tokens": 2,
+                         "total_tokens": 42})]])
+        import openai as openai_mod
+        with contextlib.ExitStack() as st:
+            sess_dir = st.enter_context(tempfile.TemporaryDirectory())
+            st.enter_context(mock.patch.dict(
+                os.environ, {"VENICE_API_KEY": "fake",
+                             "VENICE_SESSIONS_DIR": sess_dir}))
+            st.enter_context(mock.patch("venice.userconfig.load_config",
+                                        lambda *a, **k: _EMPTY_CFG))
+            st.enter_context(mock.patch("builtins.input", side_effect=["/exit"]))
+            st.enter_context(mock.patch.object(sys, "stdin", io.StringIO("")))
+            st.enter_context(mock.patch.object(sys, "stdout", io.StringIO()))
+            st.enter_context(mock.patch.object(sys, "stderr", io.StringIO()))
+            rc = _repl.run(_args(interactive=True), fake, openai_mod, None,
+                           [{"id": "llama-3.3-70b"}], "llama-3.3-70b",
+                           initial="hello", ledger=ledger)
+        return rc, calls
+
+    def test_an_injected_ledger_is_the_one_that_meters_the_turn(self):
+        L = _agent.CostLedger()
+        rc, calls = self._drive(L)
+        self.assertEqual(rc, 0)
+        self.assertEqual(len(calls), 1)
+        self.assertEqual(L.prompt_tokens, 40)      # the injected object, not a fresh one
+        self.assertEqual(L.api_calls_total, 1)
+
+    def test_rail_spend_banked_before_the_repl_starts_is_still_reported(self):
+        # The real sequence: `code.py` builds the ledger, the rails bind to it, and
+        # only then does the REPL open. Pre-existing bucket state must survive.
+        L = _agent.CostLedger()
+        L.record_bucket("scout", cost=0.01, prompt_tokens=1234)
+        rc, _ = self._drive(L)
+        self.assertEqual(rc, 0)
+        self.assertEqual(L.buckets["scout"]["prompt_tokens"], 1234)
+        self.assertAlmostEqual(L.billed_total(), 0.01)
+
+    def test_no_injected_ledger_still_builds_one(self):
+        # `venice chat` passes nothing and must keep working.
+        rc, calls = self._drive(None)
+        self.assertEqual(rc, 0)
+        self.assertEqual(len(calls), 1)
 
 
 if __name__ == "__main__":

--- a/tests/test_review.py
+++ b/tests/test_review.py
@@ -717,6 +717,94 @@ class TestRunCycle(_RepoBase):
         self.assertEqual(out["verdict"], "clean")   # the retry did its job...
         self.assertEqual(out["tokens"], 718)        # ...and paid for it: 11 + 707
 
+    # --- #117: the cycle bills the parent's `review` bucket -----------------
+
+    def _priced(self, usd):
+        return [{"id": "reviewer", "model_spec": {"pricing": {
+            "input": {"usd": usd}, "output": {"usd": usd * 2}}}}]
+
+    def test_the_cycle_lands_in_the_parent_review_bucket(self):
+        P = _agent.CostLedger()
+        with mock.patch.object(_agent, "run_review", self._spender(1000, 500)):
+            _review.run_cycle(mock.MagicMock(), "reviewer", self.collected, {},
+                              root=self.root, rounds=1, models=self._priced(1.0),
+                              parent_ledger=P)
+        row = P.buckets["review"]
+        self.assertEqual((row["calls"], row["prompt_tokens"]), (1, 1000))
+        self.assertAlmostEqual(row["cost"], 0.0020)
+        self.assertEqual(P.total, 0.0)              # never the parent's main loop
+
+    def test_a_cycle_without_a_parent_ledger_is_unchanged(self):
+        # `venice review` (the standalone CLI) passes neither argument.
+        P_free, seen = self._cycle([_report(["src/pool.cc:1 [major] bad"])], rounds=1)
+        self.assertEqual(P_free["verdict"], "findings")
+
+    def test_the_reviewer_is_priced_at_its_own_model_rate(self):
+        # THE reason pricing binds on the child. `--review-model` is deliberately a
+        # DIFFERENT model from the author's -- decorrelation is the point of the rail --
+        # so costing the reviewer's usage at the parent's rate would bill a fabricated
+        # number. Parent at 1x, reviewer at 10x: the bucket must show the reviewer's.
+        P = _agent.CostLedger()
+        P.bind_pricing({"input": {"usd": 1.0}, "output": {"usd": 2.0}})
+        with mock.patch.object(_agent, "run_review", self._spender(1000, 500)):
+            _review.run_cycle(mock.MagicMock(), "reviewer", self.collected, {},
+                              root=self.root, rounds=1, models=self._priced(10.0),
+                              parent_ledger=P)
+        self.assertAlmostEqual(P.buckets["review"]["cost"], 0.0200)   # 10x, not 0.0020
+
+    def test_the_verdict_retry_is_billed_to_the_parent_too(self):
+        # The retry is an API call made OUTSIDE `run_loop`. A usage callback threaded
+        # into `run_loop` -- the shape #117 itself proposed -- would silently miss it.
+        # Mirroring at `record()` catches it because that is where usage is READ.
+        oai = mock.MagicMock()
+        oai.chat.completions.create.return_value = FakeToolCompletion(
+            content="REVIEW: CLEAN",
+            usage={"prompt_tokens": 700, "completion_tokens": 7},
+        )
+
+        def _stub(*a, **kw):
+            kw["ledger"].record({"prompt_tokens": 10, "completion_tokens": 1})
+            return {"status": "ok", "tool_calls": 0, "truncated": False,
+                    "report": "SCOPE: x\nFINDINGS: none\n(forgot the line)"}
+
+        P = _agent.CostLedger()
+        with mock.patch.object(_agent, "run_review", _stub):
+            out = _review.run_cycle(oai, "reviewer", self.collected, {},
+                                    root=self.root, rounds=1,
+                                    models=self._priced(1.0), parent_ledger=P)
+        self.assertEqual(out["verdict"], "clean")
+        row = P.buckets["review"]
+        self.assertEqual(row["calls"], 2)                  # the round AND the retry
+        self.assertEqual(row["prompt_tokens"], 710)        # 10 + 700
+
+    def test_every_round_of_one_cycle_bills_the_same_bucket(self):
+        # ONE ledger spans the cycle, so N rounds are N calls in ONE bucket row.
+        reports = [_report(["src/pool.cc:1 [major] a"]),
+                   _report(["src/pool.cc:2 [major] b"])]
+        seen = []
+
+        def _stub(oai, model, task, tools, base_kwargs, **kw):
+            kw["ledger"].record({"prompt_tokens": 100, "completion_tokens": 10})
+            seen.append(task)
+            return {"status": "ok", "report": reports[len(seen) - 1],
+                    "tool_calls": 1, "truncated": False}
+
+        P = _agent.CostLedger()
+        with mock.patch.object(_agent, "run_review", _stub):
+            _review.run_cycle(mock.MagicMock(), "reviewer", self.collected, {},
+                              root=self.root, rounds=2, models=self._priced(1.0),
+                              parent_ledger=P)
+        self.assertEqual(sorted(P.buckets), ["review"])
+        self.assertEqual(P.buckets["review"]["calls"], 2)
+
+    @staticmethod
+    def _spender(pt, ct):
+        def _stub(oai, model, task, tools, base_kwargs, **kw):
+            kw["ledger"].record({"prompt_tokens": pt, "completion_tokens": ct})
+            return {"status": "ok", "tool_calls": 0, "truncated": False,
+                    "report": _report([], "CLEAN")}
+        return _stub
+
     def test_later_unreadable_round_does_not_erase_an_earlier_verdict(self):
         # Regression pin for a bug the drive suite caught: with the default 2 rounds,
         # a second pass that forgot the sentinel overwrote round 1's verdict with
@@ -1030,6 +1118,34 @@ class TestReviewTool(_RepoBase):
         with mock.patch.object(_agent, "run_review", _stub):
             self._tool().invoke({"max_tool_calls": 9999})
         self.assertEqual(got["calls"], _review.REVIEW_HARD_CAP)
+
+    def test_the_tool_forwards_the_parent_ledger_to_the_cycle(self):
+        # #117: the rail is TWO layers -- `review_tool` builds nothing, `run_cycle` owns
+        # the ledger. Testing `run_cycle` directly (as the cycle tests do) leaves the
+        # forwarding hop unguarded: a mutation dropping `parent_ledger=` from the
+        # `run_cycle` call here survived the whole suite until this test existed.
+        def _stub(oai, model, task, tools, base_kwargs, **kw):
+            kw["ledger"].record({"prompt_tokens": 1000, "completion_tokens": 500})
+            return {"status": "ok", "tool_calls": 0, "truncated": False,
+                    "report": _report([], "CLEAN")}
+
+        P = _agent.CostLedger()
+        models = [{"id": "m", "model_spec": {"pricing": {
+            "input": {"usd": 1.0}, "output": {"usd": 2.0}}}}]
+        with mock.patch.object(_agent, "run_review", _stub):
+            out = self._tool(models=models, parent_ledger=P).invoke({})
+        self.assertEqual(out["status"], "ok")
+        self.assertIn("review", P.buckets)          # a clean FAIL, not a KeyError
+        self.assertEqual(P.buckets["review"]["prompt_tokens"], 1000)
+        self.assertAlmostEqual(P.buckets["review"]["cost"], 0.0020)
+
+    def test_the_tool_still_works_with_no_parent_ledger(self):
+        def _stub(oai, model, task, tools, base_kwargs, **kw):
+            return {"status": "ok", "tool_calls": 0, "truncated": False,
+                    "report": _report([], "CLEAN")}
+
+        with mock.patch.object(_agent, "run_review", _stub):
+            self.assertEqual(self._tool().invoke({})["status"], "ok")
 
     def test_docs_only_diff_short_circuits_without_a_model_call(self):
         _git(self.root, "checkout", "-q", "--", "src/pool.cc")

--- a/tests/test_sessions.py
+++ b/tests/test_sessions.py
@@ -299,10 +299,20 @@ class TestSessionsCLI(_Base):
             # lists only -- so `tools` was already being dumped inline here and this
             # fixture, carrying neither key, was hiding it. Both are present now.
             "tools": {f"tool_{i}": {"seconds": 1.0, "calls": 3} for i in range(40)},
+            # #117: more than one bucket -- `compaction` plus the subagent rails, each
+            # of which renders its own row. A single-bucket fixture cannot tell a
+            # per-name loop apart from one that prints whatever it finds first.
             "buckets": {"compaction": {"calls": 2, "cost": 0.0031,
                                        "prompt_tokens": 91200,
                                        "completion_tokens": 400,
-                                       "seconds": 3.2, "unpriced": False}},
+                                       "seconds": 3.2, "unpriced": False},
+                        "review": {"calls": 3, "cost": 0.0090,
+                                   "prompt_tokens": 12000,
+                                   "completion_tokens": 1800,
+                                   "seconds": 8.1, "unpriced": False},
+                        "scout": {"calls": 4, "cost": 0.0038,
+                                  "prompt_tokens": 6200, "completion_tokens": 900,
+                                  "seconds": 5.0, "unpriced": False}},
         }
         S.save(s)
         rc, out, err = _capture(cli.main, ["sessions", "show", s.id])
@@ -316,6 +326,8 @@ class TestSessionsCLI(_Base):
         self.assertNotIn("compaction", usage_line)
         self.assertIn("  buckets:", out.split("\n"))
         self.assertIn("    compaction: $0.0031 over 2 call(s)", out.split("\n"))
+        self.assertIn("    review: $0.0090 over 3 call(s)", out.split("\n"))
+        self.assertIn("    scout: $0.0038 over 4 call(s)", out.split("\n"))
         self.assertIn("  tools: 40 entries", out)
         self.assertNotIn("'n': 7", usage_line)
         self.assertIn("  api_calls: 250 row(s)", out)

--- a/tests/test_web_search.py
+++ b/tests/test_web_search.py
@@ -111,6 +111,82 @@ class TestRunWebSearch(unittest.TestCase):
         out = _agent.run_web_search(fake, "coder-x", "q", models=priced)
         self.assertAlmostEqual(out["cost_estimate_usd"], 2.0)  # 1M input @ $2/1M
 
+    # --- #117: the search bills the parent's `web_search` bucket ------------
+
+    def test_the_search_lands_in_the_parent_web_search_bucket(self):
+        # Pre-#117 this rail was the mirror image of the other three: a real priced USD
+        # figure returned, and every token count thrown away. Now both survive.
+        usage = {"prompt_tokens": 1_000_000, "completion_tokens": 0}
+        priced = _catalog(pricing={"input": {"usd": 2.0}, "output": {"usd": 6.0}})
+        fake, _ = _fake_openai_seq([_resp(usage=usage)])
+        P = _agent.CostLedger()
+        _agent.run_web_search(fake, "coder-x", "q", models=priced,
+                              mirror=(P, "web_search"))
+        row = P.buckets["web_search"]
+        self.assertEqual((row["calls"], row["prompt_tokens"]), (1, 1_000_000))
+        self.assertAlmostEqual(row["cost"], 2.0)
+        self.assertEqual(P.total, 0.0)
+
+    def test_the_cost_estimate_survives_beside_the_bucket(self):
+        # The two are NOT redundant and neither may be deleted as a duplicate of the
+        # other: `cost_estimate_usd` is MODEL-visible handoff provenance (the agent
+        # reads it to decide whether to search again), the bucket is OPERATOR data.
+        usage = {"prompt_tokens": 1_000_000, "completion_tokens": 0}
+        priced = _catalog(pricing={"input": {"usd": 2.0}, "output": {"usd": 6.0}})
+        fake, _ = _fake_openai_seq([_resp(usage=usage)])
+        P = _agent.CostLedger()
+        out = _agent.run_web_search(fake, "coder-x", "q", models=priced,
+                                    mirror=(P, "web_search"))
+        self.assertAlmostEqual(out["cost_estimate_usd"], 2.0)
+        self.assertAlmostEqual(P.bucket_cost("web_search"), 2.0)
+
+    def test_an_unmirrored_search_leaves_the_parent_empty(self):
+        # The control: without it, the assertions above could pass for any reason.
+        usage = {"prompt_tokens": 1_000_000, "completion_tokens": 0}
+        priced = _catalog(pricing={"input": {"usd": 2.0}, "output": {"usd": 6.0}})
+        fake, _ = _fake_openai_seq([_resp(usage=usage)])
+        P = _agent.CostLedger()
+        _agent.run_web_search(fake, "coder-x", "q", models=priced)
+        self.assertEqual(P.buckets, {})
+
+    def test_a_usage_less_search_marks_the_bucket_unreported(self):
+        priced = _catalog(pricing={"input": {"usd": 2.0}, "output": {"usd": 6.0}})
+        fake, _ = _fake_openai_seq([_resp(usage=None)])
+        P = _agent.CostLedger()
+        out = _agent.run_web_search(fake, "coder-x", "q", models=priced,
+                                    mirror=(P, "web_search"))
+        self.assertIsNone(out["cost_estimate_usd"])          # honest unknown
+        self.assertIs(P.buckets["web_search"]["unreported"], True)
+
+    def test_a_search_inside_a_scout_is_billed_once(self):
+        # `code.py` builds ONE `ws_tool` and hands the SAME object to both the parent
+        # tool list and the scout's inner set. The mirror is bound once at factory time,
+        # so the search bills `web_search` exactly once whoever called it, while the
+        # scout's own turns bill `scout`. A design that rolled child ledgers up into
+        # their caller would have double-counted precisely this shared object.
+        priced = _catalog(pricing={"input": {"usd": 2.0}, "output": {"usd": 6.0}})
+        usage = {"prompt_tokens": 1_000_000, "completion_tokens": 0}
+        fake, _ = _fake_openai_seq([_resp(usage=usage)])
+        P = _agent.CostLedger()
+        ws = _code.web_search_tool(fake, "coder-x", models=priced, parent_ledger=P)
+
+        # The scout runs, makes one web search through the shared tool, and spends
+        # its own turns.
+        def _run_scout(oai, model, task, tools, base_kwargs, *, max_tool_calls,
+                       ledger=None, **kw):
+            [t for t in tools if t.name == _agent.WEB_SEARCH_TOOL_NAME][0].invoke(
+                {"query": "q"})
+            ledger.record({"prompt_tokens": 300, "completion_tokens": 40})
+            return {"status": "ok", "report": "r", "tool_calls": 1, "truncated": False}
+
+        root = tempfile.mkdtemp()
+        with mock.patch.object(_agent, "run_scout", _run_scout):
+            _code.scout_tool(fake, "coder-x", root, None, {}, web_tool=ws,
+                             models=priced, parent_ledger=P).invoke({"task": "t"})
+        self.assertEqual(P.bucket_calls("web_search"), 1)     # exactly once
+        self.assertEqual(P.buckets["scout"]["prompt_tokens"], 300)   # and disjoint
+        self.assertAlmostEqual(P.billed_total(), P.bucket_cost())
+
 
 # --------------------------------------------------------------------------- #
 # _agent.resolve_web_search_model


### PR DESCRIPTION
Closes #117. Second half of #101 — the compaction half shipped in v0.82.0.

## What was broken

Every rail (`--scout`, `--spawn`, `--review`, `--web-search`) built a throwaway
`CostLedger` that died with the call. `--session-max-spend` bounded only the main loop,
and subagent cache behaviour was recorded nowhere.

## What lands

Each rail's API calls are banked into the parent ledger as **its own off-loop bucket**
(`scout` / `spawn` / `review` / `web_search`, beside `compaction`). `--session-max-spend`
now counts every API call the CLI makes; `/usage` breaks off-loop spend down per rail.

```
  off-loop     15.9s  across 4 API call(s)  [not in the trace above]
    compaction  1 call(s)     88,110 in      420 out     $0.0889
    review      1 call(s)     12,000 in    1,800 out     $0.0156
    scout       1 call(s)      6,200 in      900 out     $0.0080
    web_search  1 call(s)        800 in      120 out     $0.0010
```

### The mechanism: a mirror at `record()`

`CostLedger` gains a keyword-only `mirror=(parent, bucket_name)`. A mirrored child banks
each call into the parent's bucket via a new `record_bucket` accumulator — and `record()`'s
existing off-loop branch was refactored onto that same accumulator first, as a pure
behaviour-neutral step, so there is still exactly one live writer of a bucket row.

Mirroring at `record()` rather than at the call sites is the point: it is the one place
usage is read, so **two rails that call the API outside `run_loop`**
(`_review._retry_for_verdict`, `run_web_search`) are covered for free. `test_the_verdict_
retry_is_billed_to_the_parent_too` fails under the callback design the issue proposed and
passes under this one.

`record_bucket` is a leaf, which bounds the design by construction: no recursion to a
grandparent, and exactly one `usage-raw:` line per API call (pinned by a test).

### Verified against HEAD before writing any code

Per the standing lesson, every load-bearing claim in #117 was checked. It is one day old
and had still drifted:

- **CONFIRMED** — the parent ledger genuinely does not exist when the tool factories run.
- **STALE LINE NUMBERS** — `_repl.py:686` is the `state = {` line, not the construction
  (`:698`); the `on_tool` precedent is at `:2774`/`:2986`, not `:2428-2431`;
  `_invoke_window`'s `acc` is at `:2721`, not `:2376`.
- **FALSE** — "`test_summary_is_unchanged_without_a_bucket` is the pin that should fail
  first." It doesn't, and shouldn't: a mirrored child writes the **parent's** buckets and
  never its own, so the invariant #117 says this slice deletes is **preserved**. Corrected
  in the test comment and in `summary()`'s docstring, which made the same claim.
- **MISSED BY THE ISSUE, and it changed the design** — `--review-model` and
  `--web-search-model` are *deliberately different models* (decorrelation is the whole
  point of `--review`). The obvious implementation — hand raw usage to the already-priced
  parent — would price the reviewer's tokens at the **author's** rate. Pricing binds on the
  child instead, via a new `subagent_ledger()` built on `_build_ledger`, which stays the
  only caller of `bind_pricing`. `test_the_reviewer_is_priced_at_its_own_model_rate` pins it
  (parent 1x, reviewer 10x).
- **MISSED BY THE ISSUE** — `record()` had no lock on the documented reasoning that it only
  runs on the ledger's owning thread. A mirrored child ends that: `--parallel` dispatches up
  to `_MAX_PARALLEL` scouts/spawns writing one parent row. Added `_buckets_lock`, held
  around the row mutation only, never nested with `_tools_lock`.

## Also

- `summary()`'s bucket-name clause is now **bounded** — 5 buckets is 44 chars of clause on a
  footer that is also two stop-reason messages. ≤2 names list; past that it collapses to
  `[incl. $X off-loop]` and defers to `/usage`.
- `_bucket_lines` gained `[concurrent -- exceeds wall]`, reusing `_tool_lines`' exact
  predicate and wording — bucket seconds are a *subset* of wall and, under `--parallel`,
  overlap each other.
- The parent ledger is **hoisted** into `code.py::_run` above the factory block; both entry
  points adopt it by identity rather than building their own. A second ledger would orphan
  every rail's spend with no error — guarded by an `assertIs` test.
- README: the bullet that named the gap no longer under-claims.

## Verification

- `make test` 1626 tests (from 1576), `make drive` 37, `make scan` clean.
- **Mutation matrix over every new guard — 21 mutants across two rounds, 21/21 killed.**
  `__pycache__` cleared per run, green baseline asserted first, each mutant asserted to
  have actually applied, and a kill required to name a **FAILING** test rather than an
  import error (an ERROR can be a syntax break wearing a kill's clothes).

  Round 1 left **two survivors, both real gaps** — worth recording because both were
  places a test *looked* like it covered the seam but structurally could not:
  - `review_tool` dropping `parent_ledger=` on its way to `run_cycle` survived, because
    every review test called `run_cycle` **directly** and never crossed the forwarding hop.
  - `_repl` building its own ledger instead of adopting survived, because the `assertIs`
    test mocks `_repl.run` away entirely and by construction cannot see inside it.

  Two more came back `SUSPECT` (errors, not failures) — my tests subscripted a missing
  bucket and raised `KeyError`, which reads as a broken test rather than a caught
  regression; they now assert membership first. One was `NO VERDICT` because the
  *harness's* anchor matched twice. All five re-run clean.
- Rail/pin invariants hold — operator flags and factory kwargs only, no new tool: chat=14,
  `_REGISTRY`=16, mcp-serve=9, `_SUBAGENT_TOOL_NAMES` untouched.
- No `SESSION_VERSION` bump: a pre-#117 envelope has no `buckets` key and degrades to `{}`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
