### PR TITLE
v0.83: secure video download fallback

### DIFF
--- a/README.md
+++ b/README.md
@@ -512,8 +512,18 @@ price. Per-model support varies — the API rejects an unsupported combination.
 
 Some (VPS-backed) models return a presigned `download_url` at queue time and
 stream nothing back from `/video/retrieve`; the CLI fetches the mp4 from that
-URL transparently. When queued with `--background`, the URL is printed alongside
-the queue id — pass it back via `venice video-status <id> --download-url <url>`.
+URL transparently. Background jobs bind that URL to the queue id in a private
+mode-0600 local registry at `~/.config/venice/video_jobs.json`, so the signed URL
+is not printed or passed through an agent/MCP transcript. Entries are capped at
+100 and expire after seven days. `video-status --download-url` remains only as a
+deprecated operator fallback for jobs queued before v0.83.10.
+
+Presigned downloads use a fail-closed HTTPS boundary: every redirect is resolved
+and connected through a validated, pinned public address while retaining normal
+TLS hostname verification. Local, private, link-local, multicast, reserved,
+unspecified, and metadata destinations are rejected for IPv4 and IPv6; ambient
+proxies are ignored. Downloads accept video media types only, allow at most five
+redirects, stream to a private temporary file, and stop at 512 MiB or 15 minutes.
 
 ## Chat
 
@@ -2023,7 +2033,7 @@ The player list (`paplay` -> `aplay` -> `ffplay` -> `mpg123` -> `play`
 | `venice image --from-file PATH [...]` | batch-generate a card set |
 | `venice music PROMPT [--duration N] [--master] [--loop] [...]` | generate long-form ambience/music |
 | `venice video PROMPT [--duration 5s] [--resolution R] [--aspect-ratio A] [--image F] [--reference-image F ...] [--element JSON] [...]` | generate a video (async queue, mp4); text- or image-to-video with reference inputs |
-| `venice video-status QUEUE_ID [--download-url URL]` | fetch a backgrounded video job |
+| `venice video-status QUEUE_ID [--download-url URL]` | fetch a backgrounded video job (`--download-url` is legacy-only) |
 | `venice master INPUT [--loop] [--lufs N] [--bit-depth N] [...]` | master audio to WAV (48k/24-bit, LUFS/true-peak) |
 | `venice contact-sheet DIR_OR_GLOB [--cols N] [--cell WxH] [--label\|--no-label] [...]` | tile images into one contact sheet (no API call) |
 | `venice chat MESSAGE [--system S] [--model M] [--web-search on] [...]` | one-shot chat completion (OpenAI SDK) |

--- a/src/venice/_egress.py
+++ b/src/venice/_egress.py
@@ -1,0 +1,197 @@
+"""Pinned public-Internet HTTPS transport for untrusted download URLs.
+
+The policy lives at connection establishment, not at the URL-string seam: every
+connection resolves its destination exactly once, rejects the whole answer set if
+any address is not globally routable, and connects only to one of those validated
+numeric addresses.  TLS still uses the original hostname for SNI and certificate
+verification, and urllib supplies the original HTTP Host header.
+
+This is intentionally stdlib-only.  Ambient proxy settings are disabled by the
+opener factory because a proxy would move DNS and connection authority outside this
+boundary.  Redirects are revalidated and bounded by :class:`GuardedRedirectHandler`.
+"""
+from __future__ import annotations
+
+import http.client
+import ipaddress
+import socket
+import ssl
+import urllib.error
+import urllib.parse
+import urllib.request
+from typing import List, Optional, Tuple
+
+MAX_REDIRECTS = 5
+
+
+class EgressPolicyError(OSError):
+    """A URL or resolved destination is outside the public HTTPS policy."""
+
+
+def safe_url(url: str) -> str:
+    """Render a URL without userinfo, query credentials, or a fragment."""
+    try:
+        parts = urllib.parse.urlsplit(str(url or ""))
+        host = parts.hostname or ""
+        port = parts.port
+    except (TypeError, ValueError):
+        return "<invalid-url>"
+    if not host:
+        return "<invalid-url>"
+    display_host = f"[{host}]" if ":" in host else host
+    netloc = display_host + (f":{port}" if port is not None else "")
+    return urllib.parse.urlunsplit(
+        ((parts.scheme or "").lower(), netloc, parts.path or "/", "", "")
+    )
+
+
+def validate_https_url(url: str) -> Tuple[str, int]:
+    """Return ``(hostname, port)`` for a structurally valid HTTPS URL."""
+    value = str(url or "")
+    if value != value.strip():
+        raise EgressPolicyError("download URL contains leading or trailing whitespace")
+    try:
+        parts = urllib.parse.urlsplit(value)
+        port = parts.port
+        host = parts.hostname
+    except ValueError:
+        raise EgressPolicyError(f"invalid download URL: {safe_url(value)}") from None
+    if (parts.scheme or "").lower() != "https":
+        raise EgressPolicyError(
+            f"blocked download URL scheme (HTTPS required): {safe_url(value)}"
+        )
+    if not host:
+        raise EgressPolicyError(f"download URL has no host: {safe_url(value)}")
+    if parts.username is not None or parts.password is not None:
+        raise EgressPolicyError(
+            f"download URL userinfo is not allowed: {safe_url(value)}"
+        )
+    if any(ord(ch) < 32 or ord(ch) == 127 for ch in value):
+        raise EgressPolicyError("download URL contains control characters")
+    return host, port or 443
+
+
+def _public_ip(value: str):
+    try:
+        address = ipaddress.ip_address(value.split("%", 1)[0])
+    except ValueError:
+        raise EgressPolicyError("resolver returned an invalid IP address") from None
+    mapped = getattr(address, "ipv4_mapped", None)
+    if mapped is not None:
+        address = mapped
+    if (
+        not address.is_global
+        or address.is_private
+        or address.is_loopback
+        or address.is_link_local
+        or address.is_multicast
+        or address.is_reserved
+        or address.is_unspecified
+    ):
+        raise EgressPolicyError(
+            f"blocked non-public download destination: {address.compressed}"
+        )
+    return address
+
+
+def resolve_public(host: str, port: int) -> List[Tuple[int, int, int, tuple]]:
+    """Resolve once and reject the complete answer set if any IP is non-public."""
+    try:
+        answers = socket.getaddrinfo(
+            host, port, family=socket.AF_UNSPEC, type=socket.SOCK_STREAM
+        )
+    except socket.gaierror as e:
+        raise EgressPolicyError(f"download DNS resolution failed for {host!r}: {e}") from None
+    if not answers:
+        raise EgressPolicyError(f"download DNS resolution returned no addresses for {host!r}")
+
+    validated: List[Tuple[int, int, int, tuple]] = []
+    seen = set()
+    for family, socktype, proto, _canonname, sockaddr in answers:
+        if family not in (socket.AF_INET, socket.AF_INET6):
+            raise EgressPolicyError("resolver returned an unsupported address family")
+        _public_ip(sockaddr[0])
+        key = (family, socktype, proto, sockaddr)
+        if key not in seen:
+            seen.add(key)
+            validated.append((family, socktype, proto, sockaddr))
+    return validated
+
+
+def _connect_public(host: str, port: int, timeout, source_address=None) -> socket.socket:
+    answers = resolve_public(host, port)
+    last_error: Optional[OSError] = None
+    for family, socktype, proto, sockaddr in answers:
+        sock = socket.socket(family, socktype, proto)
+        try:
+            sock.settimeout(timeout)
+            if source_address:
+                sock.bind(source_address)
+            # sockaddr came from the validated one-shot resolution above.  Passing
+            # it directly prevents socket.connect from resolving the hostname again.
+            sock.connect(sockaddr)
+            return sock
+        except OSError as e:
+            last_error = e
+            sock.close()
+    if last_error is not None:
+        raise last_error
+    raise EgressPolicyError(f"no usable public address for {host!r}")
+
+
+class PinnedHTTPSConnection(http.client.HTTPSConnection):
+    """HTTPSConnection whose TCP socket is pinned to a validated public address."""
+
+    def connect(self) -> None:
+        if self._tunnel_host:
+            # The opener disables proxies, so a tunnel would indicate that the
+            # boundary was bypassed by a future handler change.
+            raise EgressPolicyError("proxy tunnels are disabled for downloads")
+        raw = _connect_public(
+            self.host, self.port, self.timeout, getattr(self, "source_address", None)
+        )
+        try:
+            self.sock = self._context.wrap_socket(raw, server_hostname=self.host)
+        except Exception:
+            raw.close()
+            raise
+
+
+class PinnedHTTPSHandler(urllib.request.HTTPSHandler):
+    def https_open(self, req):
+        def connection(host, **kwargs):
+            return PinnedHTTPSConnection(host, **kwargs)
+
+        return self.do_open(connection, req, context=self._context)
+
+
+class GuardedRedirectHandler(urllib.request.HTTPRedirectHandler):
+    max_redirections = MAX_REDIRECTS
+    max_repeats = 2
+
+    def redirect_request(self, req, fp, code, msg, headers, newurl):
+        try:
+            validate_https_url(newurl)
+        except EgressPolicyError as e:
+            raise urllib.error.HTTPError(
+                safe_url(newurl), code, f"blocked redirect: {e}", headers, fp
+            ) from None
+        return super().redirect_request(req, fp, code, msg, headers, newurl)
+
+
+def build_https_opener() -> urllib.request.OpenerDirector:
+    """Build an opener whose only network path is the pinned HTTPS handler."""
+    context = ssl.create_default_context()
+    opener = urllib.request.OpenerDirector()
+    # Construct the handler graph explicitly.  build_opener would silently add
+    # HTTP, file, FTP, data, and environment-proxy handlers that this boundary
+    # must not own.
+    for handler in (
+        urllib.request.UnknownHandler(),
+        urllib.request.HTTPDefaultErrorHandler(),
+        GuardedRedirectHandler(),
+        PinnedHTTPSHandler(context=context),
+        urllib.request.HTTPErrorProcessor(),
+    ):
+        opener.add_handler(handler)
+    return opener

--- a/src/venice/client.py
+++ b/src/venice/client.py
@@ -6,14 +6,26 @@ Maps non-2xx to VeniceAPIError with status, URL, and a body excerpt.
 from __future__ import annotations
 
 import json
+import math
 import os
+import tempfile
 import time
 import urllib.error
 import urllib.parse
 import urllib.request
+from pathlib import Path
 from typing import Any, Callable, Optional, Tuple, Union
 
-from . import __version__, config
+from . import __version__, _egress, config
+
+
+VIDEO_DOWNLOAD_MAX_BYTES = 512 * 1024 * 1024
+VIDEO_DOWNLOAD_MAX_SECONDS = 15 * 60
+VIDEO_DOWNLOAD_IO_TIMEOUT_SECONDS = 60
+VIDEO_DOWNLOAD_CHUNK_BYTES = 1024 * 1024
+VIDEO_DOWNLOAD_CONTENT_TYPES = frozenset(
+    {"video/mp4", "video/webm", "video/quicktime"}
+)
 
 
 class VeniceAPIError(Exception):
@@ -21,17 +33,17 @@ class VeniceAPIError(Exception):
 
     Attributes:
         status: HTTP status code (0 if connection failed pre-response).
-        url:    final request URL.
+        url:    request URL with userinfo, query, and fragment redacted.
         body:   excerpt of the response body (first ~2 KB), for debugging.
         code:   Venice API error code (e.g. INSUFFICIENT_BALANCE), if parseable.
     """
 
     def __init__(self, status: int, url: str, body: str, code: Optional[str] = None):
         self.status = status
-        self.url = url
+        self.url = _egress.safe_url(url) if "://" in str(url) else str(url)
         self.body = body
         self.code = code
-        msg = f"HTTP {status} from {url}"
+        msg = f"HTTP {status} from {self.url}"
         if code:
             msg += f" [{code}]"
         if body:
@@ -185,28 +197,118 @@ class VeniceClient:
                 )
             time.sleep(interval)
 
-    def get_url_bytes(self, url: str) -> Tuple[str, bytes]:
-        """Fetch an arbitrary URL's bytes with a plain GET (no auth header).
+    def download_url_to_temp(
+        self,
+        url: str,
+        directory: Path,
+        *,
+        max_bytes: int = VIDEO_DOWNLOAD_MAX_BYTES,
+        max_seconds: float = VIDEO_DOWNLOAD_MAX_SECONDS,
+    ) -> Tuple[str, Path, int]:
+        """Safely stream one presigned video URL to a private temporary file.
 
-        For presigned download URLs (e.g. a video's download_url), which carry
-        their own auth in the query string and must not receive our Bearer token.
-        Returns (content_type, bytes); maps HTTP/URL errors to VeniceAPIError.
+        The egress opener owns resolution, address policy, pinning, TLS, and redirect
+        checks.  This layer owns media type, byte, and wall-time bounds.  It never
+        sends the Venice Bearer token and never renders the URL query string.
         """
-        req = urllib.request.Request(
-            url, headers={"User-Agent": self.user_agent}, method="GET"
-        )
         try:
-            with urllib.request.urlopen(req, timeout=self.timeout) as resp:
-                return resp.headers.get("Content-Type", ""), resp.read()
+            _egress.validate_https_url(url)
+        except _egress.EgressPolicyError as e:
+            raise VeniceAPIError(0, url, str(e)) from None
+        try:
+            byte_limit = int(max_bytes)
+            time_limit = float(max_seconds)
+            configured_timeout = float(self.timeout)
+        except (TypeError, ValueError):
+            raise VeniceAPIError(0, url, "invalid download resource limit") from None
+        if (
+            byte_limit <= 0
+            or time_limit <= 0
+            or not math.isfinite(time_limit)
+            or configured_timeout <= 0
+            or not math.isfinite(configured_timeout)
+        ):
+            raise VeniceAPIError(0, url, "invalid download resource limit")
+        io_timeout = min(configured_timeout, VIDEO_DOWNLOAD_IO_TIMEOUT_SECONDS)
+
+        req = urllib.request.Request(
+            url,
+            headers={"Accept": "video/*", "User-Agent": self.user_agent},
+            method="GET",
+        )
+        opener = _egress.build_https_opener()
+        tmp_path: Optional[Path] = None
+        try:
+            with opener.open(req, timeout=io_timeout) as resp:
+                ctype = resp.headers.get("Content-Type", "") or ""
+                ctype_base = ctype.split(";", 1)[0].strip().lower()
+                if ctype_base not in VIDEO_DOWNLOAD_CONTENT_TYPES:
+                    raise VeniceAPIError(
+                        0, url, f"unsupported video content type: {ctype_base or '(missing)'}"
+                    )
+                raw_length = resp.headers.get("Content-Length")
+                if raw_length:
+                    try:
+                        declared = int(raw_length)
+                    except (TypeError, ValueError):
+                        raise VeniceAPIError(0, url, "invalid download Content-Length") from None
+                    if declared < 0 or declared > byte_limit:
+                        raise VeniceAPIError(
+                            0, url, f"video download exceeds {byte_limit} byte limit"
+                        )
+
+                directory = Path(directory)
+                try:
+                    fd, tmp_name = tempfile.mkstemp(
+                        prefix=".venice-video-", suffix=".tmp", dir=str(directory)
+                    )
+                except OSError as e:
+                    raise VeniceAPIError(
+                        0, url, f"cannot create temporary download file: {e}"
+                    ) from None
+                tmp_path = Path(tmp_name)
+                total = 0
+                started = time.monotonic()
+                try:
+                    with os.fdopen(fd, "wb") as out:
+                        while True:
+                            if time.monotonic() - started > time_limit:
+                                raise VeniceAPIError(0, url, "video download timed out")
+                            chunk = resp.read(
+                                min(VIDEO_DOWNLOAD_CHUNK_BYTES, byte_limit - total + 1)
+                            )
+                            if not chunk:
+                                break
+                            total += len(chunk)
+                            if total > byte_limit:
+                                raise VeniceAPIError(
+                                    0, url, f"video download exceeds {byte_limit} byte limit"
+                                )
+                            out.write(chunk)
+                        if total == 0:
+                            raise VeniceAPIError(0, url, "video download was empty")
+                        out.flush()
+                        os.fsync(out.fileno())
+                except Exception:
+                    try:
+                        tmp_path.unlink()
+                    except OSError:
+                        pass
+                    tmp_path = None
+                    raise
+                return ctype, tmp_path, total
         except urllib.error.HTTPError as e:
-            err_body = b""
-            try:
-                err_body = e.read()
-            except Exception:
-                pass
-            self._raise_api_error(e.code, url, err_body, "")
+            raise VeniceAPIError(e.code, url, "video download request failed") from None
         except urllib.error.URLError as e:
-            raise VeniceAPIError(0, url, f"connection error: {e.reason}") from None
+            if isinstance(e.reason, _egress.EgressPolicyError):
+                detail = str(e.reason)
+            else:
+                detail = "video download connection failed"
+            raise VeniceAPIError(0, url, detail) from None
+        except _egress.EgressPolicyError as e:
+            raise VeniceAPIError(0, url, str(e)) from None
+        except (TimeoutError, OSError):
+            raise VeniceAPIError(0, url, "video download connection failed") from None
 
     @staticmethod
     def _decode_json(status: int, path: str, ctype: str, raw: bytes) -> dict:

--- a/src/venice/commands/_agent.py
+++ b/src/venice/commands/_agent.py
@@ -1918,7 +1918,6 @@ _JOB_STATUS_SCHEMA = _obj(
         "queue_id": _p("string", "The queue_id from a background venice_sfx/music/video call."),
         "type": _p("string", "sfx, music, or video -- the tool that started the job."),
         "model": _p("string", "The model id from the job handle."),
-        "download_url": _p("string", "The download_url from the job handle (VPS video only)."),
     },
     required=["queue_id", "type", "model"],
 )
@@ -1928,7 +1927,6 @@ _JOB_RESULT_SCHEMA = _obj(
         "queue_id": _p("string", "The queue_id from a background venice_sfx/music/video call."),
         "type": _p("string", "sfx, music, or video -- the tool that started the job."),
         "model": _p("string", "The model id from the job handle."),
-        "download_url": _p("string", "The download_url from the job handle (VPS video only)."),
         "max_wait": _p(
             "number",
             "Seconds to block-poll for the file (default 0 = one non-blocking "
@@ -2323,8 +2321,9 @@ _BUILTINS = [
         "venice_job_result",
         "job_result_tool",
         "Fetch a backgrounded media render's file once ready (started with "
-        "background=true). Pass back the job handle's queue_id, type, model (and "
-        "download_url for VPS video). Writes the file and returns its path, or "
+        "background=true). Pass back the job handle's queue_id, type, and model; "
+        "private VPS retrieval metadata is resolved locally. Writes the file and "
+        "returns its path, or "
         "status 'processing' if not ready yet -- retry later. Free (charged at "
         "queue time); not spend-gated.",
         _JOB_RESULT_SCHEMA,
@@ -2421,7 +2420,9 @@ def select(categories=None, names=None, exclude=None) -> set:
 
 
 # Loop-controlled kwargs the model must never supply (stripped defensively).
-_CONTROLLED = ("confirm", "max_spend", "output_dir", "path_authority")
+_CONTROLLED = (
+    "confirm", "max_spend", "output_dir", "path_authority", "download_url",
+)
 
 
 def _clean(arguments) -> dict:

--- a/src/venice/commands/_mcp.py
+++ b/src/venice/commands/_mcp.py
@@ -24,7 +24,10 @@ from types import SimpleNamespace
 from typing import List, Optional
 
 from ..client import VeniceAPIError
-from . import _audio, _browser, _index, _memory, _models, _openai, _queue, _shared
+from . import (
+    _audio, _browser, _index, _memory, _models, _openai, _queue, _shared,
+    _video_jobs,
+)
 from . import bg_remove as _bg
 from . import chat as _chat
 from . import image as _image
@@ -149,10 +152,8 @@ def _err(message: str) -> dict:
 _JOB_ROUTE = {"sfx": "audio", "music": "audio", "video": "video"}
 
 
-def _job_handle(
-    queue_id: str, *, type: str, model: str, quote_value, download_url: Optional[str] = None
-) -> dict:
-    """The stateless handle a `background=True` media call returns.
+def _job_handle(queue_id: str, *, type: str, model: str, quote_value) -> dict:
+    """The opaque handle a `background=True` media call returns.
 
     The agent holds these fields and passes them back to `venice_job_status` /
     `venice_job_result`. The charge already landed at queue time, so fetching the
@@ -169,9 +170,6 @@ def _job_handle(
             "venice_job_result using this queue_id, type, and model"
         ),
     }
-    if download_url:
-        handle["download_url"] = download_url
-        handle["message"] += " (pass download_url too for this video)"
     return handle
 
 
@@ -817,8 +815,8 @@ def video_tool(
 
     With `background=True` the call queues the job (charging up front) and returns
     a `{"status": "queued", ...}` handle immediately instead of blocking on the
-    poll; fetch the mp4 later via `venice_job_result` (pass back the handle's
-    `download_url` too, which VPS-backed models need).
+    poll; fetch the mp4 later via `venice_job_result`. VPS retrieval metadata is
+    retained privately and is not returned to the model.
     """
     if not prompt or not prompt.strip():
         return _err("video: prompt is required")
@@ -874,16 +872,27 @@ def video_tool(
     download_url = queued.get("download_url") or None
 
     if background:
-        return _job_handle(
-            queue_id, type="video", model=model,
-            quote_value=quote_value, download_url=download_url,
-        )
+        if download_url:
+            try:
+                _video_jobs.remember(queue_id, model, download_url)
+            except _video_jobs.VideoJobStoreError as e:
+                return _err(
+                    f"video: queued as {queue_id}, but could not save private "
+                    f"retrieval metadata: {e}"
+                )
+        return _job_handle(queue_id, type="video", model=model, quote_value=quote_value)
 
+    output_root = resolve_output_dir(output_dir)
     try:
-        ctype, data = _video.retrieve_bytes(
+        output_root.mkdir(parents=True, exist_ok=True)
+    except OSError as e:
+        return _err(f"video: could not create output directory {output_root}: {e}")
+    try:
+        ctype, payload, byte_count = _video.retrieve_bytes(
             client, model, queue_id,
             poll_interval=_video.config.VIDEO_POLL_INTERVAL_SEC,
             max_wait=max_wait, download_url=download_url,
+            download_dir=output_root,
         )
     except VeniceAPIError as e:
         return _err(f"video retrieve failed: {e}")
@@ -894,11 +903,21 @@ def video_tool(
 
     ext, _unknown = _queue.ext_for(ctype, _video.VIDEO_EXT_BY_CTYPE, default=".mp4")
     out_path = _queue.resolve_output_path(
-        resolve_output_dir(output_dir), queue_id, ext, prefix="venice-video"
+        output_root, queue_id, ext, prefix="venice-video"
     )
-    werr = _write(out_path, data)
-    if werr:
-        return _err(f"video: could not write {out_path}: {werr}")
+    if isinstance(payload, Path):
+        try:
+            os.replace(payload, out_path)
+        except OSError as e:
+            try:
+                payload.unlink()
+            except OSError:
+                pass
+            return _err(f"video: could not write {out_path}: {e}")
+    else:
+        werr = _write(out_path, payload)
+        if werr:
+            return _err(f"video: could not write {out_path}: {werr}")
 
     try:  # best-effort cleanup; the file is already saved
         client.post_json("/video/complete", {"model": model, "queue_id": queue_id})
@@ -907,7 +926,7 @@ def video_tool(
     return {
         "status": "ok",
         "path": str(out_path.resolve()),
-        "bytes": len(data),
+        "bytes": byte_count,
         "model": model,
         "queue_id": queue_id,
         "cost_estimate_usd": quote_value,
@@ -919,9 +938,7 @@ def _job_route(type: str) -> Optional[str]:
     return _JOB_ROUTE.get((type or "").lower())
 
 
-def job_status_tool(
-    client, *, queue_id: str, type: str, model: str, download_url: Optional[str] = None
-) -> dict:
+def job_status_tool(client, *, queue_id: str, type: str, model: str) -> dict:
     """Peek at a backgrounded media job (from a `background=True` sfx/music/video call).
 
     Free, read-only, non-blocking: one probe of the media type's retrieve route.
@@ -970,7 +987,6 @@ def job_result_tool(
     queue_id: str,
     type: str,
     model: str,
-    download_url: Optional[str] = None,
     # #57 Class C2: deliberately NOT tri-stated, unlike the generate-path
     # max_wait. Here 0.0 is a MEANING ("one non-blocking probe"), not a default
     # standing in for a preference, and this tool is not config-reachable --
@@ -1006,12 +1022,23 @@ def job_result_tool(
             )
             ext, _unknown = _audio.ext_for(ctype)
             name_prefix = f"venice-{(type or '').lower()}"
+            byte_count = len(data)
         else:  # video
             wait = max(0.0, min(max_wait, _video.config.VIDEO_POLL_MAX_WAIT_SEC))
-            ctype, data = _video.retrieve_bytes(
+            try:
+                download_url = _video_jobs.lookup(queue_id, model)
+            except _video_jobs.VideoJobStoreError as e:
+                return _err(f"job_result: cannot read private retrieval metadata: {e}")
+            output_root = resolve_output_dir(None)
+            try:
+                output_root.mkdir(parents=True, exist_ok=True)
+            except OSError as e:
+                return _err(f"job_result: could not create output directory: {e}")
+            ctype, data, byte_count = _video.retrieve_bytes(
                 client, model, queue_id,
                 poll_interval=_video.config.VIDEO_POLL_INTERVAL_SEC,
                 max_wait=wait, download_url=download_url,
+                download_dir=output_root,
             )
             ext, _unknown = _queue.ext_for(ctype, _video.VIDEO_EXT_BY_CTYPE, default=".mp4")
             name_prefix = "venice-video"
@@ -1024,7 +1051,7 @@ def job_result_tool(
     except _video.NoVideoStream:
         return _err(
             f"job_result: video job {queue_id} completed but returned no stream; "
-            "re-call with the download_url from the background job handle"
+            "no private download metadata is available"
         )
     except VeniceAPIError as e:
         return _err(f"job_result: retrieve failed: {e}")
@@ -1032,18 +1059,33 @@ def job_result_tool(
     out_path = _queue.resolve_output_path(
         resolve_output_dir(None), queue_id, ext, prefix=name_prefix
     )
-    werr = _write(out_path, data)
-    if werr:
-        return _err(f"job_result: could not write {out_path}: {werr}")
+    if isinstance(data, Path):
+        try:
+            os.replace(data, out_path)
+        except OSError as e:
+            try:
+                data.unlink()
+            except OSError:
+                pass
+            return _err(f"job_result: could not write {out_path}: {e}")
+    else:
+        werr = _write(out_path, data)
+        if werr:
+            return _err(f"job_result: could not write {out_path}: {werr}")
 
     try:  # best-effort cleanup; the file is already saved
         client.post_json(f"/{base}/complete", {"model": model, "queue_id": queue_id})
     except VeniceAPIError:
         pass
+    if base == "video":
+        try:
+            _video_jobs.forget(queue_id, model)
+        except _video_jobs.VideoJobStoreError:
+            pass
     return {
         "status": "ok",
         "path": str(out_path.resolve()),
-        "bytes": len(data),
+        "bytes": byte_count,
         "model": model,
         "queue_id": queue_id,
     }

--- a/src/venice/commands/_video_jobs.py
+++ b/src/venice/commands/_video_jobs.py
@@ -1,0 +1,171 @@
+"""Private local registry for server-issued VPS video download URLs.
+
+Queue ids and models are safe public handles; presigned download URLs are not.  This
+0600 atomic store binds the latter to the former across a background CLI process
+boundary without returning the URL to an MCP host or model transcript.
+"""
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import tempfile
+import threading
+import time
+from pathlib import Path
+from typing import Optional
+
+from .. import _egress, config
+
+STORE_VERSION = 1
+MAX_JOBS = 100
+MAX_AGE_SECONDS = 7 * 24 * 60 * 60
+
+_LOCK = threading.Lock()
+
+
+class VideoJobStoreError(Exception):
+    """The private video job registry could not be read or updated."""
+
+
+def _path() -> Path:
+    return Path(os.environ.get(config.ENV_VIDEO_JOBS_FILE) or config.VIDEO_JOBS_FILE)
+
+
+def _key(queue_id: str, model: str) -> str:
+    if not isinstance(queue_id, str) or not queue_id:
+        raise VideoJobStoreError("queue_id is required")
+    if not isinstance(model, str) or not model:
+        raise VideoJobStoreError("model is required")
+    return hashlib.sha256(f"{model}\0{queue_id}".encode("utf-8")).hexdigest()
+
+
+def _fresh() -> dict:
+    return {"version": STORE_VERSION, "jobs": {}}
+
+
+def _load(path: Path, *, strict: bool) -> dict:
+    try:
+        raw = path.read_text(encoding="utf-8")
+    except FileNotFoundError:
+        return _fresh()
+    except OSError as e:
+        raise VideoJobStoreError(f"cannot read private video job registry: {e}") from None
+    try:
+        doc = json.loads(raw)
+    except ValueError as e:
+        if strict:
+            raise VideoJobStoreError(f"private video job registry is malformed: {e}") from None
+        return _fresh()
+    if (
+        not isinstance(doc, dict)
+        or doc.get("version") != STORE_VERSION
+        or not isinstance(doc.get("jobs"), dict)
+    ):
+        if strict:
+            raise VideoJobStoreError("private video job registry is malformed")
+        return _fresh()
+    return doc
+
+
+def _save(path: Path, doc: dict) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True, mode=0o700)
+    fd, tmp_name = tempfile.mkstemp(
+        prefix=f".{path.name}.", suffix=".tmp", dir=str(path.parent)
+    )
+    tmp = Path(tmp_name)
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as f:
+            json.dump(doc, f, indent=2, sort_keys=True)
+            f.write("\n")
+            f.flush()
+            os.fsync(f.fileno())
+        os.replace(tmp, path)
+    except Exception:
+        try:
+            tmp.unlink()
+        except OSError:
+            pass
+        raise
+    try:
+        os.chmod(path, 0o600)
+    except OSError:
+        pass
+
+
+def _prune(doc: dict, now: float) -> bool:
+    jobs = doc["jobs"]
+    keep = {}
+    for key, value in jobs.items():
+        if not isinstance(value, dict):
+            continue
+        try:
+            created = float(value.get("created", 0))
+        except (TypeError, ValueError):
+            continue
+        if created > 0 and now - created <= MAX_AGE_SECONDS:
+            keep[key] = value
+    newest = sorted(
+        keep.items(), key=lambda item: float(item[1].get("created", 0)), reverse=True
+    )[:MAX_JOBS]
+    pruned = dict(newest)
+    changed = pruned != jobs
+    doc["jobs"] = pruned
+    return changed
+
+
+def remember(queue_id: str, model: str, download_url: str) -> None:
+    """Persist one server-issued URL without ever including it in an error."""
+    if not isinstance(download_url, str) or not download_url:
+        raise VideoJobStoreError("download URL is required")
+    try:
+        _egress.validate_https_url(download_url)
+    except _egress.EgressPolicyError as e:
+        raise VideoJobStoreError(str(e)) from None
+    path = _path()
+    now = time.time()
+    with _LOCK:
+        doc = _load(path, strict=True)
+        _prune(doc, now)
+        doc["jobs"][_key(queue_id, model)] = {
+            "queue_id": queue_id,
+            "model": model,
+            "download_url": download_url,
+            "created": now,
+        }
+        _prune(doc, now)
+        try:
+            _save(path, doc)
+        except OSError as e:
+            raise VideoJobStoreError(f"cannot write private video job registry: {e}") from None
+
+
+def lookup(queue_id: str, model: str) -> Optional[str]:
+    """Return the bound URL, pruning expired entries as a side effect."""
+    path = _path()
+    now = time.time()
+    with _LOCK:
+        doc = _load(path, strict=True)
+        changed = _prune(doc, now)
+        entry = doc["jobs"].get(_key(queue_id, model))
+        if changed and path.exists():
+            try:
+                _save(path, doc)
+            except OSError as e:
+                raise VideoJobStoreError(
+                    f"cannot update private video job registry: {e}"
+                ) from None
+    value = entry.get("download_url") if isinstance(entry, dict) else None
+    return value if isinstance(value, str) and value else None
+
+
+def forget(queue_id: str, model: str) -> None:
+    path = _path()
+    with _LOCK:
+        doc = _load(path, strict=True)
+        if doc["jobs"].pop(_key(queue_id, model), None) is None:
+            return
+        try:
+            _save(path, doc)
+        except OSError as e:
+            raise VideoJobStoreError(f"cannot update private video job registry: {e}") from None

--- a/src/venice/commands/video.py
+++ b/src/venice/commands/video.py
@@ -13,14 +13,15 @@ A free `/models?type=video` catalog GET (via the lean client) validates
 from __future__ import annotations
 
 import json
+import os
 import sys
 import time
 from pathlib import Path
-from typing import Optional, Tuple
+from typing import Optional, Tuple, Union
 
 from .. import billing, config, userconfig
 from ..client import VeniceAPIError
-from . import _models, _queue, _shared
+from . import _models, _queue, _shared, _video_jobs
 
 VIDEO_EXT_BY_CTYPE = {
     "video/mp4": ".mp4",
@@ -181,8 +182,8 @@ def register_status(subparsers) -> None:
         help="Fetch a previously-backgrounded video job by queue_id.",
         description=(
             "Polls /video/retrieve for an already-queued job (typically from "
-            "`venice video ... --background`) and downloads the mp4 when ready. "
-            "For VPS-backed models, pass the --download-url printed at queue time."
+            "`venice video ... --background`) and downloads the media when ready. "
+            "Current jobs resolve private download metadata from the local registry."
         ),
     )
     sp.add_argument("queue_id")
@@ -195,7 +196,7 @@ def register_status(subparsers) -> None:
         "--download-url",
         default=None,
         dest="download_url",
-        help="Presigned URL from the original queue (VPS-backed models only).",
+        help="Deprecated: presigned URL for a job queued before v0.83.10.",
     )
     sp.add_argument("--output", "-o", type=Path, default=None)
     _shared.add_cleanup_flag(sp, section="video", endpoint="/video/complete")
@@ -463,11 +464,19 @@ def _run_generate(args) -> int:
     download_url = queued.get("download_url") or None
 
     if args.background:
+        if download_url:
+            try:
+                _video_jobs.remember(queue_id, model, download_url)
+            except _video_jobs.VideoJobStoreError as e:
+                print(
+                    f"video: queued as {queue_id}, but could not save private "
+                    f"retrieval metadata: {e}",
+                    file=sys.stderr,
+                )
+                return 9
         sys.stdout.write(queue_id + "\n")
         sys.stdout.flush()
         msg = f"queued as {queue_id}; fetch with: venice video-status {queue_id} --model {model}"
-        if download_url:
-            msg += f" --download-url {download_url}"
         print(msg, file=sys.stderr)
         return 0
 
@@ -506,8 +515,15 @@ def _run_status(args) -> int:
         )
         if rc is not None:
             return rc
+    download_url = args.download_url
+    if not download_url:
+        try:
+            download_url = _video_jobs.lookup(args.queue_id, model)
+        except _video_jobs.VideoJobStoreError as e:
+            print(f"video-status: cannot read private retrieval metadata: {e}", file=sys.stderr)
+            return 9
     return _retrieve_and_save(
-        client, model, args.queue_id, args.download_url,
+        client, model, args.queue_id, download_url,
         args.output, args.poll_interval, args.max_wait, bool(args.no_cleanup),
     )
 
@@ -519,12 +535,12 @@ class NoVideoStream(Exception):
 
 def retrieve_bytes(
     client, model, queue_id, *,
-    poll_interval, max_wait, download_url=None, on_tick=None,
-) -> Tuple[str, bytes]:
-    """Poll /video/retrieve until the video is ready and return (ctype, bytes).
+    poll_interval, max_wait, download_url=None, on_tick=None, download_dir=None,
+) -> Tuple[str, Union[bytes, Path], int]:
+    """Poll until ready and return ``(ctype, bytes-or-temp-path, byte_count)``.
 
     Print-free core of `_retrieve_and_save`: the bare poll plus the VPS-model
-    download-url fallback, with no stderr, file I/O, or cleanup -- so callers
+    download-url fallback, with no stderr or cleanup -- so callers
     that own stdout (e.g. the MCP stdio server) can reuse it without corrupting
     their transport. Non-VPS models stream the mp4 straight from /video/retrieve;
     VPS-backed models report COMPLETED (JSON) and the mp4 is fetched from the
@@ -542,11 +558,14 @@ def retrieve_bytes(
         terminal_statuses=("COMPLETED",),
     )
     if isinstance(payload, (bytes, bytearray)):
-        return ctype, bytes(payload)
+        data = bytes(payload)
+        return ctype, data, len(data)
     # VPS-backed model: retrieve reported COMPLETED (JSON) -- fetch the mp4.
     if not download_url:
         raise NoVideoStream(queue_id)
-    return client.get_url_bytes(download_url)
+    if download_dir is None:
+        raise ValueError("download_dir is required for a VPS video download")
+    return client.download_url_to_temp(download_url, Path(download_dir))
 
 
 def _retrieve_and_save(
@@ -554,12 +573,19 @@ def _retrieve_and_save(
     poll_interval, max_wait, no_cleanup,
 ) -> int:
     start = time.monotonic()
+    staging_hint = _queue.resolve_output_path(
+        out_arg, queue_id, ".mp4", prefix="venice-video"
+    )
+    staged_path: Optional[Path] = None
     try:
-        ctype, data = retrieve_bytes(
+        ctype, payload, byte_count = retrieve_bytes(
             client, model, queue_id,
             poll_interval=poll_interval, max_wait=max_wait,
             download_url=download_url, on_tick=_queue.progress_tick(start),
+            download_dir=staging_hint.parent,
         )
+        if isinstance(payload, Path):
+            staged_path = payload
     except VeniceAPIError as e:
         sys.stderr.write("\n")
         print(f"retrieve failed: {e}", file=sys.stderr)
@@ -575,9 +601,9 @@ def _retrieve_and_save(
         sys.stderr.write("\n")
         print(
             "video: job completed but returned no video stream and no "
-            "download_url is known; re-run `venice video-status "
-            f"{queue_id} --model {model} --download-url <url>` with the URL "
-            "printed when the job was queued.",
+            "private download metadata is known; for a pre-v0.83.10 job, re-run "
+            f"`venice video-status {queue_id} --model {model} "
+            "--download-url <url>`.",
             file=sys.stderr,
         )
         return 2
@@ -589,14 +615,29 @@ def _retrieve_and_save(
     out_path = _queue.resolve_output_path(out_arg, queue_id, ext, prefix="venice-video")
 
     try:
-        out_path.write_bytes(data)
+        if staged_path is not None:
+            os.replace(staged_path, out_path)
+            staged_path = None
+        else:
+            out_path.write_bytes(payload)
     except OSError as e:
         print(f"could not write {out_path}: {e}", file=sys.stderr)
         return 9
+    finally:
+        if staged_path is not None:
+            try:
+                staged_path.unlink()
+            except OSError:
+                pass
 
     abs_path = out_path.resolve()
     print(str(abs_path))
-    print(f"wrote {len(data)} bytes to {abs_path}", file=sys.stderr)
+    print(f"wrote {byte_count} bytes to {abs_path}", file=sys.stderr)
+
+    try:
+        _video_jobs.forget(queue_id, model)
+    except _video_jobs.VideoJobStoreError as e:
+        print(f"warning: could not clear private video job metadata: {e}", file=sys.stderr)
 
     if not no_cleanup:
         try:

--- a/src/venice/config.py
+++ b/src/venice/config.py
@@ -16,6 +16,12 @@ SECRETS_FILE = CONFIG_DIR / "secrets.json"
 # `credentials` lives). Names resolve to <PERSONAS_DIR>/<name>.md|.txt only.
 PERSONAS_DIR = CONFIG_DIR / "personas"
 
+# VPS video jobs return a presigned download URL only in the queue response.  Keep
+# that bearer-like URL in a private local registry so background CLI/agent flows can
+# refer to the public queue id without copying the signed URL through transcripts.
+VIDEO_JOBS_FILE = CONFIG_DIR / "video_jobs.json"
+ENV_VIDEO_JOBS_FILE = "VENICE_VIDEO_JOBS_FILE"
+
 # `venice chat`/`venice code` auto-save each REPL session (id + settings + usage +
 # transcript) here (#47), so `--resume <id>` / `--continue` restore a session, not
 # just its messages. One JSON envelope per session at <SESSIONS_DIR>/<id>.json,

--- a/tests/test_agent.py
+++ b/tests/test_agent.py
@@ -2636,7 +2636,7 @@ class TestAsyncJobSchemas(unittest.TestCase):
         for schema in (_agent._JOB_STATUS_SCHEMA, _agent._JOB_RESULT_SCHEMA):
             self.assertEqual(schema.get("required"), ["queue_id", "type", "model"])
             props = schema["properties"]
-            for banned in ("confirm", "max_spend", "output_dir"):
+            for banned in ("confirm", "max_spend", "output_dir", "download_url"):
                 self.assertNotIn(banned, props)
         # only job_result exposes max_wait (block-poll seconds)
         self.assertIn("max_wait", _agent._JOB_RESULT_SCHEMA["properties"])
@@ -2647,6 +2647,12 @@ class TestAsyncJobSchemas(unittest.TestCase):
             object(), only={"venice_job_status", "venice_job_result"})}
         self.assertFalse(by["venice_job_status"].paid)
         self.assertFalse(by["venice_job_result"].paid)
+
+    def test_fabricated_download_url_is_stripped_before_dispatch(self):
+        self.assertNotIn(
+            "download_url",
+            _agent._clean({"queue_id": "q", "download_url": "file:///tmp/x"}),
+        )
 
 
 class TestMediaPathAuthorityWiring(unittest.TestCase):

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -1,9 +1,11 @@
 """Unit tests for VeniceClient. Mocks urllib.request.urlopen."""
 import io
 import json
+import tempfile
 import threading
 import unittest
 from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from pathlib import Path
 from unittest import mock
 from urllib.error import HTTPError
 
@@ -15,10 +17,17 @@ class FakeResp:
     def __init__(self, status=200, body=b"", ctype="application/json"):
         self.status = status
         self._body = body
+        self._offset = 0
         self.headers = {"Content-Type": ctype}
 
-    def read(self):
-        return self._body
+    def read(self, n=-1):
+        if n is None or n < 0:
+            result = self._body[self._offset:]
+            self._offset = len(self._body)
+            return result
+        result = self._body[self._offset:self._offset + n]
+        self._offset += len(result)
+        return result
 
     def __enter__(self):
         return self
@@ -55,22 +64,124 @@ class TestVeniceClient(unittest.TestCase):
             {"model": "x", "duration_seconds": 5},
         )
 
-    def test_get_url_bytes_sets_versioned_user_agent_without_authorization(self):
+    def test_download_streams_to_temp_without_authorization(self):
         c = VeniceClient(api_key="test-fake-key")
         captured = {}
 
-        def fake_urlopen(req, timeout=None):
-            captured["headers"] = dict(req.header_items())
-            return FakeResp(200, b"image", "image/png")
+        class Opener:
+            def open(self, req, timeout=None):
+                captured["headers"] = dict(req.header_items())
+                captured["timeout"] = timeout
+                return FakeResp(200, b"video", "video/mp4")
 
-        with mock.patch("venice.client.urllib.request.urlopen", fake_urlopen):
-            ctype, body = c.get_url_bytes("https://example.test/image.png")
+        with tempfile.TemporaryDirectory() as td, mock.patch(
+            "venice.client._egress.build_https_opener", return_value=Opener()
+        ):
+            ctype, path, size = c.download_url_to_temp(
+                "https://example.test/video.mp4?signature=secret", Path(td)
+            )
+            self.assertEqual(path.read_bytes(), b"video")
+            self.assertEqual(size, 5)
 
         headers = {k.lower(): v for k, v in captured["headers"].items()}
         self.assertEqual(headers["user-agent"], f"venice-cli/{__version__}")
         self.assertNotIn("authorization", headers)
-        self.assertEqual(ctype, "image/png")
-        self.assertEqual(body, b"image")
+        self.assertEqual(ctype, "video/mp4")
+        self.assertEqual(captured["timeout"], 60)
+
+    def test_download_rejects_non_video_content_without_creating_a_file(self):
+        c = VeniceClient(api_key="test-fake-key")
+
+        class Opener:
+            def open(self, req, timeout=None):
+                return FakeResp(200, b"not video", "text/plain")
+
+        with tempfile.TemporaryDirectory() as td, mock.patch(
+            "venice.client._egress.build_https_opener", return_value=Opener()
+        ):
+            with self.assertRaises(VeniceAPIError):
+                c.download_url_to_temp("https://example.test/video", Path(td))
+            self.assertEqual(list(Path(td).iterdir()), [])
+
+    def test_download_rejects_file_scheme_before_constructing_an_opener(self):
+        c = VeniceClient(api_key="test-fake-key")
+        with tempfile.TemporaryDirectory() as td, mock.patch(
+            "venice.client._egress.build_https_opener"
+        ) as build:
+            with self.assertRaises(VeniceAPIError):
+                c.download_url_to_temp("file:///tmp/harmless", Path(td))
+        build.assert_not_called()
+
+    def test_download_rejects_declared_oversize_and_empty_bodies(self):
+        c = VeniceClient(api_key="test-fake-key")
+        oversized = FakeResp(200, b"x", "video/mp4")
+        oversized.headers["Content-Length"] = "999"
+
+        class OversizedOpener:
+            def open(self, req, timeout=None):
+                return oversized
+
+        class EmptyOpener:
+            def open(self, req, timeout=None):
+                return FakeResp(200, b"", "video/mp4")
+
+        with tempfile.TemporaryDirectory() as td:
+            for opener in (OversizedOpener(), EmptyOpener()):
+                with self.subTest(opener=type(opener).__name__), mock.patch(
+                    "venice.client._egress.build_https_opener", return_value=opener
+                ), self.assertRaises(VeniceAPIError):
+                    c.download_url_to_temp(
+                        "https://example.test/video?signature=secret",
+                        Path(td),
+                        max_bytes=4,
+                    )
+                self.assertEqual(list(Path(td).iterdir()), [])
+
+    def test_download_enforces_streamed_byte_limit_and_cleans_partial_file(self):
+        c = VeniceClient(api_key="test-fake-key")
+
+        class Opener:
+            def open(self, req, timeout=None):
+                return FakeResp(200, b"12345", "video/mp4")
+
+        with tempfile.TemporaryDirectory() as td, mock.patch(
+            "venice.client._egress.build_https_opener", return_value=Opener()
+        ):
+            with self.assertRaises(VeniceAPIError):
+                c.download_url_to_temp(
+                    "https://example.test/video?signature=secret", Path(td), max_bytes=4
+                )
+            self.assertEqual(list(Path(td).iterdir()), [])
+
+    def test_download_enforces_total_deadline_and_cleans_partial_file(self):
+        c = VeniceClient(api_key="test-fake-key")
+
+        class Opener:
+            def open(self, req, timeout=None):
+                return FakeResp(200, b"video", "video/mp4")
+
+        with tempfile.TemporaryDirectory() as td, mock.patch(
+            "venice.client._egress.build_https_opener", return_value=Opener()
+        ), mock.patch("venice.client.time.monotonic", side_effect=[0.0, 2.0]):
+            with self.assertRaises(VeniceAPIError) as cm:
+                c.download_url_to_temp(
+                    "https://example.test/video?signature=secret",
+                    Path(td),
+                    max_seconds=1,
+                )
+            self.assertIn("timed out", str(cm.exception))
+            self.assertEqual(list(Path(td).iterdir()), [])
+
+    def test_download_error_redacts_userinfo_query_and_fragment(self):
+        c = VeniceClient(api_key="test-fake-key")
+        url = "https://user:pass@example.test/video?signature=secret#fragment"
+        with tempfile.TemporaryDirectory() as td:
+            with self.assertRaises(VeniceAPIError) as cm:
+                c.download_url_to_temp(url, Path(td))
+        rendered = str(cm.exception)
+        for secret in ("user:pass", "signature", "secret", "fragment"):
+            self.assertNotIn(secret, rendered)
+        self.assertEqual(cm.exception.url, "https://example.test/video")
 
     def test_custom_user_agent_overrides_versioned_default(self):
         c = VeniceClient(api_key="test-fake-key", user_agent="embedder/2.0")

--- a/tests/test_egress.py
+++ b/tests/test_egress.py
@@ -1,0 +1,139 @@
+"""Hermetic tests for the pinned public-HTTPS egress boundary (#140)."""
+import socket
+import unittest
+import urllib.error
+import urllib.request
+from unittest import mock
+
+from venice import _egress
+
+
+def _answer(address, *, family=socket.AF_INET):
+    sockaddr = (address, 443) if family == socket.AF_INET else (address, 443, 0, 0)
+    return (family, socket.SOCK_STREAM, socket.IPPROTO_TCP, "", sockaddr)
+
+
+class TestURLPolicy(unittest.TestCase):
+    def test_only_structural_https_without_userinfo_is_accepted(self):
+        self.assertEqual(
+            _egress.validate_https_url("https://cdn.example/video?sig=x"),
+            ("cdn.example", 443),
+        )
+        for value in (
+            "file:///tmp/x",
+            "http://example.com/x",
+            "data:text/plain,x",
+            "https://user:pass@example.com/x",
+            "https://example.com:99999/x",
+            "https://example.com/x\nheader: value",
+            " https://example.com/x",
+            "https://example.com/x ",
+        ):
+            with self.subTest(value=value), self.assertRaises(_egress.EgressPolicyError):
+                _egress.validate_https_url(value)
+
+    def test_safe_url_strips_all_bearer_like_components(self):
+        rendered = _egress.safe_url(
+            "https://user:pass@example.com:8443/video?signature=secret#fragment"
+        )
+        self.assertEqual(rendered, "https://example.com:8443/video")
+
+
+class TestResolutionBoundary(unittest.TestCase):
+    def test_non_public_ipv4_ipv6_and_mapped_addresses_are_rejected(self):
+        addresses = (
+            ("127.0.0.1", socket.AF_INET),
+            ("10.0.0.1", socket.AF_INET),
+            ("169.254.169.254", socket.AF_INET),
+            ("224.0.0.1", socket.AF_INET),
+            ("0.0.0.0", socket.AF_INET),
+            ("192.0.2.1", socket.AF_INET),
+            ("::1", socket.AF_INET6),
+            ("fe80::1", socket.AF_INET6),
+            ("fd00:ec2::254", socket.AF_INET6),
+            ("ff02::1", socket.AF_INET6),
+            ("::", socket.AF_INET6),
+            ("::ffff:127.0.0.1", socket.AF_INET6),
+        )
+        for address, family in addresses:
+            with self.subTest(address=address), mock.patch(
+                "venice._egress.socket.getaddrinfo",
+                return_value=[_answer(address, family=family)],
+            ), self.assertRaises(_egress.EgressPolicyError):
+                _egress.resolve_public("cdn.example", 443)
+
+    def test_mixed_public_private_answer_fails_closed(self):
+        with mock.patch(
+            "venice._egress.socket.getaddrinfo",
+            return_value=[_answer("8.8.8.8"), _answer("127.0.0.1")],
+        ), self.assertRaises(_egress.EgressPolicyError):
+            _egress.resolve_public("rebind.example", 443)
+
+    def test_connection_uses_the_once_resolved_numeric_address(self):
+        calls = []
+
+        class FakeSocket:
+            def settimeout(self, value):
+                calls.append(("timeout", value))
+
+            def bind(self, value):
+                calls.append(("bind", value))
+
+            def connect(self, value):
+                calls.append(("connect", value))
+
+            def close(self):
+                calls.append(("close",))
+
+        resolver = mock.Mock(return_value=[_answer("8.8.8.8")])
+        with mock.patch("venice._egress.socket.getaddrinfo", resolver), mock.patch(
+            "venice._egress.socket.socket", return_value=FakeSocket()
+        ):
+            sock = _egress._connect_public("rebind.example", 443, 12)
+
+        self.assertIsInstance(sock, FakeSocket)
+        resolver.assert_called_once()
+        self.assertIn(("connect", ("8.8.8.8", 443)), calls)
+
+    def test_tls_wrap_keeps_original_hostname_for_verification(self):
+        raw = mock.Mock()
+        wrapped = mock.Mock()
+        connection = _egress.PinnedHTTPSConnection("cdn.example", timeout=5)
+        connection._context = mock.Mock()
+        connection._context.wrap_socket.return_value = wrapped
+        with mock.patch("venice._egress._connect_public", return_value=raw):
+            connection.connect()
+        connection._context.wrap_socket.assert_called_once_with(
+            raw, server_hostname="cdn.example"
+        )
+        self.assertIs(connection.sock, wrapped)
+
+
+class TestRedirectAndProxyBoundary(unittest.TestCase):
+    def test_redirect_to_cleartext_is_blocked_with_redacted_error(self):
+        handler = _egress.GuardedRedirectHandler()
+        request = urllib.request.Request("https://public.example/start")
+        target = "http://127.0.0.1/private?signature=secret"
+        with self.assertRaises(urllib.error.HTTPError) as cm:
+            handler.redirect_request(request, None, 302, "Found", {}, target)
+        rendered = str(cm.exception)
+        self.assertNotIn("signature", rendered)
+        self.assertNotIn("secret", rendered)
+
+    def test_redirect_count_and_proxy_policy_are_explicit(self):
+        self.assertEqual(_egress.GuardedRedirectHandler.max_redirections, 5)
+        opener = _egress.build_https_opener()
+        self.assertFalse(
+            any(isinstance(h, urllib.request.ProxyHandler) for h in opener.handlers)
+        )
+        self.assertFalse(
+            any(isinstance(h, urllib.request.FileHandler) for h in opener.handlers)
+        )
+        self.assertFalse(
+            any(isinstance(h, urllib.request.HTTPHandler) for h in opener.handlers)
+        )
+        self.assertTrue(any(isinstance(h, _egress.PinnedHTTPSHandler) for h in opener.handlers))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_mcp_tools.py
+++ b/tests/test_mcp_tools.py
@@ -18,8 +18,9 @@ from unittest import mock
 from urllib.error import HTTPError
 
 from tests.test_client import FakeResp
+from venice import config
 from venice.client import VeniceClient
-from venice.commands import _mcp, _shared
+from venice.commands import _mcp, _shared, _video_jobs
 
 
 def _client():
@@ -52,6 +53,14 @@ class _ToolTest(unittest.TestCase):
     def setUp(self):
         self.td = tempfile.mkdtemp()
         self.addCleanup(shutil.rmtree, self.td, ignore_errors=True)
+        self.jobs_dir = tempfile.mkdtemp()
+        self.addCleanup(shutil.rmtree, self.jobs_dir, ignore_errors=True)
+        jobs = mock.patch.dict(
+            os.environ,
+            {config.ENV_VIDEO_JOBS_FILE: str(Path(self.jobs_dir) / "jobs.json")},
+        )
+        jobs.start()
+        self.addCleanup(jobs.stop)
 
     def stdout_guard(self):
         test = self
@@ -687,7 +696,6 @@ class TestVideoTool(_ToolTest):
             FakeResp(200, b'{"quote": 0.5}'),
             FakeResp(200, json.dumps({"queue_id": "vpsq1", "download_url": url}).encode()),
             FakeResp(200, json.dumps({"status": "COMPLETED"}).encode()),
-            FakeResp(200, b"PRESIGNEDMP4", "video/mp4"),   # get_url_bytes
             FakeResp(200, b'{"ok": true}'),
         )
         seen = []
@@ -696,14 +704,21 @@ class TestVideoTool(_ToolTest):
             seen.append(req.full_url)
             return responses(req, timeout)
 
+        def fake_download(client, value, directory, **kwargs):
+            seen.append(value)
+            path = Path(directory) / ".video.tmp"
+            path.write_bytes(b"PRESIGNEDMP4")
+            return "video/mp4", path, len(b"PRESIGNEDMP4")
+
         with mock.patch("venice.client.urllib.request.urlopen", fake), \
+             mock.patch("venice.client.VeniceClient.download_url_to_temp", fake_download), \
              mock.patch("venice.client.time.sleep"), self.stdout_guard():
             res = _mcp.video_tool(
                 _client(), "a koi pond", output_dir=self.td, confirm=True, max_wait=10
             )
         self.assertEqual(res["status"], "ok")
         self.assertEqual(Path(res["path"]).read_bytes(), b"PRESIGNEDMP4")
-        self.assertIn(url, seen)  # presigned URL fetched verbatim
+        self.assertIn(url, seen)
 
     def test_gate_blocks_before_queue(self):
         seen = []
@@ -728,7 +743,7 @@ class TestVideoTool(_ToolTest):
         res = _mcp.video_tool(_client(), "   ", confirm=True)
         self.assertEqual(res["status"], "error")
 
-    def test_background_returns_queue_id_with_download_url(self):
+    def test_background_returns_opaque_handle_and_stores_download_url_privately(self):
         url = "https://cdn.example.com/presigned?sig=abc"
 
         def fake(req, timeout=None):
@@ -749,7 +764,11 @@ class TestVideoTool(_ToolTest):
         self.assertEqual(res["status"], "queued")
         self.assertEqual(res["queue_id"], "bgvid1")
         self.assertEqual(res["type"], "video")
-        self.assertEqual(res["download_url"], url)
+        self.assertNotIn("download_url", res)
+        self.assertNotIn(url, json.dumps(res))
+        self.assertEqual(
+            _video_jobs.lookup("bgvid1", "seedance-2-0-text-to-video"), url
+        )
         self.assertEqual(os.listdir(self.td), [])
 
 
@@ -847,23 +866,33 @@ class TestJobResultTool(_ToolTest):
             seen.append(req.full_url)
             if req.full_url.endswith("/video/retrieve"):
                 return FakeResp(200, json.dumps({"status": "COMPLETED"}).encode())
-            if url in req.full_url:
-                return FakeResp(200, b"PRESIGNEDMP4", "video/mp4")
             if req.full_url.endswith("/video/complete"):
                 return FakeResp(200, b'{"ok": true}')
             raise AssertionError(f"unexpected: {req.full_url}")
 
+        _video_jobs.remember("vpsq1", "seedance-2-0-text-to-video", url)
+
+        def fake_download(client, value, directory, **kwargs):
+            seen.append(value)
+            path = Path(directory) / ".video.tmp"
+            path.write_bytes(b"PRESIGNEDMP4")
+            return "video/mp4", path, len(b"PRESIGNEDMP4")
+
         with mock.patch("venice.client.urllib.request.urlopen", fake), \
+             mock.patch("venice.client.VeniceClient.download_url_to_temp", fake_download), \
              mock.patch.dict(os.environ, {"VENICE_MCP_OUTPUT_DIR": self.td}), \
              self.stdout_guard():
             res = _mcp.job_result_tool(
                 _client(), queue_id="vpsq1", type="video",
-                model="seedance-2-0-text-to-video", download_url=url,
+                model="seedance-2-0-text-to-video",
             )
         self.assertEqual(res["status"], "ok")
         self.assertEqual(Path(res["path"]).read_bytes(), b"PRESIGNEDMP4")
         self.assertTrue(res["path"].endswith(".mp4"))
         self.assertIn(url, seen)
+        self.assertIsNone(
+            _video_jobs.lookup("vpsq1", "seedance-2-0-text-to-video")
+        )
 
     def test_video_completed_without_download_url_is_error(self):
         responses = _seq(FakeResp(200, json.dumps({"status": "COMPLETED"}).encode()))

--- a/tests/test_video.py
+++ b/tests/test_video.py
@@ -5,6 +5,7 @@ to resolve the default model (mirrors test_chat.py's catalog mock).
 """
 import argparse
 import base64
+import io
 import json
 import os
 import tempfile
@@ -77,6 +78,12 @@ class TestVideoFlow(unittest.TestCase):
         self.tmp = tempfile.TemporaryDirectory()
         self.cwd = os.getcwd()
         os.chdir(self.tmp.name)
+        self.jobs_file = str(Path(self.tmp.name) / "video_jobs.json")
+        _jobs = mock.patch.dict(
+            os.environ, {config.ENV_VIDEO_JOBS_FILE: self.jobs_file}
+        )
+        _jobs.start()
+        self.addCleanup(_jobs.stop)
 
     def tearDown(self):
         os.chdir(self.cwd)
@@ -142,7 +149,6 @@ class TestVideoFlow(unittest.TestCase):
                 }).encode(),
                 "application/json",
             ),
-            FakeResp(200, b"PRESIGNEDMP4", "video/mp4"),
             FakeResp(200, b'{"success": true}', "application/json"),
         ])
         seen = []
@@ -151,8 +157,15 @@ class TestVideoFlow(unittest.TestCase):
             seen.append(req.full_url)
             return next(responses)
 
+        def fake_download(client, value, directory, **kwargs):
+            seen.append(value)
+            path = Path(directory) / ".download.tmp"
+            path.write_bytes(b"PRESIGNEDMP4")
+            return "video/mp4", path, len(b"PRESIGNEDMP4")
+
         with mock.patch.dict(os.environ, {"VENICE_API_KEY": "fake"}), \
              mock.patch("venice.client.urllib.request.urlopen", fake_urlopen), \
+             mock.patch("venice.client.VeniceClient.download_url_to_temp", fake_download), \
              mock.patch("venice.client.time.sleep"):
             rc = video._run_generate(_build_args())
 
@@ -160,7 +173,7 @@ class TestVideoFlow(unittest.TestCase):
         written = sorted(Path(".").glob("venice-video-*.mp4"))
         self.assertEqual(len(written), 1, f"expected 1 mp4, got {written}")
         self.assertEqual(written[0].read_bytes(), b"PRESIGNEDMP4")
-        # the presigned URL was fetched verbatim (no base_url prefix)
+        # The queue-issued URL reaches only the guarded downloader seam.
         self.assertIn(url, seen)
 
     def test_dry_run_quotes_and_exits_zero(self):
@@ -206,6 +219,30 @@ class TestVideoFlow(unittest.TestCase):
         self.assertEqual(rc, 0)
         writes = "".join(c.args[0] for c in out.write.call_args_list)
         self.assertIn("BGVID99999", writes)
+
+    def test_background_vps_url_is_stored_but_never_printed(self):
+        from venice.commands import _video_jobs, video
+
+        url = "https://cdn.example/video?signature=transcript-secret"
+        responses = iter([
+            _catalog(DEFAULT_MODEL),
+            FakeResp(200, b'{"quote": 0.5}', "application/json"),
+            FakeResp(200, json.dumps({
+                "queue_id": "BGVPS12345", "download_url": url,
+            }).encode(), "application/json"),
+        ])
+        stdout = io.StringIO()
+        stderr = io.StringIO()
+        with mock.patch.dict(os.environ, {"VENICE_API_KEY": "fake"}), \
+             mock.patch("venice.client.urllib.request.urlopen", lambda *a, **kw: next(responses)), \
+             mock.patch("sys.stdout", stdout), mock.patch("sys.stderr", stderr):
+            rc = video._run_generate(_build_args(background=True))
+
+        self.assertEqual(rc, 0)
+        self.assertIn("BGVPS12345", stdout.getvalue())
+        self.assertNotIn(url, stdout.getvalue() + stderr.getvalue())
+        self.assertNotIn("transcript-secret", stdout.getvalue() + stderr.getvalue())
+        self.assertEqual(_video_jobs.lookup("BGVPS12345", DEFAULT_MODEL), url)
 
     def test_unknown_model_returns_exit_6(self):
         from venice.commands import video

--- a/tests/test_video_jobs.py
+++ b/tests/test_video_jobs.py
@@ -1,0 +1,87 @@
+"""Private background-video registry tests (#140)."""
+import json
+import os
+import stat
+import tempfile
+import unittest
+from pathlib import Path
+from unittest import mock
+
+from venice import config
+from venice.commands import _video_jobs
+
+
+class TestVideoJobRegistry(unittest.TestCase):
+    def setUp(self):
+        self.tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(self.tmp.cleanup)
+        self.path = Path(self.tmp.name) / "jobs.json"
+        env = mock.patch.dict(
+            os.environ, {config.ENV_VIDEO_JOBS_FILE: str(self.path)}
+        )
+        env.start()
+        self.addCleanup(env.stop)
+
+    def test_round_trip_is_mode_0600_and_bound_to_queue_and_model(self):
+        url = "https://cdn.example/video?signature=secret"
+        _video_jobs.remember("queue-1", "model-a", url)
+        self.assertEqual(stat.S_IMODE(self.path.stat().st_mode), 0o600)
+        self.assertEqual(_video_jobs.lookup("queue-1", "model-a"), url)
+        self.assertIsNone(_video_jobs.lookup("queue-1", "model-b"))
+        self.assertIsNone(_video_jobs.lookup("queue-2", "model-a"))
+
+    def test_forget_removes_only_the_exact_binding(self):
+        _video_jobs.remember("queue-1", "model-a", "https://a.example/v?x=1")
+        _video_jobs.remember("queue-2", "model-a", "https://b.example/v?x=2")
+        _video_jobs.forget("queue-1", "model-a")
+        self.assertIsNone(_video_jobs.lookup("queue-1", "model-a"))
+        self.assertIsNotNone(_video_jobs.lookup("queue-2", "model-a"))
+
+    def test_expired_entries_are_pruned_lazily(self):
+        with mock.patch("venice.commands._video_jobs.time.time", return_value=100.0):
+            _video_jobs.remember("old", "m", "https://old.example/v?secret=x")
+        with mock.patch(
+            "venice.commands._video_jobs.time.time",
+            return_value=100.0 + _video_jobs.MAX_AGE_SECONDS + 1,
+        ):
+            self.assertIsNone(_video_jobs.lookup("old", "m"))
+        self.assertEqual(json.loads(self.path.read_text())["jobs"], {})
+
+    def test_registry_is_bounded_to_newest_entries(self):
+        with mock.patch.object(_video_jobs, "MAX_JOBS", 2):
+            for i in range(3):
+                with mock.patch(
+                    "venice.commands._video_jobs.time.time", return_value=float(i + 1)
+                ):
+                    _video_jobs.remember(
+                        f"q{i}", "m", f"https://cdn.example/{i}?signature=secret"
+                    )
+        with mock.patch("venice.commands._video_jobs.time.time", return_value=3.0):
+            self.assertIsNone(_video_jobs.lookup("q0", "m"))
+            self.assertIsNotNone(_video_jobs.lookup("q1", "m"))
+            self.assertIsNotNone(_video_jobs.lookup("q2", "m"))
+
+    def test_malformed_store_fails_closed_without_overwrite(self):
+        self.path.write_text("not json", encoding="utf-8")
+        before = self.path.read_bytes()
+        with self.assertRaises(_video_jobs.VideoJobStoreError):
+            _video_jobs.remember("q", "m", "https://cdn.example/v?secret=x")
+        self.assertEqual(self.path.read_bytes(), before)
+
+    def test_non_https_url_is_rejected_without_storing_or_disclosing_query(self):
+        url = "http://127.0.0.1/private?signature=secret"
+        with self.assertRaises(_video_jobs.VideoJobStoreError) as cm:
+            _video_jobs.remember("q", "m", url)
+        self.assertFalse(self.path.exists())
+        self.assertNotIn("signature", str(cm.exception))
+        self.assertNotIn("secret", str(cm.exception))
+
+    def test_custom_parent_permissions_are_not_changed(self):
+        parent = self.path.parent
+        parent.chmod(0o755)
+        _video_jobs.remember("q", "m", "https://cdn.example/v?secret=x")
+        self.assertEqual(stat.S_IMODE(parent.stat().st_mode), 0o755)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- replace arbitrary video URL fetching with a pinned public-HTTPS transport that rejects local/private/special destinations on initial resolution and every redirect
- stream bounded video responses into private temporary files and redact signed URL credentials from errors
- bind VPS background jobs to server-issued URLs in a private local registry while removing the URL from MCP and agent contracts
- document the boundary and add hermetic SSRF, rebinding, redirect, size, media-type, registry, and disclosure tests

## Validation

- `VENICE_API_KEY=test-fake-key make test`
- `VENICE_API_KEY=test-fake-key make drive` (37 tests)
- affected unit suite (388 tests)
- `make lint`
- `make scan`
- `git diff --check`

No live Venice endpoint or real credential was used.

Closes #140.