### PR TITLE
Release: require successful exact-SHA CI before PyPI (#138)

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -2,8 +2,9 @@ name: publish
 
 # Publishes venice-cli to PyPI via Trusted Publishing (OIDC) -- no API token is
 # stored anywhere. Deliberately NOT triggered by a bare tag push: a PyPI version
-# is immutable once uploaded, so the trigger is a published GitHub Release (a
-# deliberate human action) or an explicit manual dispatch.
+# is immutable once uploaded, so production requires a published GitHub Release
+# whose exact tag SHA has already passed the complete master test workflow.
+# Manual dispatch is TestPyPI-only.
 #
 # Requires, one time, outside this repo:
 #   - a pending publisher on pypi.org and test.pypi.org for project venice-cli
@@ -15,12 +16,6 @@ on:
   release:
     types: [published]
   workflow_dispatch:
-    inputs:
-      target:
-        description: "Publish target"
-        type: choice
-        options: [testpypi, pypi]
-        default: testpypi
 
 permissions:
   contents: read
@@ -28,8 +23,26 @@ permissions:
 jobs:
   build:
     runs-on: ubuntu-latest
+    permissions:
+      actions: read
+      contents: read
     steps:
       - uses: actions/checkout@v5
+        with:
+          # Pin the event's commit. For a release this is the commit recorded
+          # for its tag; for TestPyPI it is the ref selected in the Actions UI.
+          ref: ${{ github.sha }}
+
+      - name: Require successful exact-SHA CI
+        if: github.event_name == 'release'
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+          RELEASE_TAG: ${{ github.event.release.tag_name }}
+        run: |
+          PYTHONPATH=src python scripts/verify_release.py \
+            --repository "$GITHUB_REPOSITORY" \
+            --tag "$RELEASE_TAG" \
+            --sha "$(git rev-parse HEAD)"
 
       - uses: actions/setup-python@v6
         with:
@@ -41,19 +54,6 @@ jobs:
           python -m build
           twine check --strict dist/*
 
-      # The version is single-sourced in src/venice/__init__.py, so nothing else
-      # stops a release being tagged v0.14.0 on a tree that still says 0.13.1.
-      - name: Verify tag matches __version__
-        if: github.event_name == 'release'
-        run: |
-          VERSION=$(python -c "import re, pathlib; print(re.search(r'\"([^\"]+)\"', pathlib.Path('src/venice/__init__.py').read_text()).group(1))")
-          TAG="${GITHUB_REF_NAME#v}"
-          if [ "$VERSION" != "$TAG" ]; then
-            echo "::error::tag $GITHUB_REF_NAME does not match __version__ $VERSION"
-            exit 1
-          fi
-          echo "ok: tag $GITHUB_REF_NAME matches __version__ $VERSION"
-
       - uses: actions/upload-artifact@v7
         with:
           name: dist
@@ -61,7 +61,7 @@ jobs:
 
   testpypi:
     needs: build
-    if: github.event_name == 'workflow_dispatch' && inputs.target == 'testpypi'
+    if: github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
     environment: testpypi
     permissions:
@@ -77,7 +77,7 @@ jobs:
 
   pypi:
     needs: build
-    if: github.event_name == 'release' || (github.event_name == 'workflow_dispatch' && inputs.target == 'pypi')
+    if: github.event_name == 'release'
     runs-on: ubuntu-latest
     environment: pypi
     permissions:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -105,6 +105,21 @@ distinction is invisible until you run the suite from a venv, where
 One `feat/<name>` branch per issue. Commit subjects follow
 `vX.Y: short description (#issue)`. Merges into `master` are `--no-ff`.
 
+## Releases
+
+Production releases are made only from `v<version>` tags on `master`. Merge the
+release-version PR, then wait for the complete `test` workflow to succeed for
+that exact merge SHA before creating and publishing the GitHub Release. The
+`publish` workflow independently verifies the tag against the imported package
+version and requires that exact successful `master` run before it builds or can
+mint PyPI credentials. A missing, pending, failed, branch-equivalent, PR, or
+manually dispatched test run never satisfies the gate.
+
+Manual dispatch of `publish` is TestPyPI-only. If a GitHub Release is published
+before exact-SHA CI finishes, production publication fails closed; after CI is
+green, rerun the failed release workflow rather than moving or recreating the
+tag.
+
 ## Reporting bugs
 
 Include the command you ran, what you expected, what happened, the exit code,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -88,6 +88,7 @@ packages = ["src/venice"]
 include = [
   "/src",
   "/tests",
+  "/scripts",
   "/bin",
   "/Makefile",
   "/install.sh",

--- a/scripts/verify_release.py
+++ b/scripts/verify_release.py
@@ -1,0 +1,166 @@
+#!/usr/bin/env python3
+"""Fail closed unless a release tag has successful exact-SHA CI.
+
+This runs before a production artifact is built.  It intentionally uses only
+the standard library and reports no response bodies or authorization values.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import sys
+import urllib.error
+import urllib.parse
+import urllib.request
+from typing import Any, Callable, List, Mapping, Optional
+
+from venice import __version__
+
+
+API_VERSION = "2022-11-28"
+MAX_RESPONSE_BYTES = 4 * 1024 * 1024
+SHA_RE = re.compile(r"[0-9a-f]{40}\Z")
+
+
+class ReleaseGateError(RuntimeError):
+    """A production release invariant was not satisfied."""
+
+
+def verify_tag(tag: str, version: str = __version__) -> None:
+    expected = f"v{version}"
+    if tag != expected:
+        raise ReleaseGateError(
+            f"tag {tag!r} does not match imported package version {expected!r}"
+        )
+
+
+def _workflow_runs(payload: Any) -> list[Mapping[str, Any]]:
+    if not isinstance(payload, dict):
+        raise ReleaseGateError("GitHub Actions response is not an object")
+    runs = payload.get("workflow_runs")
+    if not isinstance(runs, list):
+        raise ReleaseGateError("GitHub Actions response has no workflow_runs list")
+    if not all(isinstance(run, dict) for run in runs):
+        raise ReleaseGateError("GitHub Actions response contains an invalid run")
+    return runs
+
+
+def require_successful_run(payload: Any, *, sha: str, branch: str) -> Mapping[str, Any]:
+    if not SHA_RE.fullmatch(sha):
+        raise ReleaseGateError(f"invalid commit SHA {sha!r}")
+
+    runs = _workflow_runs(payload)
+    matching = [
+        run
+        for run in runs
+        if run.get("head_sha") == sha
+        and run.get("event") == "push"
+        and run.get("head_branch") == branch
+    ]
+    successful = [
+        run
+        for run in matching
+        if run.get("status") == "completed" and run.get("conclusion") == "success"
+    ]
+    if successful:
+        return successful[0]
+
+    states = sorted(
+        {
+            f"{run.get('status', 'unknown')}/{run.get('conclusion', 'none')}"
+            for run in matching
+        }
+    )
+    detail = ", ".join(states) if states else "no matching master push run"
+    raise ReleaseGateError(
+        f"test.yml has no completed successful {branch} push for exact SHA {sha}; "
+        f"observed: {detail}"
+    )
+
+
+def fetch_workflow_runs(
+    *,
+    repository: str,
+    workflow: str,
+    sha: str,
+    token: str,
+    opener: Callable[..., Any] = urllib.request.urlopen,
+) -> Any:
+    try:
+        owner, name = repository.split("/", 1)
+    except ValueError as exc:
+        raise ReleaseGateError(f"invalid GitHub repository {repository!r}") from exc
+    if not owner or not name or "/" in name:
+        raise ReleaseGateError(f"invalid GitHub repository {repository!r}")
+    if not token:
+        raise ReleaseGateError("GITHUB_TOKEN is unavailable")
+    if not SHA_RE.fullmatch(sha):
+        raise ReleaseGateError(f"invalid commit SHA {sha!r}")
+
+    repo_path = "/".join(urllib.parse.quote(part, safe="") for part in (owner, name))
+    workflow_path = urllib.parse.quote(workflow, safe="")
+    query = urllib.parse.urlencode({"head_sha": sha, "per_page": 100})
+    url = (
+        f"https://api.github.com/repos/{repo_path}/actions/workflows/"
+        f"{workflow_path}/runs?{query}"
+    )
+    request = urllib.request.Request(
+        url,
+        headers={
+            "Accept": "application/vnd.github+json",
+            "Authorization": f"Bearer {token}",
+            "X-GitHub-Api-Version": API_VERSION,
+        },
+    )
+    try:
+        with opener(request, timeout=30) as response:
+            raw = response.read(MAX_RESPONSE_BYTES + 1)
+    except urllib.error.HTTPError as exc:
+        raise ReleaseGateError(f"GitHub Actions query failed with HTTP {exc.code}") from exc
+    except (urllib.error.URLError, TimeoutError, OSError) as exc:
+        raise ReleaseGateError("GitHub Actions query failed") from exc
+    if len(raw) > MAX_RESPONSE_BYTES:
+        raise ReleaseGateError("GitHub Actions response exceeded the size limit")
+    try:
+        return json.loads(raw)
+    except (UnicodeDecodeError, json.JSONDecodeError) as exc:
+        raise ReleaseGateError("GitHub Actions response was not valid JSON") from exc
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--repository", required=True)
+    parser.add_argument("--workflow", default="test.yml")
+    parser.add_argument("--branch", default="master")
+    parser.add_argument("--tag", required=True)
+    parser.add_argument("--sha", required=True)
+    return parser
+
+
+def main(argv: Optional[List[str]] = None) -> int:
+    args = build_parser().parse_args(argv)
+    try:
+        verify_tag(args.tag)
+        payload = fetch_workflow_runs(
+            repository=args.repository,
+            workflow=args.workflow,
+            sha=args.sha,
+            token=os.environ.get("GITHUB_TOKEN", ""),
+        )
+        run = require_successful_run(payload, sha=args.sha, branch=args.branch)
+    except ReleaseGateError as exc:
+        print(f"release gate: {exc}", file=sys.stderr)
+        return 1
+
+    print(
+        f"release gate: {args.tag} is pinned to {args.sha} and exact-SHA CI "
+        f"run {run.get('id')} succeeded"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_release_gate.py
+++ b/tests/test_release_gate.py
@@ -1,0 +1,144 @@
+import importlib.util
+import io
+import json
+import pathlib
+import unittest
+import urllib.error
+from contextlib import redirect_stderr
+
+
+SCRIPT = pathlib.Path(__file__).parents[1] / "scripts" / "verify_release.py"
+SPEC = importlib.util.spec_from_file_location("verify_release", SCRIPT)
+verify_release = importlib.util.module_from_spec(SPEC)
+assert SPEC.loader is not None
+SPEC.loader.exec_module(verify_release)
+
+SHA = "a" * 40
+
+
+def run(*, event="push", branch="master", status="completed", conclusion="success", sha=SHA):
+    return {
+        "id": 123,
+        "head_sha": sha,
+        "event": event,
+        "head_branch": branch,
+        "status": status,
+        "conclusion": conclusion,
+    }
+
+
+class _Response:
+    def __init__(self, body):
+        self.body = body
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *_args):
+        return False
+
+    def read(self, _limit):
+        return self.body
+
+
+class ReleaseGateTests(unittest.TestCase):
+    def test_tag_must_match_imported_version(self):
+        verify_release.verify_tag("v1.2.3", "1.2.3")
+        with self.assertRaisesRegex(verify_release.ReleaseGateError, "imported package version"):
+            verify_release.verify_tag("v1.2.2", "1.2.3")
+
+    def test_accepts_only_completed_successful_master_push_for_exact_sha(self):
+        payload = {
+            "workflow_runs": [
+                run(event="pull_request"),
+                run(branch="other"),
+                run(sha="b" * 40),
+                run(status="in_progress", conclusion=None),
+                run(),
+            ]
+        }
+        accepted = verify_release.require_successful_run(payload, sha=SHA, branch="master")
+        self.assertEqual(accepted["id"], 123)
+
+    def test_rejects_missing_pending_failed_and_non_push_runs(self):
+        cases = (
+            [],
+            [run(status="in_progress", conclusion=None)],
+            [run(conclusion="failure")],
+            [run(event="workflow_dispatch")],
+            [run(event="pull_request")],
+            [run(branch="release")],
+            [run(sha="b" * 40)],
+        )
+        for runs in cases:
+            with self.subTest(runs=runs):
+                with self.assertRaises(verify_release.ReleaseGateError):
+                    verify_release.require_successful_run(
+                        {"workflow_runs": runs}, sha=SHA, branch="master"
+                    )
+
+    def test_rejects_malformed_payload_and_sha(self):
+        for payload in (None, [], {}, {"workflow_runs": {}}, {"workflow_runs": [None]}):
+            with self.subTest(payload=payload):
+                with self.assertRaises(verify_release.ReleaseGateError):
+                    verify_release.require_successful_run(payload, sha=SHA, branch="master")
+        with self.assertRaisesRegex(verify_release.ReleaseGateError, "invalid commit SHA"):
+            verify_release.require_successful_run(
+                {"workflow_runs": []}, sha="not-a-sha", branch="master"
+            )
+
+    def test_fetch_uses_bounded_authenticated_exact_sha_query(self):
+        seen = {}
+
+        def opener(request, timeout):
+            seen["request"] = request
+            seen["timeout"] = timeout
+            return _Response(json.dumps({"workflow_runs": [run()]}).encode())
+
+        payload = verify_release.fetch_workflow_runs(
+            repository="owner/repo",
+            workflow="test.yml",
+            sha=SHA,
+            token="test-token",
+            opener=opener,
+        )
+        self.assertEqual(payload["workflow_runs"][0]["head_sha"], SHA)
+        self.assertIn(f"head_sha={SHA}", seen["request"].full_url)
+        self.assertIn("test.yml", seen["request"].full_url)
+        self.assertEqual(seen["request"].get_header("Authorization"), "Bearer test-token")
+        self.assertEqual(seen["timeout"], 30)
+
+    def test_fetch_fails_closed_without_echoing_token(self):
+        token = "test-secret-never-print"
+
+        def opener(_request, timeout):
+            self.assertEqual(timeout, 30)
+            raise urllib.error.HTTPError("https://api.github.invalid", 403, "no", {}, None)
+
+        stderr = io.StringIO()
+        with redirect_stderr(stderr):
+            with self.assertRaisesRegex(verify_release.ReleaseGateError, "HTTP 403"):
+                verify_release.fetch_workflow_runs(
+                    repository="owner/repo",
+                    workflow="test.yml",
+                    sha=SHA,
+                    token=token,
+                    opener=opener,
+                )
+        self.assertNotIn(token, stderr.getvalue())
+
+    def test_fetch_rejects_invalid_json_and_oversized_response(self):
+        for body in (b"not-json", b"x" * (verify_release.MAX_RESPONSE_BYTES + 1)):
+            with self.subTest(size=len(body)):
+                with self.assertRaises(verify_release.ReleaseGateError):
+                    verify_release.fetch_workflow_runs(
+                        repository="owner/repo",
+                        workflow="test.yml",
+                        sha=SHA,
+                        token="test-token",
+                        opener=lambda *_args, **_kwargs: _Response(body),
+                    )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Closes #138

## Summary
- require a completed successful `test.yml` master-push run for the exact release SHA before building
- import the package version for tag validation and fail closed on malformed or unavailable Actions results
- remove manual production dispatch while retaining manual TestPyPI publication
- document the exact-SHA release invariant and ship the tested stdlib gate in the sdist

## Validation
- `PYTHONPATH=src python3 -m unittest -v tests.test_release_gate`
- `make test` (1,626 tests)
- `make lint`
- `make scan`
- `GOMAXPROCS=2 go run github.com/rhysd/actionlint/cmd/actionlint@latest .github/workflows/publish.yml`
- isolated sdist/wheel build plus `twine check --strict`
- fresh `--no-deps` wheel install, command-graph import, and base dependency smoke
- live read-only gate check against the historical v0.83.6 exact-SHA test run