### PR TITLE
Security: constrain model media path authority (#141)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1423,6 +1423,11 @@ forced cwd, timeout, and env-scrub — which is why it always confirms. git muta
 `--shell-allow`/`--shell-deny`) — a denied command is refused; an empty policy leaves
 it unrestricted (unchanged behavior).
 
+The same active/attached readable-root and secret-path policy applies when
+`venice_vision` or a `--assets` media tool reads a model-supplied local file. Those
+inputs must also match a recognized media signature; confirmation and `--auto` do
+not widen this authority.
+
 The free `git` tool validates arguments per operation rather than trusting a
 subcommand name. `branch` and `remote` are listing-only; content diffs require
 literal, root-confined paths after `--`; pathspec magic, `REV:path`, `--no-index`,
@@ -1774,6 +1779,13 @@ gated.
 inline base64). Files land in `VENICE_MCP_OUTPUT_DIR` (default: the current
 working directory), or a per-call `output_dir`. The API key is read the usual
 way (`$VENICE_API_KEY` or the credentials file) and is never echoed.
+
+**Local media inputs.** Paths supplied to image/video tools by an MCP host are
+confined to the server's startup working directory after resolving symlinks.
+Secret-shaped files and `.git`/`.venice` paths are refused, and the file must have
+a recognized bounded image/audio/video signature before any bytes are sent. This
+model-facing rail does not narrow paths explicitly supplied by an operator to the
+ordinary `venice upscale`, `bg-remove`, `image-edit`, or `video` CLI commands.
 
 Only stdout carries the JSON-RPC protocol; the server's own diagnostics go to
 stderr. Video generation and image editing are exposed over MCP too: the

--- a/src/venice/commands/_agent.py
+++ b/src/venice/commands/_agent.py
@@ -47,6 +47,7 @@ from . import _memory
 from . import _models
 from . import _compact
 from . import _openai
+from . import _shared
 from .models import MODEL_TYPES
 
 
@@ -2420,7 +2421,7 @@ def select(categories=None, names=None, exclude=None) -> set:
 
 
 # Loop-controlled kwargs the model must never supply (stripped defensively).
-_CONTROLLED = ("confirm", "max_spend", "output_dir")
+_CONTROLLED = ("confirm", "max_spend", "output_dir", "path_authority")
 
 
 def _clean(arguments) -> dict:
@@ -2572,6 +2573,7 @@ def builtin_tools(
     browser_output_dir: Optional[str] = None,
     memory: bool = False,
     exec_timeout: int = _exec.DEFAULT_EXEC_TIMEOUT,
+    media_path_authority=None,
 ) -> List[Tool]:
     """Build the in-process venice tools, bound to `client`.
 
@@ -2599,31 +2601,44 @@ def builtin_tools(
     `memory` (issue #49) appends the persistent memory + task rails (`memory_tools`):
     free, local notes (two tiers) + a project task list. Also a rail (added after the
     `only` filter, absent from `_BUILTINS`/`mcp-serve`).
+
+    `media_path_authority` is loop-controlled and never advertised. It confines
+    every model-supplied local media input to operator-authorized roots; chat
+    defaults to the cwd captured here, while code supplies its mutable root set.
     """
+
+    if media_path_authority is None:
+        media_path_authority = _shared.MediaPathAuthority(os.getcwd())
 
     def _config_defaults(section, impl) -> dict:
         # #58: shared with mcp-serve -- layer defaults.<section>.* under tool args.
         return userconfig.config_defaults_for(section, impl, config)
 
-    def _make_paid(impl, section):
+    def _make_paid(impl, section, impl_name):
         defaults = _config_defaults(section, impl)
 
         def invoke(arguments, *, confirm: bool = False):
-            return impl(
-                client,
-                confirm=confirm,
-                max_spend=max_spend,
-                output_dir=output_dir,
-                **{**defaults, **_clean(arguments)},
-            )
+            controlled = {
+                "confirm": confirm,
+                "max_spend": max_spend,
+                "output_dir": output_dir,
+            }
+            if impl_name in {
+                "upscale_tool", "bg_remove_tool", "video_tool", "image_edit_tool"
+            }:
+                controlled["path_authority"] = media_path_authority
+            return impl(client, **controlled, **{**defaults, **_clean(arguments)})
 
         return invoke
 
-    def _make_free(impl, section):
+    def _make_free(impl, section, impl_name):
         defaults = _config_defaults(section, impl)
 
         def invoke(arguments, *, confirm: bool = False):
-            return impl(client, **{**defaults, **_clean(arguments)})
+            controlled = {}
+            if impl_name == "vision_tool":
+                controlled["path_authority"] = media_path_authority
+            return impl(client, **controlled, **{**defaults, **_clean(arguments)})
 
         return invoke
 
@@ -2634,9 +2649,13 @@ def builtin_tools(
             description=spec.description,
             parameters=spec.parameters,
             invoke=(
-                _make_paid(getattr(_mcp, spec.impl), _tool_section(spec.name))
+                _make_paid(
+                    getattr(_mcp, spec.impl), _tool_section(spec.name), spec.impl
+                )
                 if spec.paid
-                else _make_free(getattr(_mcp, spec.impl), _tool_section(spec.name))
+                else _make_free(
+                    getattr(_mcp, spec.impl), _tool_section(spec.name), spec.impl
+                )
             ),
             paid=spec.paid,
             category=spec.category,

--- a/src/venice/commands/_code.py
+++ b/src/venice/commands/_code.py
@@ -45,7 +45,7 @@ import threading
 from pathlib import Path
 from typing import List, Optional
 
-from . import _agent, _exec, _index, _mcp, _memory
+from . import _agent, _exec, _index, _mcp, _memory, _shared
 from ._exec import (  # shared exec rails (#33): one gate for `code` and chat --shell
     DEFAULT_EXEC_TIMEOUT,
     MAX_OUTPUT_CHARS,
@@ -71,7 +71,7 @@ MAX_GREP_MATCHES = 200
 MAX_GREP_FILES = 5_000
 
 # Loop-controlled kwargs the model must never supply (mirrors _agent._CONTROLLED).
-_CONTROLLED = ("confirm", "max_spend", "output_dir")
+_CONTROLLED = ("confirm", "max_spend", "output_dir", "path_authority")
 
 
 def _clean(arguments) -> dict:
@@ -845,6 +845,9 @@ def code_tools(
     """
     roots = Roots(root, allow=allow_root, deny=deny_root)
     root = roots.base  # startup-root snapshot for the asset/browser output dirs
+    media_path_authority = _shared.MediaPathAuthority(
+        lambda: roots.base, lambda: roots.allow
+    )
 
     def free(fn):
         def invoke(arguments, *, confirm: bool = False):
@@ -967,7 +970,7 @@ def code_tools(
             # (== {venice_models, venice_model_details, venice_vision,
             # venice_job_status, venice_job_result}).
             only=_agent.select(categories={"catalog", "vision", "jobs"}),
-            config=config))
+            config=config, media_path_authority=media_path_authority))
 
     if assets and client is not None:
         asset_dir = os.environ.get("VENICE_MCP_OUTPUT_DIR") or root
@@ -978,6 +981,7 @@ def code_tools(
             # in _CODE_ASSET_BUILTINS -- select scans the union).
             only=_agent.select(categories={"image", "audio", "video"}),
             config=config,  # #58: asset tools honor defaults.<cmd>.*
+            media_path_authority=media_path_authority,
         ))
 
     if browser:

--- a/src/venice/commands/_mcp.py
+++ b/src/venice/commands/_mcp.py
@@ -113,6 +113,20 @@ def resolve_output_dir(output_dir: Optional[str]) -> Path:
     return Path(output_dir or os.environ.get("VENICE_MCP_OUTPUT_DIR") or os.getcwd())
 
 
+def media_path_authority(path_authority=None) -> _shared.MediaPathAuthority:
+    """Return the caller-bound authority or a fail-closed cwd authority."""
+    return path_authority or _shared.MediaPathAuthority(os.getcwd())
+
+
+def _model_media_path(path_authority, value, *, kind: str, max_bytes: int, label: str):
+    try:
+        return media_path_authority(path_authority).resolve(
+            value, kind=kind, max_bytes=max_bytes
+        )
+    except _shared.MediaPathError as e:
+        return _err(f"{label}: {e}")
+
+
 def _write(path: Path, data: bytes) -> Optional[str]:
     """Write bytes to path (creating parents). Returns an error string, else None."""
     try:
@@ -538,9 +552,16 @@ def upscale_tool(
     output_dir: Optional[str] = None,
     confirm: bool = False,
     max_spend: Optional[float] = None,
+    path_authority=None,
 ) -> dict:
     """Upscale/enhance an image via /image/upscale (dynamic price -> needs confirm)."""
-    inp = Path(input_path)
+    resolved = _model_media_path(
+        path_authority, input_path, kind="image",
+        max_bytes=_shared.MAX_IMAGE_BYTES, label="upscale",
+    )
+    if isinstance(resolved, dict):
+        return resolved
+    inp, _mime = resolved
     ns = SimpleNamespace(
         input=inp, scale=scale, enhance=enhance,
         enhance_creativity=enhance_creativity, enhance_prompt=enhance_prompt,
@@ -567,9 +588,20 @@ def bg_remove_tool(
     output_dir: Optional[str] = None,
     confirm: bool = False,
     max_spend: Optional[float] = None,
+    path_authority=None,
 ) -> dict:
     """Remove an image background via /image/background-remove (dynamic -> confirm)."""
-    inp = Path(input_path) if input_path else None
+    if bool(input_path) == bool(image_url):
+        return _err("bg-remove: exactly one of input_path or image_url is required")
+    inp = None
+    if input_path:
+        resolved = _model_media_path(
+            path_authority, input_path, kind="image",
+            max_bytes=_shared.MAX_IMAGE_BYTES, label="bg-remove",
+        )
+        if isinstance(resolved, dict):
+            return resolved
+        inp, _mime = resolved
     ns = SimpleNamespace(input=inp, image_url=image_url)
     rc = _bg._validate(ns)  # stderr warnings only
     if rc is not None:
@@ -662,6 +694,7 @@ def vision_tool(
     prompt: Optional[str] = None,
     model: Optional[str] = None,
     max_tokens: Optional[int] = None,
+    path_authority=None,
 ) -> dict:
     """Describe/inspect an image via a multimodal /chat/completions call.
 
@@ -676,18 +709,23 @@ def vision_tool(
     if bool(input_path) == bool(image_url):
         return _err("vision: exactly one of input_path or image_url is required")
 
+    if input_path:
+        resolved = _model_media_path(
+            path_authority, input_path, kind="image",
+            max_bytes=_shared.MAX_IMAGE_BYTES, label="vision",
+        )
+        if isinstance(resolved, dict):
+            return resolved
+        p, mime = resolved
+        url = _shared.encode_data_url(
+            p, default_mime="image/png", detected_mime=mime
+        )
+    else:
+        url = image_url
+
     openai = _openai.import_openai("vision")  # stderr hint if missing
     if openai is None:
         return _err('vision: needs the openai package: pip install "venice-cli[openai]"')
-
-    if input_path:
-        p = Path(input_path)
-        rc = _shared.check_image_file(p, label="vision")  # stderr detail
-        if rc is not None:
-            return _err(f"vision: invalid input file (exit {rc})")
-        url = _shared.encode_data_url(p, default_mime="image/png")
-    else:
-        url = image_url
 
     models = _models.catalog(client, "text")
     if model:
@@ -768,6 +806,7 @@ def video_tool(
     max_spend: Optional[float] = None,
     max_wait: float = _video.config.VIDEO_POLL_MAX_WAIT_SEC,
     background: bool = False,
+    path_authority=None,
 ) -> dict:
     """Generate a video via Venice's async /video queue; write a file, return path.
 
@@ -784,14 +823,6 @@ def video_tool(
     if not prompt or not prompt.strip():
         return _err("video: prompt is required")
 
-    models = _models.catalog(client, "video")
-    model, rc = _models.resolve_model(
-        model, models, label="video", noun="video model",
-        config_key="defaults.video.model",
-    )
-    if rc is not None:
-        return _err(f"video: could not resolve model (exit {rc})")
-
     ns = SimpleNamespace(
         image=image_url, end_image=end_image_url, video=video_url,
         audio_input=audio_url, reference_image=reference_image_urls,
@@ -800,9 +831,19 @@ def video_tool(
         reference_video_duration=reference_video_duration,
         resolution=resolution, aspect_ratio=aspect_ratio, no_audio=no_audio,
     )
-    quote_media, queue_media, rc = _video._collect_media(ns)  # stderr on bad media
+    quote_media, queue_media, rc = _video._collect_media(
+        ns, path_authority=media_path_authority(path_authority)
+    )  # stderr on bad media
     if rc is not None:
         return _err(f"video: invalid media input (exit {rc})")
+
+    models = _models.catalog(client, "video")
+    model, rc = _models.resolve_model(
+        model, models, label="video", noun="video model",
+        config_key="defaults.video.model",
+    )
+    if rc is not None:
+        return _err(f"video: could not resolve model (exit {rc})")
 
     extra = _video._shared_params(ns)
     quote_body = {"model": model, "duration": duration}
@@ -1023,6 +1064,7 @@ def image_edit_tool(
     output_dir: Optional[str] = None,
     confirm: bool = False,
     max_spend: Optional[float] = None,
+    path_authority=None,
 ) -> dict:
     """Edit/inpaint an image via /image/edit (dynamic price -> needs confirm).
 
@@ -1030,8 +1072,35 @@ def image_edit_tool(
     `layer_paths` (masks/overlays) route to /image/multi-edit. Writes the
     result and returns its path.
     """
-    inp = Path(input_path) if input_path else None
-    layers = [Path(p) for p in (layer_paths or [])]
+    if bool(input_path) == bool(image_url):
+        return _err("image-edit: exactly one of input_path or image_url is required")
+    if not prompt:
+        return _err("image-edit: prompt is required")
+    if len(prompt) > _image_edit.MAX_PROMPT:
+        return _err(f"image-edit: prompt exceeds {_image_edit.MAX_PROMPT} chars")
+    if len(layer_paths or []) > _image_edit.MAX_LAYERS:
+        return _err(
+            f"image-edit: at most {_image_edit.MAX_LAYERS} layer paths are allowed"
+        )
+    inp = None
+    if input_path:
+        resolved = _model_media_path(
+            path_authority, input_path, kind="image",
+            max_bytes=_shared.MAX_IMAGE_BYTES, label="image-edit",
+        )
+        if isinstance(resolved, dict):
+            return resolved
+        inp, _mime = resolved
+    layers = []
+    for layer_path in layer_paths or []:
+        resolved = _model_media_path(
+            path_authority, layer_path, kind="image",
+            max_bytes=_shared.MAX_IMAGE_BYTES, label="image-edit",
+        )
+        if isinstance(resolved, dict):
+            return resolved
+        layer, _mime = resolved
+        layers.append(layer)
     ns = SimpleNamespace(
         input=inp, image_url=image_url, prompt=prompt, layer=layers or None,
         model=model, aspect_ratio=aspect_ratio, resolution=resolution,

--- a/src/venice/commands/_shared.py
+++ b/src/venice/commands/_shared.py
@@ -9,12 +9,132 @@ from __future__ import annotations
 
 import base64
 import mimetypes
+import os
+import stat
 import sys
 from pathlib import Path
-from typing import List, Optional
+from typing import Callable, Iterable, List, Optional, Tuple, Union
 
 from .. import billing
 from ..client import VeniceAPIError
+from . import _index
+
+
+class MediaPathError(ValueError):
+    """A model-supplied local-media path failed the session's read authority."""
+
+
+_RootSource = Union[str, Path, Callable[[], Union[str, Path]]]
+_RootsSource = Union[Iterable[Union[str, Path]], Callable[[], Iterable[Union[str, Path]]]]
+_MEDIA_SNIFF_BYTES = 64
+
+
+def _root_value(source: _RootSource) -> str:
+    value = source() if callable(source) else source
+    return os.path.realpath(os.fspath(value))
+
+
+def _roots_value(source: _RootsSource) -> List[str]:
+    values = source() if callable(source) else source
+    return [os.path.realpath(os.fspath(value)) for value in values]
+
+
+def _sniff_media_mime(prefix: bytes, kind: str) -> Optional[str]:
+    """Return a conservative MIME type from a bounded media-file prefix."""
+    if kind == "image":
+        if prefix.startswith(b"\x89PNG\r\n\x1a\n"):
+            return "image/png"
+        if prefix.startswith(b"\xff\xd8\xff"):
+            return "image/jpeg"
+        if prefix.startswith((b"GIF87a", b"GIF89a")):
+            return "image/gif"
+        if len(prefix) >= 12 and prefix[:4] == b"RIFF" and prefix[8:12] == b"WEBP":
+            return "image/webp"
+        return None
+
+    if kind == "video":
+        if prefix.startswith(b"\x1aE\xdf\xa3"):
+            return "video/webm"
+        if len(prefix) >= 12 and prefix[4:8] == b"ftyp":
+            return "video/quicktime" if prefix[8:12] == b"qt  " else "video/mp4"
+        return None
+
+    if kind == "audio":
+        if prefix.startswith(b"fLaC"):
+            return "audio/flac"
+        if prefix.startswith(b"OggS"):
+            return "audio/ogg"
+        if len(prefix) >= 12 and prefix[:4] == b"RIFF" and prefix[8:12] == b"WAVE":
+            return "audio/wav"
+        if prefix.startswith(b"ID3"):
+            return "audio/mpeg"
+        if len(prefix) >= 2 and prefix[0] == 0xFF:
+            if prefix[1] & 0xF6 == 0xF0:
+                return "audio/aac"
+            if prefix[1] & 0xE0 == 0xE0 and prefix[1] & 0x06:
+                return "audio/mpeg"
+        if len(prefix) >= 12 and prefix[4:8] == b"ftyp":
+            return "audio/mp4"
+        return None
+
+    raise ValueError(f"unknown media kind: {kind}")
+
+
+class MediaPathAuthority:
+    """Resolve model-supplied media paths inside operator-authorized roots.
+
+    ``base`` controls relative-path resolution and ``roots`` controls readable
+    containment. Either may be a callable so ``venice code`` can bind this guard to
+    its mutable active/attached-root set without rebuilding every tool closure.
+    """
+
+    def __init__(self, base: _RootSource, roots: Optional[_RootsSource] = None):
+        self._base = base
+        self._roots = roots if roots is not None else lambda: [_root_value(self._base)]
+
+    def resolve(
+        self, value: Union[str, Path], *, kind: str, max_bytes: int
+    ) -> Tuple[Path, str]:
+        raw = os.fspath(value)
+        if not raw.strip():
+            raise MediaPathError("local media path is required")
+
+        base = _root_value(self._base)
+        roots = _roots_value(self._roots)
+        if base not in roots:
+            roots.append(base)
+        joined = raw if os.path.isabs(raw) else os.path.join(base, raw)
+        real = os.path.realpath(os.path.normpath(joined))
+        containers = [root for root in roots if _index.resolves_inside(Path(real), Path(root))]
+        if not containers:
+            raise MediaPathError("local media path escapes the authorized project roots")
+        container = max(containers, key=len)
+        rel = Path(os.path.relpath(real, container)).as_posix()
+        if _index.is_secret_path(rel) or _index.is_protected_dir_path(rel):
+            raise MediaPathError("local media path is in a protected location")
+
+        try:
+            info = os.stat(real)
+        except OSError:
+            raise MediaPathError("local media file does not exist") from None
+        if not stat.S_ISREG(info.st_mode):
+            raise MediaPathError("local media path must name a regular file")
+        if info.st_size == 0:
+            raise MediaPathError("local media file is empty")
+        if info.st_size > max_bytes:
+            raise MediaPathError(
+                f"local {kind} file is {info.st_size} bytes; limit is {max_bytes} bytes"
+            )
+
+        try:
+            with open(real, "rb") as handle:
+                prefix = handle.read(_MEDIA_SNIFF_BYTES)
+        except OSError:
+            raise MediaPathError("local media file could not be read") from None
+        mime = _sniff_media_mime(prefix, kind)
+        if mime is None:
+            raise MediaPathError(f"local file is not a recognized {kind} container")
+        return Path(real), mime
 
 
 def resolve_output(arg_output: Optional[Path], default_name: str) -> Path:
@@ -148,7 +268,10 @@ def resolve_poll(poll_interval, max_wait, *, label: str,
     return poll_interval, max_wait
 
 
-def encode_data_url(path: Path, *, default_mime: str = "application/octet-stream") -> str:
+def encode_data_url(
+    path: Path, *, default_mime: str = "application/octet-stream",
+    detected_mime: Optional[str] = None,
+) -> str:
     """Read a local file and return a `data:<mime>;base64,<b64>` URL.
 
     The MIME type is sniffed from the filename; callers pass `default_mime` as
@@ -156,7 +279,7 @@ def encode_data_url(path: Path, *, default_mime: str = "application/octet-stream
     base64 that `bg-remove`/`image-edit` send in an `image` field, the Venice
     `/video` media inputs want a full data URL, so this prepends the prefix.
     """
-    mime = mimetypes.guess_type(str(path))[0] or default_mime
+    mime = detected_mime or mimetypes.guess_type(str(path))[0] or default_mime
     b64 = base64.b64encode(path.read_bytes()).decode("ascii")
     return f"data:{mime};base64,{b64}"
 

--- a/src/venice/commands/video.py
+++ b/src/venice/commands/video.py
@@ -221,14 +221,24 @@ def _is_url(value: str) -> bool:
     return value.startswith(("http://", "https://", "data:"))
 
 
-def _resolve_media(value: str, *, kind: str):
+def _resolve_media(value: str, *, kind: str, path_authority=None):
     """Resolve one media input to a URL string. A value that is already an
     http(s)/data URL passes through; anything else is a local file that is
     size-checked and encoded to a `data:` URL. Returns (url_or_None, rc_or_None).
     """
     if _is_url(value):
         return value, None
-    path = Path(value)
+    detected_mime = None
+    if path_authority is not None:
+        try:
+            path, detected_mime = path_authority.resolve(
+                value, kind=kind, max_bytes=MEDIA_LIMITS[kind]
+            )
+        except _shared.MediaPathError as e:
+            print(f"video: {e}", file=sys.stderr)
+            return None, 2
+    else:
+        path = Path(value)
     if not path.is_file():
         print(f"video: input file not found: {value}", file=sys.stderr)
         return None, 2
@@ -244,10 +254,14 @@ def _resolve_media(value: str, *, kind: str):
             file=sys.stderr,
         )
         return None, 2
-    return _shared.encode_data_url(path, default_mime=DEFAULT_MIME[kind]), None
+    return _shared.encode_data_url(
+        path, default_mime=DEFAULT_MIME[kind], detected_mime=detected_mime
+    ), None
 
 
-def _resolve_media_list(values, *, kind: str, cap: int, flag: str):
+def _resolve_media_list(
+    values, *, kind: str, cap: int, flag: str, path_authority=None
+):
     """Resolve a repeatable media flag. Returns (list_or_None, rc_or_None);
     (None, None) when the flag was not given."""
     if values is None:
@@ -257,14 +271,14 @@ def _resolve_media_list(values, *, kind: str, cap: int, flag: str):
         return None, 2
     out = []
     for value in values:
-        url, rc = _resolve_media(value, kind=kind)
+        url, rc = _resolve_media(value, kind=kind, path_authority=path_authority)
         if rc is not None:
             return None, rc
         out.append(url)
     return out, None
 
 
-def _resolve_elements(raw_list):
+def _resolve_elements(raw_list, *, path_authority=None):
     """Parse `--element` JSON objects, resolving any media paths inside. Returns
     (list_or_None, rc_or_None). Unknown keys pass through verbatim so the JSON
     escape hatch stays forward-compatible with the schema."""
@@ -286,7 +300,9 @@ def _resolve_elements(raw_list):
         resolved = dict(el)  # keep any unknown keys as-is
         for key, kind in (("frontal_image_url", "image"), ("video_url", "video")):
             if el.get(key) is not None:
-                url, rc = _resolve_media(el[key], kind=kind)
+                url, rc = _resolve_media(
+                    el[key], kind=kind, path_authority=path_authority
+                )
                 if rc is not None:
                     return None, rc
                 resolved[key] = url
@@ -298,6 +314,7 @@ def _resolve_elements(raw_list):
             urls, rc = _resolve_media_list(
                 refs, kind="image", cap=ELEMENT_REF_IMAGE_MAX,
                 flag="element reference_image_urls",
+                path_authority=path_authority,
             )
             if rc is not None:
                 return None, rc
@@ -306,7 +323,7 @@ def _resolve_elements(raw_list):
     return out, None
 
 
-def _collect_media(args):
+def _collect_media(args, *, path_authority=None):
     """Resolve every media input up front (before any spend). Returns
     (quote_media, queue_media, rc). `quote_media` holds fields valid on
     /video/quote (video_url + reference_video_total_duration); `queue_media`
@@ -325,7 +342,9 @@ def _collect_media(args):
         value = getattr(args, attr, None)
         if value is None:
             continue
-        url, rc = _resolve_media(value, kind=kind)
+        url, rc = _resolve_media(
+            value, kind=kind, path_authority=path_authority
+        )
         if rc is not None:
             return None, None, rc
         queue_media[field] = url
@@ -339,13 +358,18 @@ def _collect_media(args):
         ("reference_audio", "audio", REF_AUDIO_MAX, "--reference-audio", "reference_audio_urls"),
         ("scene_image", "image", SCENE_MAX, "--scene-image", "scene_image_urls"),
     ):
-        urls, rc = _resolve_media_list(getattr(args, attr, None), kind=kind, cap=cap, flag=flag)
+        urls, rc = _resolve_media_list(
+            getattr(args, attr, None), kind=kind, cap=cap, flag=flag,
+            path_authority=path_authority,
+        )
         if rc is not None:
             return None, None, rc
         if urls is not None:
             queue_media[field] = urls
 
-    elements, rc = _resolve_elements(getattr(args, "element", None))
+    elements, rc = _resolve_elements(
+        getattr(args, "element", None), path_authority=path_authority
+    )
     if rc is not None:
         return None, None, rc
     if elements is not None:

--- a/src/venice/mcp_server.py
+++ b/src/venice/mcp_server.py
@@ -10,12 +10,13 @@ Do NOT add `from __future__ import annotations` here: FastMCP builds each tool's
 input schema via typing.get_type_hints, so the annotations must stay concrete
 (`typing.Optional[int]`, not stringized `int | None`).
 """
+import os
 from typing import List, Optional
 
 from mcp.server.fastmcp import FastMCP
 
 from . import userconfig
-from .commands import _mcp
+from .commands import _mcp, _shared
 
 
 def _merged(defaults: dict, host: dict) -> dict:
@@ -27,7 +28,7 @@ def _merged(defaults: dict, host: dict) -> dict:
     return {**defaults, **{k: v for k, v in host.items() if v is not None}}
 
 
-def build_server(client, doc=None) -> FastMCP:
+def build_server(client, doc=None, root=None) -> FastMCP:
     """Build a FastMCP server exposing venice tools, all bound to `client`.
 
     `doc` is a userconfig document (issue #58): `defaults.<section>.*` values are
@@ -36,6 +37,9 @@ def build_server(client, doc=None) -> FastMCP:
     contract `venice chat`/`code` already honor. `doc=None` loads the config file.
     """
     server = FastMCP("venice")
+    path_authority = _shared.MediaPathAuthority(
+        os.path.realpath(root or os.getcwd())
+    )
     if doc is None:
         doc = userconfig.load_config()
     _defaults = {
@@ -181,7 +185,7 @@ def build_server(client, doc=None) -> FastMCP:
                 scale=scale, enhance=enhance,
                 enhance_creativity=enhance_creativity, enhance_prompt=enhance_prompt,
                 replication=replication, output_dir=output_dir, confirm=confirm,
-                max_spend=max_spend,
+                max_spend=max_spend, path_authority=path_authority,
             )),
         )
 
@@ -202,6 +206,7 @@ def build_server(client, doc=None) -> FastMCP:
             **_merged(_defaults["bg_remove"], dict(
                 image_url=image_url, output_dir=output_dir,
                 confirm=confirm, max_spend=max_spend,
+                path_authority=path_authority,
             )),
         )
 
@@ -273,7 +278,7 @@ def build_server(client, doc=None) -> FastMCP:
                 scene_image_urls=scene_image_urls,
                 reference_video_duration=reference_video_duration,
                 output_dir=output_dir, confirm=confirm, max_spend=max_spend,
-                max_wait=max_wait,
+                max_wait=max_wait, path_authority=path_authority,
             )),
         )
 
@@ -303,7 +308,7 @@ def build_server(client, doc=None) -> FastMCP:
                 layer_paths=layer_paths, model=model, aspect_ratio=aspect_ratio,
                 resolution=resolution, output_format=output_format,
                 safe_mode=safe_mode, output_dir=output_dir, confirm=confirm,
-                max_spend=max_spend,
+                max_spend=max_spend, path_authority=path_authority,
             )),
         )
 

--- a/tests/test_agent.py
+++ b/tests/test_agent.py
@@ -2649,6 +2649,30 @@ class TestAsyncJobSchemas(unittest.TestCase):
         self.assertFalse(by["venice_job_result"].paid)
 
 
+class TestMediaPathAuthorityWiring(unittest.TestCase):
+
+    def test_free_and_paid_media_tools_receive_only_host_authority(self):
+        authority = object()
+        with mock.patch.object(
+            _agent._mcp, "vision_tool", return_value={"status": "ok"}
+        ) as vision, mock.patch.object(
+            _agent._mcp, "upscale_tool", return_value={"status": "ok"}
+        ) as upscale:
+            tools = {tool.name: tool for tool in _agent.builtin_tools(
+                object(), only={"venice_vision", "venice_upscale"},
+                media_path_authority=authority,
+            )}
+            tools["venice_vision"].invoke({
+                "input_path": "frame.png", "path_authority": "model-controlled"
+            })
+            tools["venice_upscale"].invoke(
+                {"input_path": "frame.png", "path_authority": "model-controlled"},
+                confirm=True,
+            )
+        self.assertIs(vision.call_args.kwargs["path_authority"], authority)
+        self.assertIs(upscale.call_args.kwargs["path_authority"], authority)
+
+
 class TestReindexBuiltin(unittest.TestCase):
     """#44: reindex is a paid, no-arg builtin advertised by chat's default set."""
 

--- a/tests/test_code_command.py
+++ b/tests/test_code_command.py
@@ -12,6 +12,7 @@ import os
 import sys
 import tempfile
 import unittest
+from pathlib import Path
 from unittest import mock
 
 from tests.test_chat import (
@@ -436,6 +437,15 @@ class TestCodeCommand(unittest.TestCase):
         # --auto -> confirm=True bypasses the spend gate
         self.assertTrue(stub.call_args.kwargs.get("confirm"))
         self.assertEqual(stub.call_args.kwargs.get("prompt"), "a koi pond at dawn")
+        authority = stub.call_args.kwargs.get("path_authority")
+        self.assertIsNotNone(authority)
+        frame = Path(self.root) / "frame.png"
+        frame.write_bytes(b"\x89PNG\r\n\x1a\nbody")
+        resolved, mime = authority.resolve(
+            frame, kind="image", max_bytes=1024
+        )
+        self.assertEqual(resolved, frame.resolve())
+        self.assertEqual(mime, "image/png")
 
     def test_acceptance_fail_returns_1(self):
         seq = [

--- a/tests/test_mcp_serve.py
+++ b/tests/test_mcp_serve.py
@@ -9,7 +9,9 @@ import importlib.util
 import inspect
 import io
 import sys
+import tempfile
 import unittest
+from pathlib import Path
 from unittest import mock
 
 _HAS_MCP = importlib.util.find_spec("mcp") is not None
@@ -45,6 +47,39 @@ class TestServerWiring(unittest.TestCase):
         server = build_server(FakeClient())
         names = {t.name for t in server._tool_manager.list_tools()}
         self.assertEqual(names, EXPECTED_TOOLS)
+
+    def test_server_captures_startup_root_for_media_authority(self):
+        from venice.mcp_server import build_server
+        from venice.commands import _mcp, _shared
+
+        class FakeClient:
+            api_key = "fake"
+            base_url = "https://api.venice.ai/api/v1"
+
+        captured = {}
+
+        def upscale_tool(client, input_path, *, path_authority=None, **kwargs):
+            captured["authority"] = path_authority
+            return {"status": "ok"}
+
+        with tempfile.TemporaryDirectory() as root, \
+             tempfile.TemporaryDirectory() as outside, \
+             mock.patch.object(_mcp, "upscale_tool", upscale_tool):
+            server = build_server(FakeClient(), doc={}, root=root)
+            server._tool_manager.get_tool("venice_upscale").fn(input_path="frame.png")
+            frame = Path(root) / "frame.png"
+            frame.write_bytes(b"\x89PNG\r\n\x1a\nbody")
+            resolved, mime = captured["authority"].resolve(
+                frame, kind="image", max_bytes=1024
+            )
+            self.assertEqual(resolved, frame.resolve())
+            self.assertEqual(mime, "image/png")
+            denied = Path(outside) / "frame.png"
+            denied.write_bytes(b"\x89PNG\r\n\x1a\nbody")
+            with self.assertRaises(_shared.MediaPathError):
+                captured["authority"].resolve(
+                    denied, kind="image", max_bytes=1024
+                )
 
 
 @unittest.skipUnless(_HAS_MCP, "mcp SDK not installed (expected on Python 3.9)")

--- a/tests/test_mcp_tools.py
+++ b/tests/test_mcp_tools.py
@@ -19,7 +19,7 @@ from urllib.error import HTTPError
 
 from tests.test_client import FakeResp
 from venice.client import VeniceClient
-from venice.commands import _mcp
+from venice.commands import _mcp, _shared
 
 
 def _client():
@@ -69,6 +69,9 @@ class _ToolTest(unittest.TestCase):
                 return False
 
         return _G()
+
+    def media_authority(self, root=None):
+        return _shared.MediaPathAuthority(root or self.td)
 
 
 class TestImageTool(_ToolTest):
@@ -302,7 +305,7 @@ class TestMusicTool(_ToolTest):
 class TestBinaryTools(_ToolTest):
     def _png(self):
         ip = Path(self.td) / "in.png"
-        ip.write_bytes(b"\x89PNG\r\n" + b"x" * 32)
+        ip.write_bytes(b"\x89PNG\r\n\x1a\n" + b"x" * 32)
         return ip
 
     def test_upscale_needs_confirm(self):
@@ -312,7 +315,10 @@ class TestBinaryTools(_ToolTest):
             raise AssertionError("must not hit the network without confirm")
 
         with mock.patch("venice.client.urllib.request.urlopen", boom):
-            res = _mcp.upscale_tool(_client(), str(ip), output_dir=self.td, confirm=False)
+            res = _mcp.upscale_tool(
+                _client(), str(ip), output_dir=self.td, confirm=False,
+                path_authority=self.media_authority(),
+            )
         self.assertEqual(res["status"], "confirmation_required")
         self.assertIsNone(res["estimated_cost_usd"])
 
@@ -322,7 +328,10 @@ class TestBinaryTools(_ToolTest):
             "venice.client.urllib.request.urlopen",
             _seq(FakeResp(200, b"UPSCALED", "image/png")),
         ), self.stdout_guard():
-            res = _mcp.upscale_tool(_client(), str(ip), output_dir=self.td, confirm=True)
+            res = _mcp.upscale_tool(
+                _client(), str(ip), output_dir=self.td, confirm=True,
+                path_authority=self.media_authority(),
+            )
         self.assertEqual(res["status"], "ok")
         self.assertEqual(Path(res["path"]).read_bytes(), b"UPSCALED")
         self.assertTrue(res["path"].endswith("-upscaled.png"))
@@ -337,6 +346,41 @@ class TestBinaryTools(_ToolTest):
             )
         self.assertEqual(res["status"], "ok")
         self.assertEqual(Path(res["path"]).read_bytes(), b"NOBG")
+
+    def test_bg_remove_from_authorized_local_image(self):
+        ip = self._png()
+        captured = {}
+
+        def fake(req, timeout=None):
+            captured["body"] = json.loads(req.data.decode())
+            return FakeResp(200, b"NOBG", "image/png")
+
+        with mock.patch("venice.client.urllib.request.urlopen", fake):
+            res = _mcp.bg_remove_tool(
+                _client(), str(ip), output_dir=self.td, confirm=True,
+                path_authority=self.media_authority(),
+            )
+        self.assertEqual(res["status"], "ok")
+        self.assertEqual(base64.b64decode(captured["body"]["image"]), ip.read_bytes())
+
+    def test_path_authority_cannot_be_overridden_by_confirmation(self):
+        outside_dir = tempfile.mkdtemp()
+        self.addCleanup(shutil.rmtree, outside_dir, ignore_errors=True)
+        outside = Path(outside_dir) / "outside.png"
+        outside.write_bytes(b"\x89PNG\r\n\x1a\nbody")
+
+        def boom(*a, **kw):
+            raise AssertionError("denied media must not reach the network")
+
+        for confirm in (False, True):
+            with self.subTest(confirm=confirm), \
+                 mock.patch("venice.client.urllib.request.urlopen", boom):
+                res = _mcp.upscale_tool(
+                    _client(), str(outside), output_dir=self.td, confirm=confirm,
+                    path_authority=self.media_authority(),
+                )
+            self.assertEqual(res["status"], "error")
+            self.assertIn("escapes", res["message"])
 
     def test_bg_remove_requires_one_source(self):
         res = _mcp.bg_remove_tool(_client(), confirm=True)  # neither file nor url
@@ -393,7 +437,7 @@ def _vision_catalog(default_vision=False):
 class TestVisionTool(_ToolTest):
     def _png(self):
         ip = Path(self.td) / "shot.png"
-        ip.write_bytes(b"\x89PNG\r\n" + b"x" * 16)
+        ip.write_bytes(b"\x89PNG\r\n\x1a\n" + b"x" * 16)
         return ip
 
     def _oai(self, content="a red square"):
@@ -412,7 +456,10 @@ class TestVisionTool(_ToolTest):
         err = io.StringIO()
         with mock.patch.dict(sys.modules, {"openai": None}), \
              mock.patch.object(sys, "stderr", err):
-            res = _mcp.vision_tool(_client(), str(self._png()))
+            res = _mcp.vision_tool(
+                _client(), str(self._png()),
+                path_authority=self.media_authority(),
+            )
         self.assertEqual(res["status"], "error")
         self.assertIn("openai", res["message"])
 
@@ -424,7 +471,9 @@ class TestVisionTool(_ToolTest):
              self.stdout_guard():
             neither = _mcp.vision_tool(_client())
             both = _mcp.vision_tool(
-                _client(), str(self._png()), image_url="https://x/y.png")
+                _client(), str(self._png()), image_url="https://x/y.png",
+                path_authority=self.media_authority(),
+            )
         self.assertEqual(neither["status"], "error")
         self.assertEqual(both["status"], "error")
 
@@ -433,9 +482,31 @@ class TestVisionTool(_ToolTest):
         oai = self._oai()
         with mock.patch("openai.OpenAI", return_value=oai), \
              mock.patch.object(sys, "stderr", err), self.stdout_guard():
-            res = _mcp.vision_tool(_client(), str(Path(self.td) / "nope.png"))
+            res = _mcp.vision_tool(
+                _client(), str(Path(self.td) / "nope.png"),
+                path_authority=self.media_authority(),
+            )
         self.assertEqual(res["status"], "error")
         oai.chat.completions.create.assert_not_called()
+
+    def test_rejects_secret_named_and_non_image_inputs_before_api(self):
+        secret = Path(self.td) / "credentials"
+        secret.write_bytes(b"\x89PNG\r\n\x1a\nbody")
+        fake = Path(self.td) / "fake.png"
+        fake.write_text("not an image", encoding="utf-8")
+
+        def boom(*a, **kw):
+            raise AssertionError("denied media must not reach the API")
+
+        for candidate, message in ((secret, "protected"), (fake, "recognized image")):
+            with self.subTest(candidate=candidate), \
+                 mock.patch("venice.client.urllib.request.urlopen", boom):
+                res = _mcp.vision_tool(
+                    _client(), str(candidate),
+                    path_authority=self.media_authority(),
+                )
+            self.assertEqual(res["status"], "error")
+            self.assertIn(message, res["message"])
 
     def test_ok_local_image_sends_data_url(self):
         oai = self._oai()
@@ -443,7 +514,10 @@ class TestVisionTool(_ToolTest):
             "venice.client.urllib.request.urlopen",
             _seq(FakeResp(200, _vision_catalog())),
         ), mock.patch("openai.OpenAI", return_value=oai), self.stdout_guard():
-            res = _mcp.vision_tool(_client(), str(self._png()), model="qwen-vl")
+            res = _mcp.vision_tool(
+                _client(), str(self._png()), model="qwen-vl",
+                path_authority=self.media_authority(),
+            )
         self.assertEqual(res["status"], "ok")
         self.assertEqual(res["content"], "a red square")
         self.assertEqual(res["model"], "qwen-vl")
@@ -478,7 +552,9 @@ class TestVisionTool(_ToolTest):
             _seq(FakeResp(200, _vision_catalog())),
         ), mock.patch("openai.OpenAI", return_value=oai), self.stdout_guard():
             res = _mcp.vision_tool(
-                _client(), str(self._png()), model="venice-uncensored")
+                _client(), str(self._png()), model="venice-uncensored",
+                path_authority=self.media_authority(),
+            )
         self.assertEqual(res["status"], "error")
         self.assertIn("supportsVision", res["message"])
         oai.chat.completions.create.assert_not_called()
@@ -492,7 +568,10 @@ class TestVisionTool(_ToolTest):
         with mock.patch(
             "venice.client.urllib.request.urlopen", _seq(FakeResp(200, catalog))
         ), mock.patch("openai.OpenAI", return_value=oai), self.stdout_guard():
-            res = _mcp.vision_tool(_client(), str(self._png()), model="mystery")
+            res = _mcp.vision_tool(
+                _client(), str(self._png()), model="mystery",
+                path_authority=self.media_authority(),
+            )
         self.assertEqual(res["status"], "ok")
 
     def test_default_skips_non_vision_default_trait(self):
@@ -501,7 +580,10 @@ class TestVisionTool(_ToolTest):
             "venice.client.urllib.request.urlopen",
             _seq(FakeResp(200, _vision_catalog(default_vision=False))),
         ), mock.patch("openai.OpenAI", return_value=oai), self.stdout_guard():
-            res = _mcp.vision_tool(_client(), str(self._png()))
+            res = _mcp.vision_tool(
+                _client(), str(self._png()),
+                path_authority=self.media_authority(),
+            )
         self.assertEqual(res["status"], "ok")
         self.assertEqual(res["model"], "qwen-vl")
 
@@ -511,7 +593,10 @@ class TestVisionTool(_ToolTest):
             "venice.client.urllib.request.urlopen",
             _seq(FakeResp(200, _vision_catalog(default_vision=True))),
         ), mock.patch("openai.OpenAI", return_value=oai), self.stdout_guard():
-            res = _mcp.vision_tool(_client(), str(self._png()))
+            res = _mcp.vision_tool(
+                _client(), str(self._png()),
+                path_authority=self.media_authority(),
+            )
         self.assertEqual(res["status"], "ok")
         self.assertEqual(res["model"], "venice-uncensored")
 
@@ -526,13 +611,54 @@ class TestVisionTool(_ToolTest):
         with mock.patch(
             "venice.client.urllib.request.urlopen", _seq(FakeResp(200, catalog))
         ), mock.patch("openai.OpenAI", return_value=oai), self.stdout_guard():
-            res = _mcp.vision_tool(_client(), str(self._png()))
+            res = _mcp.vision_tool(
+                _client(), str(self._png()),
+                path_authority=self.media_authority(),
+            )
         self.assertEqual(res["status"], "error")
         self.assertIn("vision-capable", res["message"])
         oai.chat.completions.create.assert_not_called()
 
 
 class TestVideoTool(_ToolTest):
+    def test_authorized_local_media_uses_signature_mime_before_catalog(self):
+        frame = Path(self.td) / "frame.txt"
+        frame.write_bytes(b"\x00\x00\x00\x18ftypisombody")
+        seen_body = {}
+
+        def fake(req, timeout=None):
+            if req.full_url.endswith("/video/quote"):
+                seen_body["quote"] = json.loads(req.data.decode())
+                return FakeResp(200, b'{"quote": 5.0}')
+            if "type=video" in req.full_url:
+                return FakeResp(200, _video_catalog())
+            raise AssertionError(f"unexpected call: {req.full_url}")
+
+        with mock.patch("venice.client.urllib.request.urlopen", fake):
+            res = _mcp.video_tool(
+                _client(), "animate", video_url=str(frame), confirm=False,
+                max_spend=0.10, path_authority=self.media_authority(),
+            )
+        self.assertEqual(res["status"], "confirmation_required")
+        encoded = seen_body["quote"]["video_url"]
+        self.assertTrue(encoded.startswith("data:video/mp4;base64,"))
+
+    def test_denied_local_media_stops_before_catalog_or_quote(self):
+        outside_dir = tempfile.mkdtemp()
+        self.addCleanup(shutil.rmtree, outside_dir, ignore_errors=True)
+        outside = Path(outside_dir) / "frame.png"
+        outside.write_bytes(b"\x89PNG\r\n\x1a\nbody")
+
+        def boom(*a, **kw):
+            raise AssertionError("denied media must stop before every API call")
+
+        with mock.patch("venice.client.urllib.request.urlopen", boom), \
+             self.stdout_guard():
+            res = _mcp.video_tool(
+                _client(), "animate", image_url=str(outside), confirm=True,
+                path_authority=self.media_authority(),
+            )
+        self.assertEqual(res["status"], "error")
     def test_ok_queue_poll_save(self):
         responses = _seq(
             FakeResp(200, _video_catalog()),               # /models?type=video
@@ -776,7 +902,7 @@ class TestJobResultTool(_ToolTest):
 class TestImageEditTool(_ToolTest):
     def _png(self):
         ip = Path(self.td) / "base.png"
-        ip.write_bytes(b"\x89PNG\r\n" + b"x" * 16)
+        ip.write_bytes(b"\x89PNG\r\n\x1a\n" + b"x" * 16)
         return ip
 
     def test_needs_confirm(self):
@@ -789,6 +915,7 @@ class TestImageEditTool(_ToolTest):
             res = _mcp.image_edit_tool(
                 _client(), "make it blue", input_path=str(ip),
                 output_dir=self.td, confirm=False,
+                path_authority=self.media_authority(),
             )
         self.assertEqual(res["status"], "confirmation_required")
         self.assertIsNone(res["estimated_cost_usd"])
@@ -806,6 +933,7 @@ class TestImageEditTool(_ToolTest):
             res = _mcp.image_edit_tool(
                 _client(), "make it blue", input_path=str(ip),
                 output_dir=self.td, confirm=True,
+                path_authority=self.media_authority(),
             )
         self.assertEqual(res["status"], "ok")
         self.assertEqual(Path(res["path"]).read_bytes(), b"EDITED")
@@ -825,18 +953,20 @@ class TestImageEditTool(_ToolTest):
 
         with mock.patch("venice.client.urllib.request.urlopen", fake), self.stdout_guard():
             _mcp.image_edit_tool(_client(), "make it blue", input_path=str(ip),
-                                 output_dir=self.td, confirm=True, safe_mode=False)
+                                 output_dir=self.td, confirm=True, safe_mode=False,
+                                 path_authority=self.media_authority())
         self.assertIs(captured["body"]["safe_mode"], False)
 
         with mock.patch("venice.client.urllib.request.urlopen", fake), self.stdout_guard():
             _mcp.image_edit_tool(_client(), "make it blue", input_path=str(ip),
-                                 output_dir=self.td, confirm=True)
+                                 output_dir=self.td, confirm=True,
+                                 path_authority=self.media_authority())
         self.assertIs(captured["body"]["safe_mode"], True)
 
     def test_multi_edit_with_layers(self):
         ip = self._png()
         layer = Path(self.td) / "mask.png"
-        layer.write_bytes(b"\x89PNG\r\nMASK")
+        layer.write_bytes(b"\x89PNG\r\n\x1a\nMASK")
         captured = {}
 
         def fake(req, timeout=None):
@@ -848,10 +978,30 @@ class TestImageEditTool(_ToolTest):
             res = _mcp.image_edit_tool(
                 _client(), "composite the mask", input_path=str(ip),
                 layer_paths=[str(layer)], output_dir=self.td, confirm=True,
+                path_authority=self.media_authority(),
             )
         self.assertEqual(res["status"], "ok")
         self.assertTrue(captured["url"].endswith("/image/multi-edit"))
         self.assertEqual(len(captured["body"]["images"]), 2)  # base + 1 layer
+
+    def test_denied_layer_stops_before_confirmation_and_api(self):
+        ip = self._png()
+        outside_dir = tempfile.mkdtemp()
+        self.addCleanup(shutil.rmtree, outside_dir, ignore_errors=True)
+        layer = Path(outside_dir) / "mask.png"
+        layer.write_bytes(b"\x89PNG\r\n\x1a\nMASK")
+
+        def boom(*a, **kw):
+            raise AssertionError("denied layer must not reach the API")
+
+        with mock.patch("venice.client.urllib.request.urlopen", boom):
+            res = _mcp.image_edit_tool(
+                _client(), "composite", input_path=str(ip),
+                layer_paths=[str(layer)], output_dir=self.td, confirm=True,
+                path_authority=self.media_authority(),
+            )
+        self.assertEqual(res["status"], "error")
+        self.assertIn("escapes", res["message"])
 
     def test_missing_source_is_error(self):
         res = _mcp.image_edit_tool(_client(), "edit", confirm=True)  # no input/url

--- a/tests/test_shared.py
+++ b/tests/test_shared.py
@@ -8,6 +8,8 @@ raw-base64 round-trip and the exists / non-empty / size gate with its
 """
 import base64
 import io
+import os
+import shutil
 import sys
 import tempfile
 import unittest
@@ -84,6 +86,104 @@ class TestCheckImageFile(unittest.TestCase):
             rc, err = self._check(p, label="upscale")
             self.assertEqual(rc, 2)
             self.assertIn("must be < 25 MB", err)
+
+
+class TestMediaPathAuthority(unittest.TestCase):
+
+    def setUp(self):
+        self.root = tempfile.mkdtemp()
+        self.outside = tempfile.mkdtemp()
+        self.addCleanup(shutil.rmtree, self.outside, ignore_errors=True)
+        self.addCleanup(shutil.rmtree, self.root, ignore_errors=True)
+        self.authority = _shared.MediaPathAuthority(self.root)
+
+    def _write(self, directory, name, data):
+        path = Path(directory) / name
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_bytes(data)
+        return path
+
+    def test_recognizes_supported_signatures_and_ignores_false_extension(self):
+        cases = (
+            ("image", b"\x89PNG\r\n\x1a\nbody", "image/png"),
+            ("image", b"\xff\xd8\xff\xe0body", "image/jpeg"),
+            ("image", b"GIF89abody", "image/gif"),
+            ("image", b"RIFFxxxxWEBPbody", "image/webp"),
+            ("video", b"\x00\x00\x00\x18ftypisombody", "video/mp4"),
+            ("video", b"\x1aE\xdf\xa3body", "video/webm"),
+            ("audio", b"ID3body", "audio/mpeg"),
+            ("audio", b"\xff\xfbbody", "audio/mpeg"),
+            ("audio", b"\xff\xf1body", "audio/aac"),
+            ("audio", b"RIFFxxxxWAVEbody", "audio/wav"),
+            ("audio", b"fLaCbody", "audio/flac"),
+            ("audio", b"OggSbody", "audio/ogg"),
+        )
+        for index, (kind, data, expected) in enumerate(cases):
+            with self.subTest(kind=kind, expected=expected):
+                path = self._write(self.root, f"media-{index}.txt", data)
+                resolved, mime = self.authority.resolve(
+                    path, kind=kind, max_bytes=1024
+                )
+                self.assertEqual(resolved, path.resolve())
+                self.assertEqual(mime, expected)
+
+    def test_rejects_outside_root_and_symlink_escape(self):
+        target = self._write(
+            self.outside, "outside.png", b"\x89PNG\r\n\x1a\nbody"
+        )
+        link = Path(self.root) / "inside.png"
+        os.symlink(target, link)
+        for candidate in (target, link):
+            with self.subTest(candidate=candidate):
+                with self.assertRaisesRegex(_shared.MediaPathError, "escapes"):
+                    self.authority.resolve(
+                        candidate, kind="image", max_bytes=1024
+                    )
+
+    def test_rejects_secret_and_protected_paths(self):
+        for name in ("credentials", ".env", ".git/object.png", ".venice/key.png"):
+            path = self._write(
+                self.root, name, b"\x89PNG\r\n\x1a\nbody"
+            )
+            with self.subTest(name=name):
+                with self.assertRaisesRegex(_shared.MediaPathError, "protected"):
+                    self.authority.resolve(path, kind="image", max_bytes=1024)
+
+    def test_rejects_missing_directory_empty_oversized_and_non_media(self):
+        directory = Path(self.root) / "folder"
+        directory.mkdir()
+        empty = self._write(self.root, "empty.png", b"")
+        large = self._write(self.root, "large.png", b"\x89PNG\r\n\x1a\nxxx")
+        text = self._write(self.root, "fake.png", b"plain text")
+        cases = (
+            (Path(self.root) / "missing.png", "does not exist", 1024),
+            (directory, "regular file", 1024),
+            (empty, "empty", 1024),
+            (large, "limit", 8),
+            (text, "recognized image", 1024),
+        )
+        for candidate, message, limit in cases:
+            with self.subTest(candidate=candidate):
+                with self.assertRaisesRegex(_shared.MediaPathError, message):
+                    self.authority.resolve(
+                        candidate, kind="image", max_bytes=limit
+                    )
+
+    def test_dynamic_active_and_attached_roots(self):
+        other = tempfile.mkdtemp()
+        self.addCleanup(shutil.rmtree, other, ignore_errors=True)
+        media = self._write(other, "frame", b"\x89PNG\r\n\x1a\nbody")
+        state = {"base": self.root, "roots": [self.root]}
+        authority = _shared.MediaPathAuthority(
+            lambda: state["base"], lambda: state["roots"]
+        )
+        with self.assertRaises(_shared.MediaPathError):
+            authority.resolve(media, kind="image", max_bytes=1024)
+        state["roots"].append(other)
+        state["base"] = other
+        resolved, mime = authority.resolve("frame", kind="image", max_bytes=1024)
+        self.assertEqual(resolved, media.resolve())
+        self.assertEqual(mime, "image/png")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

- add one shared, root-confined resolver for model-supplied local media paths with realpath, secret/protected-name, regular-file, size, and media-signature checks
- bind that authority across chat tools, code active/attached roots, MCP server startup roots, and every local image/audio/video input including nested video elements
- keep direct operator CLI path behavior unchanged and document the model-facing boundary

## Validation

- `VENICE_API_KEY=test-fake-key make test` — 1,645 passed
- focused affected tests — 541 passed
- `VENICE_API_KEY=test-fake-key make drive` — 37 passed
- `make lint`
- `make scan`
- `git diff --check`

No live Venice API calls or real credentials were used.

Closes #141