### PR TITLE
Security: constrain ungated Git tool authority (#139)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1387,7 +1387,7 @@ jq '.usage.billed_total' ~/.config/venice/sessions/<id>.json
 | Tool | Does | Confirms? |
 | --- | --- | --- |
 | `read_file` / `list_dir` / `grep` | read a file, list a dir, regex-search the tree | no |
-| `git` | read-only git (`status`/`diff`/`log`/`show`/…) | no |
+| `git` | validated read-only Git (`status`/`diff`/`log`/`show`/…); literal paths go after `--` | no |
 | `project_search` | semantic search over the `.venice` index (if built) — a **snapshot** of the last build; use `grep` for live matches | no |
 | `reindex` | rebuild the `.venice` index so `project_search` reflects this session's edits (re-embeds only changed files); present only when an index exists | yes (paid) |
 | `venice_vision` | describe/inspect a local image or image URL via a vision-capable model | no |
@@ -1422,6 +1422,15 @@ forced cwd, timeout, and env-scrub — which is why it always confirms. git muta
 [`shell` allow/deny policy](#shell-exec-tool---shell) (config `shell.*` or
 `--shell-allow`/`--shell-deny`) — a denied command is refused; an empty policy leaves
 it unrestricted (unchanged behavior).
+
+The free `git` tool validates arguments per operation rather than trusting a
+subcommand name. `branch` and `remote` are listing-only; content diffs require
+literal, root-confined paths after `--`; pathspec magic, `REV:path`, `--no-index`,
+output files, external diff/text conversion, and config injection are refused before
+Git starts. Path operands must resolve to existing regular files, so a directory cannot
+smuggle protected descendants into a broad diff. Git also runs without inherited
+`GIT_*` controls, optional locks, system/global config, hooks, fsmonitor, pagers, or
+external diff helpers. Use the confirmed `run` tool for other Git forms.
 
 | flag | effect |
 | --- | --- |

--- a/src/venice/commands/_code.py
+++ b/src/venice/commands/_code.py
@@ -29,10 +29,11 @@ Safety model:
   child env. A shell command can still read/write **outside** the root (``cat ../x``);
   exec's boundary is the confirm gate + cwd + timeout + env-scrub + the optional
   allow/deny **shell policy**, **not** path containment -- which is why it is always
-  gated. ``git`` exposes only read-only subcommands freely; mutations go through the
-  (gated) ``run`` tool. The exec rails (``run_cmd``/``git_cmd``/``_scrubbed_env``/the
-  policy) live in :mod:`commands._exec` so `venice chat --shell` (#33) shares the
-  exact same gate.
+  gated. ``git`` exposes only argument-validated read forms freely, confines literal
+  pathspecs to the active root, and neutralizes Git-selected helpers/config; mutations
+  and arbitrary Git options go through the (gated) ``run`` tool. The exec rails
+  (``run_cmd``/``git_cmd``/``_scrubbed_env``/the policy) live in
+  :mod:`commands._exec` so `venice chat --shell` (#33) shares the exact same gate.
 """
 from __future__ import annotations
 
@@ -208,6 +209,22 @@ def _safe_path(roots: "Roots", arg, *, must_exist: bool = False, write: bool = F
     if must_exist and not os.path.exists(real):
         raise _PathError(f"no such file or directory: {arg}")
     return real, rel
+
+
+def _safe_git_path(roots: "Roots", arg) -> str:
+    """Resolve a literal Git pathspec inside the active repository root.
+
+    File tools may read any attached root, but one Git invocation is bound to the
+    active root's repository. Rewriting an approved path to an active-root-relative
+    POSIX path prevents absolute operands and attached-root ``..`` escapes from
+    crossing that boundary.
+    """
+    real, _rel = _safe_path(roots, arg, must_exist=True, write=False)
+    if not _index.resolves_inside(Path(real), Path(roots.base)):
+        raise _PathError(f"Git path escapes the active project root: {arg}")
+    if not os.path.isfile(real):
+        raise _PathError(f"Git path must name a regular file: {arg}")
+    return Path(os.path.relpath(real, roots.base)).as_posix()
 
 
 def _stage_write(target: str, text: str) -> str:
@@ -845,7 +862,14 @@ def code_tools(
                        allow=shell_allow, deny=shell_deny, **_clean(arguments))
 
     def git_invoke(arguments, *, confirm: bool = False):
-        return git_cmd(roots.base, exec_timeout=exec_timeout, **_clean(arguments))
+        clean = _clean(arguments)
+        return git_cmd(
+            roots.base,
+            clean.get("subcommand"),
+            args=clean.get("args"),
+            path_guard=lambda path: _safe_git_path(roots, path),
+            exec_timeout=exec_timeout,
+        )
 
     tools = [
         _agent.Tool("read_file",
@@ -890,8 +914,9 @@ def code_tools(
                     _RUN_SCHEMA, run_invoke, paid=True,
                     category="exec", tags=("exec", "mutate")),
         _agent.Tool("git",
-                    "Run a read-only git subcommand (status/diff/log/show/...) in "
-                    "the project root. For commits/adds use the run tool.",
+                    "Run a validated read-only Git operation in the project root. "
+                    "Put literal paths after --; mutations and arbitrary Git "
+                    "options are refused. For commits/adds use the run tool.",
                     _GIT_SCHEMA, git_invoke, paid=False,
                     category="vcs", tags=("read",)),
         _agent.Tool("attach_root",
@@ -996,7 +1021,14 @@ def read_only_tools(root: str, client=None, *, include_search: bool = False
         return invoke
 
     def git_invoke(arguments, *, confirm: bool = False):
-        return git_cmd(roots.base, exec_timeout=DEFAULT_EXEC_TIMEOUT, **_clean(arguments))
+        clean = _clean(arguments)
+        return git_cmd(
+            roots.base,
+            clean.get("subcommand"),
+            args=clean.get("args"),
+            path_guard=lambda path: _safe_git_path(roots, path),
+            exec_timeout=DEFAULT_EXEC_TIMEOUT,
+        )
 
     tools = [
         _agent.Tool("read_file",
@@ -1015,8 +1047,8 @@ def read_only_tools(root: str, client=None, *, include_search: bool = False
                     _GREP_SCHEMA, free(grep_files), paid=False,
                     category="fs", tags=("read", "search")),
         _agent.Tool("git",
-                    "Run a read-only git subcommand (status/diff/log/show/...) in "
-                    "the project root.",
+                    "Run a validated read-only Git operation in the project root. "
+                    "Put literal paths after --; arbitrary options are refused.",
                     _GIT_SCHEMA, git_invoke, paid=False,
                     category="vcs", tags=("read",)),
     ]

--- a/src/venice/commands/_exec.py
+++ b/src/venice/commands/_exec.py
@@ -22,14 +22,21 @@ Policy (issue #33 decision -- "simple-command + globs"):
 The exec boundary is the confirm gate + cwd + timeout + env-scrub + this policy,
 **not** path containment: a shell command can still read/write outside the root,
 which is why it is always gated (and why an operator scopes it with allow/deny).
+
+The free Git boundary is different: :func:`git_cmd` accepts only exact read forms,
+requires its caller to resolve every literal path through project authority, and
+neutralizes Git environment/config features that can write or execute helpers.
+Package-authored review plumbing uses the private :func:`_git_cmd_internal`; its
+controlled ``diff --no-index`` form is never reachable from the model schema.
 """
 from __future__ import annotations
 
 import fnmatch
 import os
+import re
 import shlex
 import subprocess
-from typing import Optional
+from typing import Callable, List, Optional, Tuple
 
 # --------------------------------------------------------------------------- #
 # Limits + constants
@@ -87,10 +94,15 @@ _RUN_SCHEMA = _obj(
 )
 _GIT_SCHEMA = _obj(
     {
-        "subcommand": _p("string", "Read-only git subcommand (status/diff/log/show/...)."),
+        "subcommand": _p(
+            "string",
+            "Read-only Git operation. Arguments are validated per operation; "
+            "mutations require the confirmed run tool.",
+        ),
         "args": {"type": "array", "items": {"type": "string"},
-                 "description": "Extra arguments for the subcommand -- do NOT "
-                                "repeat the subcommand itself here."},
+                 "description": "Validated flags/revisions for the operation. "
+                                "Put literal project paths after -- and do NOT "
+                                "repeat the subcommand itself."},
     },
     ["subcommand"],
 )
@@ -101,6 +113,19 @@ _GIT_SCHEMA = _obj(
 # --------------------------------------------------------------------------- #
 def _scrubbed_env() -> dict:
     return {k: v for k, v in os.environ.items() if k not in _SECRET_ENV}
+
+
+def _git_env() -> dict:
+    """Return an exec environment that cannot redirect Git to helpers/config."""
+    env = {k: v for k, v in _scrubbed_env().items() if not k.startswith("GIT_")}
+    env.update({
+        "GIT_CONFIG_NOSYSTEM": "1",
+        "GIT_CONFIG_GLOBAL": os.devnull,
+        "GIT_TERMINAL_PROMPT": "0",
+        "GIT_PAGER": "cat",
+        "GIT_OPTIONAL_LOCKS": "0",
+    })
+    return env
 
 
 def _split(command: str):
@@ -188,40 +213,297 @@ def run_cmd(root: str, command, *, timeout=None, exec_timeout: int = DEFAULT_EXE
 
 _GIT_READONLY = frozenset({
     "status", "diff", "log", "show", "branch", "ls-files", "blame", "remote",
-    "rev-parse", "describe", "shortlog",
-    # `merge-base` computes the fork point of two refs and writes nothing (#80
-    # part 1a: `venice review` pins its diff range to merge-base(base, HEAD)).
-    "merge-base",
+    "rev-parse", "describe", "shortlog", "merge-base",
+})
+
+# Revisions deliberately exclude Git's ``REV:path`` object syntax and option-like
+# forms. Common refs, hashes, ancestry suffixes, and one range remain available.
+_REV_ATOM = r"(?:HEAD|[A-Za-z0-9][A-Za-z0-9._/@{}^~+/-]*)"
+_REV_RE = re.compile(rf"{_REV_ATOM}(?:(?:\.\.|\.\.\.){_REV_ATOM})?\Z")
+_CONTROL_RE = re.compile(r"[\x00-\x1f\x7f]")
+_CONTEXT_RE = re.compile(
+    r"(?:-U\d{1,3}|--unified=\d{1,3}|--inter-hunk-context=\d{1,3})\Z"
+)
+_MAX_COUNT_RE = re.compile(r"--max-count=(\d+)\Z")
+
+_STATUS_FLAGS = frozenset({
+    "-s", "--short", "-b", "--branch", "--show-stash", "--porcelain",
+    "--porcelain=v1", "--porcelain=v2", "--long", "--ahead-behind",
+    "--no-ahead-behind", "--renames", "--no-renames", "--ignored",
+    "--ignored=traditional", "--ignored=matching", "--ignored=no",
+    "--untracked-files", "--untracked-files=all", "--untracked-files=normal",
+    "--untracked-files=no", "-uno", "-unormal", "-uall", "-z", "--null",
+})
+_DIFF_FLAGS = frozenset({
+    "--cached", "--staged", "--merge-base", "--stat", "--numstat",
+    "--shortstat", "--name-only", "--name-status", "--check", "--summary",
+    "--patch", "-p", "--no-patch", "-s", "--raw", "--no-color",
+    "--color=never", "--minimal", "--patience", "--histogram", "-w",
+    "--ignore-all-space", "-b", "--ignore-space-change", "--ignore-space-at-eol",
+    "--ignore-blank-lines", "-W", "--function-context", "--word-diff",
+    "--word-diff=plain", "--word-diff=color", "--word-diff=porcelain",
+    "--no-renames",
+})
+_LOG_FLAGS = frozenset({
+    "--oneline", "--decorate", "--decorate=short", "--decorate=full",
+    "--no-decorate", "--graph", "--all", "--branches", "--remotes", "--tags",
+    "--first-parent", "--merges", "--no-merges", "--reverse", "--topo-order",
+    "--date-order", "--author-date-order", "--no-color", "--color=never",
+})
+_SHOW_FLAGS = frozenset({
+    "--oneline", "--stat", "--numstat", "--shortstat", "--name-only",
+    "--name-status", "--summary", "--patch", "-p", "--no-patch", "-s",
+    "--raw", "--no-color", "--color=never", "-w", "--ignore-all-space",
+    "-b", "--ignore-space-change", "-W", "--function-context", "--no-renames",
+})
+_LS_FILES_FLAGS = frozenset({
+    "--cached", "-c", "--deleted", "-d", "--modified", "-m", "--others", "-o",
+    "--ignored", "-i", "--stage", "-s", "--unmerged", "-u", "--killed", "-k",
+    "--directory", "--no-empty-directory", "--exclude-standard", "-z",
+    "--deduplicate", "--sparse",
+})
+_BLAME_FLAGS = frozenset({
+    "--line-porcelain", "--porcelain", "-w", "--show-stats", "--root",
+    "--first-parent", "--show-name", "--show-number", "--score-debug",
+})
+_SHORTLOG_FLAGS = frozenset({"-n", "--numbered", "-s", "--summary", "-e", "--email"})
+_DESCRIBE_FLAGS = frozenset({
+    "--always", "--tags", "--all", "--long", "--exact-match", "--dirty",
+    "--contains", "--first-parent",
+})
+_REV_PARSE_FLAGS = frozenset({
+    "--verify", "--quiet", "-q", "--abbrev-ref", "--symbolic-full-name",
+    "--short", "--show-toplevel", "--show-prefix", "--show-cdup",
+    "--is-inside-work-tree", "--is-bare-repository", "--is-shallow-repository",
+})
+_MERGE_BASE_FLAGS = frozenset({
+    "--all", "--octopus", "--independent", "--is-ancestor", "--fork-point",
 })
 
 
-def git_cmd(root: str, subcommand, *, args=None,
-            exec_timeout: int = DEFAULT_EXEC_TIMEOUT) -> dict:
-    sub = str(subcommand or "").strip()
-    if sub not in _GIT_READONLY:
-        return _err(
-            "git: only read-only subcommands are allowed here "
-            f"({', '.join(sorted(_GIT_READONLY))}); use the run tool "
-            "(which confirms) for mutations like add/commit"
+class _GitPolicyError(ValueError):
+    pass
+
+
+def _safe_revision(value: str) -> bool:
+    if value.startswith("-") or ":" in value or "\\" in value:
+        return False
+    return bool(_REV_RE.fullmatch(value))
+
+
+def _split_paths(args: List[str]) -> Tuple[List[str], List[str]]:
+    if args.count("--") > 1:
+        raise _GitPolicyError("git: '--' may appear only once")
+    if "--" not in args:
+        return args, []
+    at = args.index("--")
+    paths = args[at + 1:]
+    if not paths:
+        raise _GitPolicyError("git: '--' must be followed by a project path")
+    return args[:at], paths
+
+
+def _bounded_max_count(token: str) -> bool:
+    match = _MAX_COUNT_RE.fullmatch(token)
+    return bool(match and 1 <= int(match.group(1)) <= 200)
+
+
+def _option_with_value(token: str, prefixes) -> bool:
+    return any(token.startswith(prefix) and len(token) > len(prefix) for prefix in prefixes)
+
+
+def _validate_simple(before: List[str], flags, *, max_revs: int,
+                     value_prefixes=()) -> None:
+    revs = 0
+    i = 0
+    while i < len(before):
+        token = before[i]
+        if token in flags or _CONTEXT_RE.fullmatch(token):
+            i += 1
+            continue
+        if _bounded_max_count(token):
+            i += 1
+            continue
+        if token in ("-n", "--max-count"):
+            if i + 1 >= len(before) or not before[i + 1].isdigit() \
+                    or not 1 <= int(before[i + 1]) <= 200:
+                raise _GitPolicyError("git: max-count must be an integer from 1 to 200")
+            i += 2
+            continue
+        if _option_with_value(token, value_prefixes):
+            i += 1
+            continue
+        if _safe_revision(token) and revs < max_revs:
+            revs += 1
+            i += 1
+            continue
+        raise _GitPolicyError(f"git: argument is not allowed for this read form: {token!r}")
+
+
+def _validate_branch(before: List[str]) -> None:
+    if not before:
+        return
+    listing = "--list" in before
+    no_value = {
+        "--list", "-a", "--all", "-r", "--remotes", "-v", "-vv", "--verbose",
+        "--no-color", "--color=never", "--show-current", "--column", "--no-column",
+    }
+    value_prefixes = (
+        "--contains=", "--no-contains=", "--merged=", "--no-merged=",
+        "--points-at=", "--sort=", "--column=",
+    )
+    for token in before:
+        if token in no_value:
+            continue
+        if _option_with_value(token, value_prefixes):
+            value = token.split("=", 1)[1]
+            if token.startswith((
+                    "--contains=", "--no-contains=", "--merged=",
+                    "--no-merged=", "--points-at=",
+            )) and not _safe_revision(value):
+                raise _GitPolicyError(f"git: unsafe branch revision: {value!r}")
+            continue
+        if listing and not token.startswith("-") and not _CONTROL_RE.search(token):
+            continue
+        raise _GitPolicyError(f"git: branch permits listing forms only: {token!r}")
+
+
+def _validate_args(sub: str, args: List[str],
+                   path_guard: Callable[[str], str]) -> List[str]:
+    before, paths = _split_paths(args)
+    if any(_CONTROL_RE.search(token) for token in args):
+        raise _GitPolicyError("git: control characters are not allowed in arguments")
+
+    if sub == "status":
+        if any(token not in _STATUS_FLAGS for token in before):
+            raise _GitPolicyError("git: status accepts display flags and '--' paths only")
+    elif sub == "diff":
+        _validate_simple(
+            before, _DIFF_FLAGS, max_revs=2,
+            value_prefixes=("--word-diff-regex=",),
         )
-    argv = ["git", sub]
-    if args:
-        if not isinstance(args, list):
-            return _err("args must be a list of strings")
-        if args and str(args[0]).strip() == sub:
-            return _err(
-                f"git: don't repeat the subcommand in 'args'; pass only the "
-                f"flags/arguments that follow {sub!r} (got args starting with "
-                f"{sub!r}, which would run 'git {sub} {sub} ...')"
+    elif sub == "log":
+        _validate_simple(
+            before, _LOG_FLAGS, max_revs=1,
+            value_prefixes=(
+                "--date=", "--author=", "--grep=", "--since=", "--until=",
+                "--after=", "--before=",
+            ),
+        )
+    elif sub == "show":
+        _validate_simple(before, _SHOW_FLAGS, max_revs=1)
+    elif sub == "ls-files":
+        if any(token not in _LS_FILES_FLAGS for token in before):
+            raise _GitPolicyError("git: ls-files option is not in the read allowlist")
+    elif sub == "blame":
+        i = 0
+        revs = 0
+        while i < len(before):
+            token = before[i]
+            if token in _BLAME_FLAGS:
+                i += 1
+            elif token == "-L" and i + 1 < len(before) \
+                    and re.fullmatch(r"\d+(?:,\d+)?", before[i + 1]):
+                i += 2
+            elif token.startswith("-L") and re.fullmatch(r"-L\d+(?:,\d+)?", token):
+                i += 1
+            elif _safe_revision(token) and revs == 0:
+                revs += 1
+                i += 1
+            else:
+                raise _GitPolicyError(f"git: blame argument is not allowed: {token!r}")
+        if len(paths) != 1:
+            raise _GitPolicyError("git: blame requires exactly one project path after '--'")
+    elif sub == "branch":
+        if paths:
+            raise _GitPolicyError("git: branch does not accept path operands")
+        _validate_branch(before)
+    elif sub == "remote":
+        if before or paths:
+            raise _GitPolicyError("git: remote permits names-only listing with no arguments")
+    elif sub == "rev-parse":
+        has_revision = False
+        for token in before:
+            if token in _REV_PARSE_FLAGS or re.fullmatch(r"--short=\d{1,2}", token):
+                continue
+            if _safe_revision(token):
+                has_revision = True
+                continue
+            raise _GitPolicyError(f"git: rev-parse argument is not allowed: {token!r}")
+        if has_revision and "--verify" not in before:
+            raise _GitPolicyError("git: rev-parse revisions require --verify")
+        if paths:
+            raise _GitPolicyError("git: rev-parse does not accept path operands")
+    elif sub == "describe":
+        for token in before:
+            if token in _DESCRIBE_FLAGS or re.fullmatch(r"--abbrev=\d{1,2}", token) \
+                    or _option_with_value(token, ("--match=", "--exclude=", "--candidates=")):
+                continue
+            if _safe_revision(token):
+                continue
+            raise _GitPolicyError(f"git: describe argument is not allowed: {token!r}")
+        if paths:
+            raise _GitPolicyError("git: describe does not accept path operands")
+    elif sub == "shortlog":
+        _validate_simple(before, _SHORTLOG_FLAGS, max_revs=2)
+        if paths:
+            raise _GitPolicyError("git: shortlog does not accept path operands")
+    elif sub == "merge-base":
+        for token in before:
+            if token in _MERGE_BASE_FLAGS or _safe_revision(token):
+                continue
+            raise _GitPolicyError(f"git: merge-base argument is not allowed: {token!r}")
+        if paths:
+            raise _GitPolicyError("git: merge-base does not accept path operands")
+    else:
+        raise _GitPolicyError(f"git: unsupported read operation: {sub!r}")
+
+    guarded = []
+    for path in paths:
+        if path.startswith(":") or any(ch in path for ch in "*?["):
+            raise _GitPolicyError(f"git: pathspec magic/globs are not allowed: {path!r}")
+        try:
+            guarded.append(path_guard(path))
+        except Exception as exc:
+            raise _GitPolicyError(str(exc)) from exc
+    if sub == "diff" and not guarded:
+        metadata = {
+            "--stat", "--numstat", "--shortstat", "--name-only",
+            "--name-status", "--raw", "--summary",
+        }
+        if not any(token in metadata for token in before):
+            raise _GitPolicyError(
+                "git: content diffs require one or more approved paths after '--'"
             )
-        for a in args:
-            if not isinstance(a, (str, int, float)):
-                return _err("each arg must be a string")
-            argv.append(str(a))
+    if sub == "show" and not guarded and not ({"--no-patch", "-s"} & set(before)):
+        raise _GitPolicyError(
+            "git: show without an approved path requires --no-patch"
+        )
+    if guarded:
+        return before + ["--"] + guarded
+    # Disambiguate revision-looking values from implicit filesystem operands.
+    if sub in ("diff", "log", "show"):
+        return before + ["--"]
+    return before
+
+
+def _run_git(root: str, sub: str, args: List[str], *, exec_timeout: int) -> dict:
+    """Execute code-authored Git argv with helper execution neutralized."""
+    argv = [
+        "git", "--no-pager",
+        "-c", "core.fsmonitor=false",
+        "-c", f"core.hooksPath={os.devnull}",
+        "-c", "diff.external=",
+        "-c", "interactive.diffFilter=",
+        sub,
+    ]
+    if sub in ("diff", "log", "show"):
+        argv.extend(("--no-ext-diff", "--no-textconv"))
+    argv.extend(args)
     try:
         proc = subprocess.run(
             argv, cwd=root, capture_output=True, text=True,
-            timeout=int(exec_timeout), env=_scrubbed_env(),
+            timeout=int(exec_timeout), env=_git_env(),
         )
     except FileNotFoundError:
         return _err("git is not installed")
@@ -236,3 +518,46 @@ def git_cmd(root: str, subcommand, *, args=None,
         stderr=errout[:MAX_OUTPUT_CHARS],
         truncated=(len(out) > MAX_OUTPUT_CHARS),
     )
+
+
+def _git_cmd_internal(root: str, subcommand: str, args, *,
+                      exec_timeout: int = DEFAULT_EXEC_TIMEOUT) -> dict:
+    """Run package-authored read-only Git argv outside the model tool schema."""
+    if subcommand not in _GIT_READONLY:
+        return _err(f"git: internal read operation is not supported: {subcommand!r}")
+    if not isinstance(args, list) or not all(isinstance(a, str) for a in args):
+        return _err("git: internal args must be a list of strings")
+    return _run_git(os.path.realpath(root), subcommand, args,
+                    exec_timeout=exec_timeout)
+
+
+def git_cmd(root: str, subcommand, *, args=None,
+            path_guard: Optional[Callable[[str], str]] = None,
+            exec_timeout: int = DEFAULT_EXEC_TIMEOUT) -> dict:
+    """Run one strictly validated, argument-aware, read-only Git operation."""
+    sub = str(subcommand or "").strip()
+    if sub not in _GIT_READONLY:
+        return _err(
+            "git: only validated read-only operations are allowed here "
+            f"({', '.join(sorted(_GIT_READONLY))}); use the run tool "
+            "(which confirms) for mutations like add/commit"
+        )
+    if args is None:
+        args = []
+    if not isinstance(args, list) or not all(isinstance(a, str) for a in args):
+        return _err("args must be a list of strings")
+    if args and args[0].strip() == sub:
+        return _err(
+            f"git: don't repeat the subcommand in 'args'; pass only the "
+            f"flags/arguments that follow {sub!r} (got args starting with "
+            f"{sub!r}, which would run 'git {sub} {sub} ...')"
+        )
+    if path_guard is None:
+        def path_guard(_path: str) -> str:
+            raise _GitPolicyError("git: path authority is unavailable")
+    try:
+        safe_args = _validate_args(sub, args, path_guard)
+    except (OSError, ValueError) as exc:
+        return _err(str(exc))
+    return _run_git(os.path.realpath(root), sub, safe_args,
+                    exec_timeout=exec_timeout)

--- a/src/venice/commands/_review.py
+++ b/src/venice/commands/_review.py
@@ -149,7 +149,7 @@ def classify(path: str, added: str = "", deleted: str = "") -> str:
 
 
 # --------------------------------------------------------------------------- #
-# git plumbing (everything goes through the read-only `_exec.git_cmd` gate)
+# git plumbing (code-authored argv use `_exec`'s private hardened runner)
 # --------------------------------------------------------------------------- #
 class ReviewError(Exception):
     """A review could not be set up. `.message` is printable; `.code` is the exit code."""
@@ -168,7 +168,9 @@ def _git(root: str, sub: str, args, exec_timeout: int,
     differ" as exit 1 -- the normal, expected outcome when diffing an untracked
     file against /dev/null.
     """
-    out = _exec.git_cmd(root, sub, args=list(args), exec_timeout=exec_timeout)
+    out = _exec._git_cmd_internal(
+        root, sub, args=list(args), exec_timeout=exec_timeout
+    )
     if out.get("status") != "ok" or out.get("exit_code") not in ok_codes:
         return False, (out.get("stderr") or out.get("message") or "").strip()
     return True, (out.get("stdout") or "").strip()

--- a/tests/test_code.py
+++ b/tests/test_code.py
@@ -4,6 +4,7 @@ Hermetic: a throwaway project tree under a tmpdir, no network, no real key. The
 engine is stdlib-only + mcp-free, so this whole file runs on the 3.9 floor.
 """
 import os
+import subprocess
 import sys
 import tempfile
 import unittest
@@ -375,6 +376,94 @@ class TestCodeTools(unittest.TestCase):
         bad = self.tools["git"].invoke({"subcommand": "commit", "args": ["-m", "x"]})
         self.assertEqual(bad["status"], "error")
         self.assertIn("read-only", bad["message"])
+
+    def _init_git_fixture(self):
+        subprocess.run(
+            ["git", "init", "-q", "-b", "master", "."], cwd=self.root, check=True
+        )
+        self._write("tracked.txt", "before\n")
+        subprocess.run(["git", "add", "tracked.txt"], cwd=self.root, check=True)
+        subprocess.run(
+            ["git", "-c", "user.name=Test", "-c", "user.email=test@example.invalid",
+             "commit", "-qm", "baseline"],
+            cwd=self.root, check=True,
+        )
+
+    def test_git_remote_and_branch_mutations_leave_repository_unchanged(self):
+        self._init_git_fixture()
+        subprocess.run(["git", "branch", "keep"], cwd=self.root, check=True)
+
+        remote = self.tools["git"].invoke({
+            "subcommand": "remote",
+            "args": ["add", "audit", "https://example.invalid/repo"],
+        })
+        branch = self.tools["git"].invoke({
+            "subcommand": "branch", "args": ["-D", "keep"],
+        })
+
+        self.assertEqual(remote["status"], "error")
+        self.assertEqual(branch["status"], "error")
+        remotes = subprocess.run(
+            ["git", "remote"], cwd=self.root, check=True, capture_output=True, text=True
+        ).stdout.splitlines()
+        branches = subprocess.run(
+            ["git", "branch", "--list", "keep"], cwd=self.root, check=True,
+            capture_output=True, text=True,
+        ).stdout
+        self.assertNotIn("audit", remotes)
+        self.assertIn("keep", branches)
+
+    def test_git_paths_enforce_root_secret_and_symlink_authority(self):
+        self._init_git_fixture()
+        outside_dir = tempfile.mkdtemp()
+        self.addCleanup(__import__("shutil").rmtree, outside_dir, True)
+        outside = Path(outside_dir) / "outside.txt"
+        outside.write_text("outside marker\n", encoding="utf-8")
+        (Path(self.root) / "escape.txt").symlink_to(outside)
+        self._write(".env", "not-a-real-secret\n")
+
+        for path in (str(outside), "escape.txt", ".env", ".git/config", "."):
+            with self.subTest(path=path):
+                result = self.tools["git"].invoke({
+                    "subcommand": "diff", "args": ["--", path],
+                })
+                self.assertEqual(result["status"], "error")
+                self.assertIn("path", result["message"].lower())
+
+        object_read = self.tools["git"].invoke({
+            "subcommand": "show", "args": ["HEAD:.env"],
+        })
+        self.assertEqual(object_read["status"], "error")
+
+    def test_git_configured_executables_never_run(self):
+        self._init_git_fixture()
+        marker = Path(self.root) / "helper-ran"
+        helper = self._write(
+            "helper.sh", f"#!/bin/sh\ntouch {marker}\nexit 0\n"
+        )
+        helper.chmod(0o755)
+        subprocess.run(
+            ["git", "config", "core.fsmonitor", str(helper)],
+            cwd=self.root, check=True,
+        )
+        subprocess.run(
+            ["git", "config", "diff.external", str(helper)],
+            cwd=self.root, check=True,
+        )
+        self._write("tracked.txt", "after\n")
+        os.environ["GIT_EXTERNAL_DIFF"] = str(helper)
+        try:
+            status = self.tools["git"].invoke({
+                "subcommand": "status", "args": ["--short"],
+            })
+            diff = self.tools["git"].invoke({
+                "subcommand": "diff", "args": ["--", "tracked.txt"],
+            })
+        finally:
+            os.environ.pop("GIT_EXTERNAL_DIFF", None)
+        self.assertEqual(status["status"], "ok")
+        self.assertEqual(diff["status"], "ok")
+        self.assertFalse(marker.exists())
 
 
 class TestCodeFactory(unittest.TestCase):

--- a/tests/test_exec.py
+++ b/tests/test_exec.py
@@ -110,6 +110,10 @@ class TestGitCmd(unittest.TestCase):
     def setUp(self):
         self.root = tempfile.mkdtemp()
 
+    def tearDown(self):
+        import shutil
+        shutil.rmtree(self.root, ignore_errors=True)
+
     def test_duplicate_subcommand_in_args_rejected_before_exec(self):
         # #69: passing the subcommand inside args (mirroring a CLI invocation)
         # would run `git remote remote -v`; reject it with a tool error and never
@@ -120,14 +124,18 @@ class TestGitCmd(unittest.TestCase):
         self.assertIn("don't repeat the subcommand", r["message"])
         run.assert_not_called()
 
-    def test_normal_args_are_unchanged(self):
-        # Regression guard: args that do NOT repeat the subcommand still build the
-        # expected argv and run.
+    def test_validated_args_reach_hardened_git(self):
         with mock.patch("venice.commands._exec.subprocess.run") as run:
-            run.return_value = mock.Mock(returncode=0, stdout="origin\n", stderr="")
-            r = _exec.git_cmd(self.root, "remote", args=["-v"])
+            run.return_value = mock.Mock(returncode=0, stdout=" M source.py\n", stderr="")
+            r = _exec.git_cmd(
+                self.root, "status", args=["--short", "--", "source.py"],
+                path_guard=lambda path: f"safe/{path}",
+            )
         self.assertEqual(r["status"], "ok")
-        self.assertEqual(run.call_args[0][0], ["git", "remote", "-v"])
+        argv = run.call_args[0][0]
+        self.assertEqual(argv[0:2], ["git", "--no-pager"])
+        self.assertIn("core.fsmonitor=false", argv)
+        self.assertEqual(argv[-4:], ["status", "--short", "--", "safe/source.py"])
 
     def test_merge_base_is_allowed(self):
         # #80 part 1a: `venice review` pins its diff range to merge-base(base, HEAD),
@@ -137,8 +145,8 @@ class TestGitCmd(unittest.TestCase):
             run.return_value = mock.Mock(returncode=0, stdout="abc123\n", stderr="")
             r = _exec.git_cmd(self.root, "merge-base", args=["origin/master", "HEAD"])
         self.assertEqual(r["status"], "ok")
-        self.assertEqual(run.call_args[0][0],
-                         ["git", "merge-base", "origin/master", "HEAD"])
+        self.assertEqual(run.call_args[0][0][-3:],
+                         ["merge-base", "origin/master", "HEAD"])
 
     def test_mutating_subcommands_still_refused(self):
         # Anti-vacuity for the row above: widening the allow-list must not have
@@ -148,8 +156,62 @@ class TestGitCmd(unittest.TestCase):
                 with mock.patch("venice.commands._exec.subprocess.run") as run:
                     r = _exec.git_cmd(self.root, sub)
                 self.assertEqual(r["status"], "error")
-                self.assertIn("only read-only subcommands", r["message"])
+                self.assertIn("read-only operations", r["message"])
                 run.assert_not_called()
+
+    def test_argument_level_mutations_and_escape_options_are_refused(self):
+        cases = (
+            ("remote", ["add", "audit", "https://example.invalid/repo"]),
+            ("branch", ["-D", "work"]),
+            ("branch", ["-f", "work", "HEAD"]),
+            ("diff", ["--no-index", "--", "one", "two"]),
+            ("diff", ["--output=leak.txt"]),
+            ("diff", ["--ext-diff"]),
+            ("diff", ["--textconv"]),
+            ("blame", ["--contents", "outside", "--", "inside"]),
+            ("rev-parse", ["--git-path", "config"]),
+            ("rev-parse", ["README.md"]),
+            ("show", ["HEAD:credentials"]),
+            ("show", ["HEAD"]),
+            ("diff", ["HEAD"]),
+        )
+        for sub, args in cases:
+            with self.subTest(sub=sub, args=args):
+                with mock.patch("venice.commands._exec.subprocess.run") as run:
+                    result = _exec.git_cmd(
+                        self.root, sub, args=list(args), path_guard=lambda path: path
+                    )
+                self.assertEqual(result["status"], "error")
+                run.assert_not_called()
+
+    def test_paths_require_authority_and_reject_magic(self):
+        for args in (["--", "file.txt"], ["--", ":(top)file"], ["--", "*.py"]):
+            with self.subTest(args=args):
+                with mock.patch("venice.commands._exec.subprocess.run") as run:
+                    result = _exec.git_cmd(self.root, "diff", args=args)
+                self.assertEqual(result["status"], "error")
+                run.assert_not_called()
+
+    def test_git_environment_discards_all_inherited_git_controls(self):
+        os.environ["GIT_DIR"] = "/outside"
+        os.environ["GIT_EXTERNAL_DIFF"] = "/outside/helper"
+        os.environ["VENICE_API_KEY"] = "test-fake-key"
+        try:
+            with mock.patch("venice.commands._exec.subprocess.run") as run:
+                run.return_value = mock.Mock(returncode=0, stdout="", stderr="")
+                result = _exec.git_cmd(self.root, "status")
+        finally:
+            os.environ.pop("GIT_DIR", None)
+            os.environ.pop("GIT_EXTERNAL_DIFF", None)
+            os.environ.pop("VENICE_API_KEY", None)
+        self.assertEqual(result["status"], "ok")
+        env = run.call_args.kwargs["env"]
+        self.assertNotIn("GIT_DIR", env)
+        self.assertNotIn("GIT_EXTERNAL_DIFF", env)
+        self.assertNotIn("VENICE_API_KEY", env)
+        self.assertEqual(env["GIT_CONFIG_NOSYSTEM"], "1")
+        self.assertEqual(env["GIT_CONFIG_GLOBAL"], os.devnull)
+        self.assertEqual(env["GIT_OPTIONAL_LOCKS"], "0")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Closes #139

## Summary
- validate each model-facing Git operation with an exact read-only argument grammar
- confine literal path operands to existing regular files inside the active project root
- neutralize inherited Git controls, optional locks, hooks, fsmonitor, pagers, and external diff/textconv helpers
- retain review-only `diff --no-index` through private package-authored plumbing

## Validation
- `PYTHONPATH=src VENICE_API_KEY=test-fake-key python3 -m unittest tests.test_exec tests.test_code tests.test_review` (203 tests)
- `VENICE_API_KEY=test-fake-key make test` (1,632 tests)
- `VENICE_API_KEY=test-fake-key make drive` (37 tests)
- `make lint`
- `make scan`
- live local exercise of 14 retained validated Git forms
- manual security diff review; no real Venice API calls or credential reads