### PR TITLE
fix(agent): preserve reasoning in assistant history

### DIFF
--- a/src/venice/commands/_agent.py
+++ b/src/venice/commands/_agent.py
@@ -2708,11 +2708,51 @@ def supports_function_calling(models, model_id) -> Optional[bool]:
 # --------------------------------------------------------------------------- #
 # The loop
 # --------------------------------------------------------------------------- #
+_REASONING_FIELDS = ("reasoning_content", "reasoning_details", "reasoning")
+
+
+def _message_field(msg, name):
+    """Read one response-message field from an SDK model or a plain mapping."""
+    if isinstance(msg, dict):
+        return msg.get(name)
+    return getattr(msg, name, None) if msg is not None else None
+
+
+def _request_value(value):
+    """Turn nested SDK response values into request-safe Python values.
+
+    ``reasoning_content`` is normally a string, but the compatible
+    ``reasoning_details`` extension may contain SDK model objects.  Serialize only
+    the selected value recursively instead of dumping the complete response message;
+    the latter also carries response-only metadata rejected by request schemas.
+    """
+    if hasattr(value, "model_dump"):
+        return value.model_dump(exclude_none=True)
+    if isinstance(value, list):
+        return [_request_value(item) for item in value]
+    if isinstance(value, tuple):
+        return [_request_value(item) for item in value]
+    if isinstance(value, dict):
+        return {key: _request_value(item) for key, item in value.items()}
+    return value
+
+
 def _assistant_dict(msg) -> dict:
-    """Reconstruct an assistant turn for the message history (explicit, not
-    model_dump()) so the follow-up tool messages carry the exact tool_call_ids."""
-    d = {"role": "assistant", "content": (getattr(msg, "content", None) or "")}
-    tcs = getattr(msg, "tool_calls", None) if msg is not None else None
+    """Reconstruct the replayable subset of an assistant response.
+
+    Keep content and exact tool-call ids plus one deliberately allowlisted reasoning
+    extension.  Compatible providers use three aliases; when a response unexpectedly
+    carries more than one, preserve the first in ``_REASONING_FIELDS`` order rather
+    than sending conflicting thinking payloads back on the next request.  Do not use a
+    whole-message ``model_dump()``: response-only metadata can be rejected on replay.
+    """
+    d = {"role": "assistant", "content": (_message_field(msg, "content") or "")}
+    for field in _REASONING_FIELDS:
+        value = _message_field(msg, field)
+        if value is not None:
+            d[field] = _request_value(value)
+            break
+    tcs = _message_field(msg, "tool_calls")
     if tcs:
         d["tool_calls"] = [
             {

--- a/src/venice/commands/_repl.py
+++ b/src/venice/commands/_repl.py
@@ -309,13 +309,13 @@ def _compose_in_editor(initial: str = "") -> Optional[str]:
 # One turn
 # --------------------------------------------------------------------------- #
 def _stream_turn(oai, chat, model: str, messages: List[dict], gen_kwargs: dict):
-    """One streamed turn; returns (reply_text, usage) for history + budget (#48)."""
+    """One streamed turn; returns (assistant_message, usage) for replay + budget."""
     kwargs = dict(gen_kwargs)
     kwargs["model"] = model
     kwargs["messages"] = messages
     kwargs["stream"] = True
     kwargs["stream_options"] = {"include_usage": True}
-    return chat._consume_stream_full(oai.chat.completions.create(**kwargs))
+    return chat._consume_stream_message_full(oai.chat.completions.create(**kwargs))
 
 
 def _do_turn(oai, openai, chat, text, messages, gen_kwargs, state, args) -> None:
@@ -413,7 +413,9 @@ def _turn(oai, openai, chat, text, messages, gen_kwargs, state, args) -> bool:
                 )
         else:
             _t0 = time.monotonic()
-            reply, usage = _stream_turn(oai, chat, state["model"], messages, gen_kwargs)
+            reply_message, usage = _stream_turn(
+                oai, chat, state["model"], messages, gen_kwargs,
+            )
             if budget is not None:
                 budget.observe(usage)
             if ledger is not None:
@@ -422,7 +424,7 @@ def _turn(oai, openai, chat, text, messages, gen_kwargs, state, args) -> bool:
                 # difference is real -- do not compare a streamed row against a buffered
                 # one and conclude the provider got slower.
                 ledger.record(usage, seconds=time.monotonic() - _t0)
-            messages.append({"role": "assistant", "content": reply})
+            messages.append(reply_message)
     except KeyboardInterrupt:
         # Ctrl-C aborts just this turn -- roll it back and keep the session. With #79's
         # attached steering this is the *second* Ctrl+C (or Ctrl+C at the steer prompt);

--- a/src/venice/commands/chat.py
+++ b/src/venice/commands/chat.py
@@ -706,9 +706,21 @@ def _consume_stream_full(stream):
     The REPL's auto-compact budget (#48) observes the server-reported prompt
     token count; printing behavior is identical to `_consume_stream`.
     """
+    message, usage = _consume_stream_message_full(stream)
+    return message["content"], usage
+
+
+def _consume_stream_message_full(stream):
+    """Consume a stream and retain its replayable assistant-message extensions.
+
+    The ordinary one-shot surface still returns/prints only visible content.  The
+    multi-turn REPL uses this richer result so Kimi-style reasoning deltas survive in
+    history and the next request can replay the complete assistant turn.
+    """
     citations = None
     usage = None
     parts: list = []
+    reasoning_parts = {field: [] for field in _agent._REASONING_FIELDS}
     for chunk in stream:
         vp = getattr(chunk, "venice_parameters", None)
         if vp is not None and citations is None:
@@ -716,16 +728,33 @@ def _consume_stream_full(stream):
         if getattr(chunk, "usage", None):
             usage = chunk.usage
         if chunk.choices:
-            piece = getattr(chunk.choices[0].delta, "content", None)
+            delta = chunk.choices[0].delta
+            piece = getattr(delta, "content", None)
             if piece:
                 sys.stdout.write(piece)
                 sys.stdout.flush()
                 parts.append(piece)
+            for field in _agent._REASONING_FIELDS:
+                value = getattr(delta, field, None)
+                if value is not None:
+                    reasoning_parts[field].append(_agent._request_value(value))
     if parts:
         sys.stdout.write("\n")
     _print_citations(citations)
     _print_usage(usage)
-    return "".join(parts), usage
+    message = {"role": "assistant", "content": "".join(parts)}
+    for field in _agent._REASONING_FIELDS:
+        values = reasoning_parts[field]
+        if not values:
+            continue
+        if all(isinstance(value, str) for value in values):
+            message[field] = "".join(values)
+        elif all(isinstance(value, list) for value in values):
+            message[field] = [item for value in values for item in value]
+        else:
+            message[field] = values[0] if len(values) == 1 else values
+        break
+    return message, usage
 
 
 def _run_stream(oai, kwargs: dict) -> int:

--- a/src/venice/commands/code.py
+++ b/src/venice/commands/code.py
@@ -532,7 +532,7 @@ def _human_pause(acc):
         acc[0] += time.monotonic() - t
 
 
-def _no_tool_turn(oai, model, messages, gen_kwargs, oai_tools, *, ledger=None) -> str:
+def _no_tool_turn(oai, model, messages, gen_kwargs, oai_tools, *, ledger=None) -> dict:
     """One completion with tools advertised but ``tool_choice="none"`` (no side
     effects) -- used for the plan turn and the acceptance-check turn.
 
@@ -550,9 +550,8 @@ def _no_tool_turn(oai, model, messages, gen_kwargs, oai_tools, *, ledger=None) -
         # transcript (see above), so they are the largest rows in the trace -- a trace
         # whose biggest calls read `n/a` would be worse than no trace at all.
         ledger.record(getattr(resp, "usage", None), seconds=time.monotonic() - _t0)
-    if getattr(resp, "choices", None):
-        return resp.choices[0].message.content or ""
-    return ""
+    msg = resp.choices[0].message if getattr(resp, "choices", None) else None
+    return _agent._assistant_dict(msg)
 
 
 # Promoted to `_agent` (#52): the scout subagent firewalls its stdout the same way,
@@ -866,12 +865,13 @@ def _run_oneshot(args, oai, openai, model, tools, system, gen_kwargs, root, task
             try:
                 # Inside the re-plan loop: each `edit` revision buys another plan turn,
                 # so recording per call (not once) is what makes the total honest.
-                plan_text = _no_tool_turn(oai, model, plan_messages, gen_kwargs,
-                                          oai_tools, ledger=ledger)
+                plan_message = _no_tool_turn(oai, model, plan_messages, gen_kwargs,
+                                             oai_tools, ledger=ledger)
+                plan_text = plan_message.get("content") or ""
             except openai.OpenAIError as e:
                 _finish(ledger, t0, human, json_out=args.json)
                 return _openai.status_to_exit(openai, e, "code")
-            messages.append({"role": "assistant", "content": plan_text})
+            messages.append(plan_message)
 
             if args.plan_only:
                 _finish(ledger, t0, human, json_out=args.json)
@@ -1000,14 +1000,17 @@ def _run_oneshot(args, oai, openai, model, tools, system, gen_kwargs, root, task
     if not args.no_verify and not args.no_plan:
         messages.append({"role": "user", "content": _VERIFY_MSG})
         try:
-            report = _no_tool_turn(oai, model, messages, gen_kwargs, oai_tools,
-                                   ledger=ledger)
+            report_message = _no_tool_turn(oai, model, messages, gen_kwargs, oai_tools,
+                                           ledger=ledger)
+            report = report_message.get("content") or ""
             parsed = _parse_verdict(report)
             if parsed is None:      # re-prompt ONCE for the exact verdict line
-                messages.append({"role": "assistant", "content": report})
+                messages.append(report_message)
                 messages.append({"role": "user", "content": _VERIFY_RETRY_MSG})
-                retry = _no_tool_turn(oai, model, messages, gen_kwargs, oai_tools,
-                                      ledger=ledger)
+                retry_message = _no_tool_turn(
+                    oai, model, messages, gen_kwargs, oai_tools, ledger=ledger,
+                )
+                retry = retry_message.get("content") or ""
                 report = f"{report}\n{retry}" if report else retry
                 parsed = _parse_verdict(retry)
         except openai.OpenAIError as e:

--- a/tests/test_agent.py
+++ b/tests/test_agent.py
@@ -13,6 +13,7 @@ import tempfile
 import threading
 import time
 import unittest
+from types import SimpleNamespace
 from unittest import mock
 
 from venice.commands import _agent
@@ -44,6 +45,99 @@ def _tool(name, impl, *, paid=False):
 
 def _free_tool():
     return _tool("t", lambda a, *, confirm=False: {"status": "ok"})
+
+
+class TestAssistantReplay(unittest.TestCase):
+    """#129: compatible reasoning fields survive every buffered history seam."""
+
+    def test_synthetic_sdk_message_replays_reasoning_and_exact_tool_call(self):
+        from openai.types.chat import ChatCompletion
+
+        response = ChatCompletion.model_validate({
+            "id": "chatcmpl-test",
+            "object": "chat.completion",
+            "created": 0,
+            "model": "kimi-k3",
+            "choices": [{
+                "index": 0,
+                "finish_reason": "tool_calls",
+                "message": {
+                    "role": "assistant",
+                    "content": "I will inspect it.",
+                    "reasoning_content": "reasoning bytes: \u2603",
+                    "tool_calls": [{
+                        "id": "call-123",
+                        "type": "function",
+                        "function": {"name": "t", "arguments": '{"x":1}'},
+                    }],
+                },
+            }],
+        })
+
+        self.assertEqual(_agent._assistant_dict(response.choices[0].message), {
+            "role": "assistant",
+            "content": "I will inspect it.",
+            "reasoning_content": "reasoning bytes: \u2603",
+            "tool_calls": [{
+                "id": "call-123",
+                "type": "function",
+                "function": {"name": "t", "arguments": '{"x":1}'},
+            }],
+        })
+
+    def test_alias_precedence_is_explicit_and_response_metadata_is_dropped(self):
+        msg = SimpleNamespace(
+            content="visible",
+            tool_calls=None,
+            reasoning_content="preferred",
+            reasoning_details=[{"type": "summary", "text": "other"}],
+            reasoning="last",
+            refusal="response-only",
+        )
+        self.assertEqual(_agent._assistant_dict(msg), {
+            "role": "assistant",
+            "content": "visible",
+            "reasoning_content": "preferred",
+        })
+
+    def test_non_reasoning_message_shape_is_unchanged(self):
+        msg = SimpleNamespace(content=None, tool_calls=None)
+        self.assertEqual(_agent._assistant_dict(msg), {
+            "role": "assistant", "content": "",
+        })
+
+    def test_next_tool_request_includes_reasoning_byte_for_byte(self):
+        first = FakeToolCompletion(
+            tool_calls=[_FnCall("c1", "t", "{}")],
+            reasoning_content="keep this exactly \u2603",
+        )
+        fake, calls = _fake_oai([first, FakeToolCompletion("done")])
+        messages = [{"role": "user", "content": "go"}]
+        with mock.patch.object(sys, "stdout", io.StringIO()), \
+             mock.patch.object(sys, "stderr", io.StringIO()):
+            _agent.run_loop(
+                fake, "kimi-k3", messages, {}, [_free_tool()],
+                max_tool_calls=0, yes=True, json_out=False,
+            )
+        self.assertEqual(
+            calls[1]["messages"][1]["reasoning_content"],
+            "keep this exactly \u2603",
+        )
+
+    def test_forced_final_response_keeps_reasoning_in_history(self):
+        seq = [
+            FakeToolCompletion(tool_calls=[_FnCall("c1", "t", "{}")]),
+            FakeToolCompletion("wrapped", reasoning_content="final thought"),
+        ]
+        fake, _calls = _fake_oai(seq)
+        messages = [{"role": "user", "content": "go"}]
+        with mock.patch.object(sys, "stdout", io.StringIO()), \
+             mock.patch.object(sys, "stderr", io.StringIO()):
+            _agent.run_loop(
+                fake, "kimi-k3", messages, {}, [_free_tool()],
+                max_tool_calls=1, yes=True, json_out=False,
+            )
+        self.assertEqual(messages[-1]["reasoning_content"], "final thought")
 
 
 def _tty(value=True):

--- a/tests/test_chat.py
+++ b/tests/test_chat.py
@@ -95,18 +95,23 @@ class FakeCompletion:
 
 
 class _Delta:
-    def __init__(self, content):
+    def __init__(self, content, **fields):
         self.content = content
+        for name, value in fields.items():
+            setattr(self, name, value)
 
 
 class _StreamChoice:
-    def __init__(self, content):
-        self.delta = _Delta(content)
+    def __init__(self, content, **fields):
+        self.delta = _Delta(content, **fields)
 
 
 class FakeChunk:
-    def __init__(self, content=None, usage=None, venice_parameters=None):
-        self.choices = [_StreamChoice(content)] if content is not None else []
+    def __init__(self, content=None, usage=None, venice_parameters=None, **delta_fields):
+        self.choices = (
+            [_StreamChoice(content, **delta_fields)]
+            if content is not None or delta_fields else []
+        )
         self.usage = usage
         self.venice_parameters = venice_parameters
 
@@ -166,9 +171,11 @@ class _FnCall:
 
 
 class _ToolMsg:
-    def __init__(self, content=None, tool_calls=None):
+    def __init__(self, content=None, tool_calls=None, **fields):
         self.content = content
         self.tool_calls = tool_calls
+        for name, value in fields.items():
+            setattr(self, name, value)
 
 
 class _ToolChoice:
@@ -180,8 +187,8 @@ class FakeToolCompletion:
     """A completion whose message may carry tool_calls (None => a final answer)."""
 
     def __init__(self, content=None, tool_calls=None, venice_parameters=None,
-                 usage=None):
-        self.choices = [_ToolChoice(_ToolMsg(content, tool_calls))]
+                 usage=None, **message_fields):
+        self.choices = [_ToolChoice(_ToolMsg(content, tool_calls, **message_fields))]
         self.venice_parameters = venice_parameters
         self.usage = usage
 

--- a/tests/test_code_command.py
+++ b/tests/test_code_command.py
@@ -146,6 +146,41 @@ class TestCodeCommand(unittest.TestCase):
         with open(os.path.join(self.root, "hello.py")) as f:
             self.assertEqual(f.read(), "def hi():\n    return 1\n")
 
+    def test_plan_reasoning_replays_and_survives_the_session_round_trip(self):
+        seq = [
+            FakeToolCompletion(
+                "plan: inspect then fix",
+                reasoning_content="plan reasoning \u2603",
+            ),
+            FakeToolCompletion("done"),
+            FakeToolCompletion("ACCEPTANCE: PASS"),
+        ]
+        rc, calls = self._run(
+            _code_args(task="fix it", root=self.root, auto=True), seq,
+        )
+        self.assertEqual(rc, 0)
+
+        plan_in_execute = [
+            message for message in calls[1]["messages"]
+            if message.get("role") == "assistant"
+        ][0]
+        self.assertEqual(plan_in_execute["content"], "plan: inspect then fix")
+        self.assertEqual(plan_in_execute["reasoning_content"], "plan reasoning \u2603")
+
+        session_files = [
+            os.path.join(self._sess_dir, name)
+            for name in os.listdir(self._sess_dir)
+            if name.endswith(".json")
+        ]
+        self.assertEqual(len(session_files), 1)
+        with open(session_files[0]) as fh:
+            saved = json.load(fh)
+        saved_plan = [
+            message for message in saved["messages"]
+            if message.get("content") == "plan: inspect then fix"
+        ][0]
+        self.assertEqual(saved_plan["reasoning_content"], "plan reasoning \u2603")
+
     # --- #76: cross-repo write protection wired through code._run ---
     def _sibling(self):
         other = os.path.realpath(tempfile.mkdtemp())
@@ -387,6 +422,27 @@ class TestCodeCommand(unittest.TestCase):
         self.assertEqual(rc, 0)
         self.assertEqual(len(calls), 4)                 # extra re-prompt turn
         self.assertEqual(calls[3]["tool_choice"], "none")
+
+    def test_acceptance_retry_replays_the_complete_assistant_message(self):
+        seq = [
+            FakeToolCompletion("plan"),
+            FakeToolCompletion("did the work"),
+            FakeToolCompletion(
+                "All acceptance criteria are met.",
+                reasoning_details=[{"type": "summary", "text": "checked"}],
+            ),
+            FakeToolCompletion("ACCEPTANCE: PASS"),
+        ]
+        rc, calls = self._run(
+            _code_args(task="x", root=self.root, auto=True), seq,
+        )
+        self.assertEqual(rc, 0)
+        replayed = calls[3]["messages"][-2]
+        self.assertEqual(replayed["content"], "All acceptance criteria are met.")
+        self.assertEqual(
+            replayed["reasoning_details"],
+            [{"type": "summary", "text": "checked"}],
+        )
 
     # --- #37: still no verdict after the re-prompt -> exit 10 + warning ---
     def test_acceptance_unknown_persists_exits_10(self):

--- a/tests/test_repl.py
+++ b/tests/test_repl.py
@@ -371,6 +371,32 @@ class TestRepl(unittest.TestCase):
             env2 = json.loads((Path(d) / (sid + ".json")).read_text())
             self.assertEqual(len(env2["messages"]), 4)
 
+    def test_streamed_reasoning_replays_and_is_saved(self):
+        with tempfile.TemporaryDirectory() as d:
+            results = [
+                [
+                    FakeChunk(reasoning_content="think "),
+                    FakeChunk("answer", reasoning_content="carefully"),
+                ],
+                [FakeChunk("follow-up")],
+            ]
+            rc, _fake, calls = _run_repl(
+                _args(interactive=True),
+                results,
+                ["first", "second", "/exit"],
+                sessions_dir=d,
+            )
+            self.assertEqual(rc, 0)
+            replayed = calls[1]["messages"][1]
+            self.assertEqual(replayed["content"], "answer")
+            self.assertEqual(replayed["reasoning_content"], "think carefully")
+
+            saved = json.loads(list(Path(d).glob("*.json"))[0].read_text())
+            self.assertEqual(
+                saved["messages"][1]["reasoning_content"],
+                "think carefully",
+            )
+
     def test_ephemeral_writes_no_file(self):
         with tempfile.TemporaryDirectory() as d:
             rc, fake, calls = _run_repl(

--- a/tests/test_sessions.py
+++ b/tests/test_sessions.py
@@ -62,6 +62,22 @@ class TestStore(_Base):
         self.assertEqual(r.usage["cache_read_tokens"], 4)
         self.assertEqual([m["content"] for m in r.messages], ["hi"])
 
+    def test_reasoning_extension_round_trips_without_schema_loss(self):
+        sess = self._mk(messages=[
+            {"role": "user", "content": "question"},
+            {
+                "role": "assistant",
+                "content": "answer",
+                "reasoning_content": "provider state \u2603",
+            },
+        ])
+        S.save(sess)
+        got = S.load(sess.id, "chat")
+        self.assertEqual(
+            got.messages[1]["reasoning_content"],
+            "provider state \u2603",
+        )
+
     def test_envelope_has_version_and_no_key(self):
         sess = self._mk()
         path = S.save(sess)


### PR DESCRIPTION
## Summary

- preserve allowlisted OpenAI-compatible reasoning fields in assistant history
- retain complete planning and acceptance-retry messages while keeping CLI output unchanged
- reassemble streamed reasoning deltas for REPL replay and session persistence

## Validation

- 430 focused unit tests
- full 1,616-test suite
- 37-test PTY/fake-server drive suite
- syntax, diff, and invisible-character checks

Closes #129