### PR TITLE
v0.83: reject non-finite spend and polling inputs

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,7 +163,11 @@ After charge:   $32.69 USD
 Suppress with `--no-balance`, or set `defaults.no_balance` once to suppress it
 everywhere (`--show-balance` re-enables it for a single run). Hard-cap a single call
 with `--max-spend USD` (refuses to queue / synthesize if the estimate exceeds
-the cap).
+the cap). Caps and polling durations must be finite numbers; `NaN` and infinity
+are rejected before any paid request. When an endpoint has no reliable upfront
+estimate, supplying `--max-spend` fails closed instead of treating the cap as
+unmetered; use the ordinary confirmation prompt or `--yes` without a cap if you
+accept that endpoint's dynamic price.
 
 ## Sound effects
 

--- a/src/venice/_numeric.py
+++ b/src/venice/_numeric.py
@@ -1,0 +1,30 @@
+"""Strict numeric coercion shared by CLI, config, MCP, and client rails."""
+from __future__ import annotations
+
+import math
+
+
+def finite_float(value) -> float:
+    """Return *value* as a finite float, rejecting booleans and JSON extensions."""
+    if isinstance(value, bool):
+        raise ValueError("must be a finite number")
+    try:
+        number = float(value)
+    except (TypeError, ValueError):
+        raise ValueError("must be a finite number") from None
+    if not math.isfinite(number):
+        raise ValueError("must be finite")
+    return number
+
+
+def non_negative_float(value) -> float:
+    """Return a finite float greater than or equal to zero."""
+    number = finite_float(value)
+    if number < 0:
+        raise ValueError("must be >= 0")
+    return number
+
+
+def reject_json_constant(value: str):
+    """Reject Python's non-standard JSON NaN/Infinity extensions on input."""
+    raise ValueError(f"non-finite JSON number {value!r} is not permitted")

--- a/src/venice/audio_post.py
+++ b/src/venice/audio_post.py
@@ -14,7 +14,7 @@ import sys
 from pathlib import Path
 from typing import List, Optional
 
-from . import userconfig
+from . import _numeric, userconfig
 
 _CODECS = {16: "pcm_s16le", 24: "pcm_s24le", 32: "pcm_s32le"}
 
@@ -71,13 +71,17 @@ def add_master_flags(parser, *, include_toggle: bool) -> None:
     # them; the literals go back on in `apply_master_literals`. They are GLOBAL
     # config keys, not per-command ones, because this one chain is shared by
     # three commands -- `defaults.<cmd>.<knob>` still overrides (see _GLOBAL_MAP).
-    parser.add_argument("--lufs", type=float, default=None, metavar="LUFS",
-                        help=f"Integrated loudness target (default {DEFAULT_LUFS:g}). "
-                             "Config-backable via defaults.lufs.")
-    parser.add_argument("--true-peak", type=float, default=None, dest="true_peak",
-                        metavar="DBTP",
-                        help=f"True-peak ceiling in dBTP (default {DEFAULT_TRUE_PEAK:g}). "
-                             "Config-backable via defaults.true_peak.")
+    parser.add_argument(
+        "--lufs", type=_numeric.finite_float, default=None, metavar="LUFS",
+        help=f"Integrated loudness target (default {DEFAULT_LUFS:g}). "
+             "Config-backable via defaults.lufs.",
+    )
+    parser.add_argument(
+        "--true-peak", type=_numeric.finite_float, default=None, dest="true_peak",
+        metavar="DBTP",
+        help=f"True-peak ceiling in dBTP (default {DEFAULT_TRUE_PEAK:g}). "
+             "Config-backable via defaults.true_peak.",
+    )
     parser.add_argument("--sample-rate", type=int, default=None, dest="sample_rate",
                         metavar="HZ",
                         help=f"Output sample rate (default {DEFAULT_SAMPLE_RATE}). "
@@ -90,7 +94,7 @@ def add_master_flags(parser, *, include_toggle: bool) -> None:
                         help="Make it seamlessly loopable (crossfade tail into head). "
                              "Config-backable via defaults.{master,sfx,music}.loop; an "
                              "explicit --loop/--no-loop still wins.")
-    parser.add_argument("--loop-crossfade", type=float, default=None,
+    parser.add_argument("--loop-crossfade", type=_numeric.finite_float, default=None,
                         dest="loop_crossfade", metavar="SEC",
                         help="Loop crossfade length in seconds (default "
                              f"{DEFAULT_LOOP_CROSSFADE:g}). Config-backable via "

--- a/src/venice/client.py
+++ b/src/venice/client.py
@@ -16,7 +16,7 @@ import urllib.request
 from pathlib import Path
 from typing import Any, Callable, Optional, Tuple, Union
 
-from . import __version__, _egress, config
+from . import __version__, _egress, _numeric, config
 
 
 VIDEO_DOWNLOAD_MAX_BYTES = 512 * 1024 * 1024
@@ -87,7 +87,12 @@ class VeniceClient:
         }
         data: Optional[bytes] = None
         if json_body is not None:
-            data = json.dumps(json_body).encode("utf-8")
+            try:
+                data = json.dumps(json_body, allow_nan=False).encode("utf-8")
+            except (TypeError, ValueError) as e:
+                raise VeniceAPIError(
+                    0, path, f"request body is not valid strict JSON: {e}"
+                ) from None
             headers["Content-Type"] = "application/json"
 
         req = urllib.request.Request(url, data=data, headers=headers, method=method)
@@ -169,6 +174,8 @@ class VeniceClient:
         Raises VeniceAPIError on terminal HTTP errors or an unexpected status.
         Raises TimeoutError if max_wait elapses while still PROCESSING.
         """
+        interval = _numeric.finite_float(interval)
+        max_wait = _numeric.finite_float(max_wait)
         deadline = time.monotonic() + max_wait
         while True:
             ctype, payload = self.post_for_bytes_or_json(path, body)

--- a/src/venice/commands/_agent.py
+++ b/src/venice/commands/_agent.py
@@ -39,6 +39,7 @@ from typing import Callable, Dict, List, NamedTuple, Optional, Tuple
 
 # Aliased: a bare `config` would be shadowed by the `config=None` keyword argument
 # that `browser_tools` (and its callers) already take further down this module.
+from .. import _numeric
 from .. import config as _config
 from .. import userconfig
 from . import _exec
@@ -178,8 +179,11 @@ def _usd_per_token(pricing, key) -> Optional[float]:
     if not isinstance(pricing, dict):
         return None
     node = pricing.get(key)
-    if isinstance(node, dict) and isinstance(node.get("usd"), (int, float)):
-        return float(node["usd"]) / 1_000_000.0
+    if isinstance(node, dict) and "usd" in node:
+        try:
+            return _numeric.non_negative_float(node["usd"]) / 1_000_000.0
+        except ValueError:
+            raise ValueError(f"invalid catalog pricing for {key}") from None
     return None
 
 
@@ -191,7 +195,10 @@ def _as_int(v) -> int:
     if isinstance(v, bool):
         return 0
     if isinstance(v, (int, float)):
-        return int(v) if v > 0 else 0
+        try:
+            return int(_numeric.non_negative_float(v)) if v > 0 else 0
+        except (OverflowError, ValueError):
+            return 0
     return 0
 
 
@@ -204,7 +211,10 @@ def _as_float(v) -> float:
     if isinstance(v, bool):
         return 0.0
     if isinstance(v, (int, float)):
-        return float(v) if v > 0 else 0.0
+        try:
+            return _numeric.non_negative_float(v) if v > 0 else 0.0
+        except ValueError:
+            return 0.0
     return 0.0
 
 
@@ -295,9 +305,15 @@ def _dump_raw_usage(usage) -> None:
         return
     try:
         raw = usage.model_dump() if hasattr(usage, "model_dump") else usage
-        line = json.dumps(raw, sort_keys=True, default=str)
+        line = json.dumps(raw, sort_keys=True, default=str, allow_nan=False)
     except Exception:  # noqa: BLE001 - a diagnostic must never break the turn
-        line = repr(usage)
+        try:
+            normalized = (
+                {str(k): v for k, v in raw.items()} if isinstance(raw, dict) else raw
+            )
+            line = json.dumps(normalized, default=str, allow_nan=False)
+        except Exception:  # noqa: BLE001 - same diagnostic-only boundary
+            line = "<usage is not valid strict JSON>"
     print(f"usage-raw: {line}", file=sys.stderr)
 
 
@@ -341,7 +357,7 @@ class CostLedger:
     def __init__(self, max_spend: Optional[float] = None,
                  max_tokens: Optional[int] = None, *, mirror=None):
         # A non-positive cap means "uncapped" (mirrors --max-tool-calls 0).
-        cap = float(max_spend) if max_spend is not None else None
+        cap = _numeric.finite_float(max_spend) if max_spend is not None else None
         self.max_spend = cap if (cap is not None and cap > 0) else None
         # #52: an orthogonal cumulative *token* ceiling (prompt+completion), used by
         # per-subagent runs (`--subagent-max-tokens`). Same non-positive->None rule.
@@ -460,6 +476,7 @@ class CostLedger:
         self._out = None         # per-token output rate (USD)
         self._cache_in = None    # per-token cache-read rate (USD); None -> use _in
         self._cache_write = None  # per-token cache-write rate (USD); None -> use _in
+        self.invalid_pricing = False
 
     def bind_pricing(self, pricing) -> None:
         """Set the per-token rates from a catalog `model_spec.pricing` block.
@@ -467,10 +484,15 @@ class CostLedger:
         `cache_input`/`cache_write` are optional (present only for cache-capable
         models); left None they fall back to the plain input rate at cost time.
         """
-        self._in = _usd_per_token(pricing, "input")
-        self._out = _usd_per_token(pricing, "output")
-        self._cache_in = _usd_per_token(pricing, "cache_input")
-        self._cache_write = _usd_per_token(pricing, "cache_write")
+        self.invalid_pricing = False
+        try:
+            self._in = _usd_per_token(pricing, "input")
+            self._out = _usd_per_token(pricing, "output")
+            self._cache_in = _usd_per_token(pricing, "cache_input")
+            self._cache_write = _usd_per_token(pricing, "cache_write")
+        except ValueError:
+            self._in = self._out = self._cache_in = self._cache_write = None
+            self.invalid_pricing = True
 
     def to_dict(self) -> dict:
         """Serialize the running accumulators for cross-resume persistence (#47/#75).
@@ -790,7 +812,7 @@ class CostLedger:
             # sticky marker or `0 in  0 out  $0.0000` would read as a measurement.
             if unreported:
                 row["unreported"] = True
-            row["cost"] += cost
+            row["cost"] += _as_float(cost)
             row["prompt_tokens"] += _as_int(prompt_tokens)
             row["completion_tokens"] += _as_int(completion_tokens)
             # Rounded on the way in like `record_turn`'s; an unstamped window adds 0.
@@ -802,14 +824,14 @@ class CostLedger:
     def bucket_cost(self, name=None) -> float:
         """Off-loop spend (#101): one bucket's cost, or every bucket's when `name` is None."""
         if name is not None:
-            return float(self.buckets.get(name, {}).get("cost", 0.0))
+            return _as_float(self.buckets.get(name, {}).get("cost", 0.0))
         # #117: snapshot under the lock. A mirrored child adds a NEW KEY on a pool
         # worker, and iterating a dict while another thread inserts into it raises
         # outright. Reads happen on the main thread while workers are joined today, so
         # this is insurance rather than a live fix -- but it is two lines.
         with self._buckets_lock:
             rows = list(self.buckets.values())
-        return sum(float(b.get("cost", 0.0)) for b in rows)
+        return sum(_as_float(b.get("cost", 0.0)) for b in rows)
 
     def bucket_calls(self, name=None) -> int:
         """Off-loop API calls (#101) -- deliberately NOT part of `api_calls_total`."""
@@ -1069,7 +1091,9 @@ class CostLedger:
         (compaction today) and not just the main loop. Still monotonic -- both terms
         only grow -- so a gate that has tripped stays tripped.
         """
-        return self.max_spend is not None and self.billed_total() >= self.max_spend
+        return self.max_spend is not None and (
+            self.invalid_pricing or self.billed_total() >= self.max_spend
+        )
 
     def over_tokens(self) -> bool:
         """True when cumulative prompt+completion tokens reached/exceeded the cap.
@@ -3065,7 +3089,7 @@ def _dispatch_parallel(
                 "role": "tool",
                 "tool_call_id": tc.id,
                 "name": tc.function.name,
-                "content": json.dumps(results[i], default=str),
+                "content": json.dumps(results[i], default=str, allow_nan=False),
             }
         )
     return calls_made + min(slots, n)
@@ -3073,7 +3097,9 @@ def _dispatch_parallel(
 
 def _emit_final(resp, json_out: bool) -> int:
     if json_out:
-        json.dump(resp.model_dump(), sys.stdout, indent=2, default=str)
+        json.dump(
+            resp.model_dump(), sys.stdout, indent=2, default=str, allow_nan=False
+        )
         sys.stdout.write("\n")
         return 0
     content = ""
@@ -3183,6 +3209,13 @@ def run_loop(
                     "content": "[steering message received mid-run]\n" + _steer,
                 })
         # Spend gate (#66): don't start a new paid turn once the cap is hit.
+        if ledger is not None and ledger.invalid_pricing:
+            print(
+                "chat: model catalog contains invalid non-finite pricing; "
+                "refusing to start a paid turn",
+                file=sys.stderr,
+            )
+            return 2
         if ledger is not None and ledger.over():
             return _force_final(
                 f"chat: reached --max-spend ({ledger.summary()}); "
@@ -3258,7 +3291,7 @@ def run_loop(
                         "role": "tool",
                         "tool_call_id": tc.id,
                         "name": tc.function.name,
-                        "content": json.dumps(result, default=str),
+                        "content": json.dumps(result, default=str, allow_nan=False),
                     }
                 )
 

--- a/src/venice/commands/_code.py
+++ b/src/venice/commands/_code.py
@@ -45,6 +45,7 @@ import threading
 from pathlib import Path
 from typing import List, Optional
 
+from .. import _numeric
 from . import _agent, _exec, _index, _mcp, _memory, _shared
 from ._exec import (  # shared exec rails (#33): one gate for `code` and chat --shell
     DEFAULT_EXEC_TIMEOUT,
@@ -1246,8 +1247,18 @@ def _meter(tool: _agent.Tool, cap: float, spent: list) -> _agent.Tool:
         result = inner(arguments, confirm=confirm)
         if isinstance(result, dict):
             c = result.get("cost_estimate_usd")
-            if isinstance(c, (int, float)) and not isinstance(c, bool) and c > 0:
-                spent[0] += float(c)
+            if c is not None:
+                try:
+                    spent[0] += _numeric.non_negative_float(c)
+                except ValueError:
+                    spent[0] = cap
+                    return {
+                        "status": "error",
+                        "message": (
+                            "spawn: paid tool returned an invalid cost estimate; "
+                            "the worker spend cap is closed"
+                        ),
+                    }
         return result
 
     return dataclasses.replace(tool, invoke=metered)
@@ -1350,6 +1361,10 @@ def spawn_tool(oai, model, base_kwargs, parent_tools, *,
         # Per-worker USD media cap: wrap each paid tool in a spend meter sharing one
         # accumulator. `<= 0` disables (identity pass-through == pre-slice behavior).
         raw = _SPAWN_MAX_SPEND if max_spend is None else max_spend
+        try:
+            raw = _numeric.finite_float(raw)
+        except ValueError as e:
+            return _err(f"spawn: invalid max_spend: {e}")
         cap = None if raw <= 0 else float(raw)
         spent = [0.0]
         if cap is not None:
@@ -1487,8 +1502,12 @@ def merge_summary(dispatches: List[dict]) -> dict:
         if tid is not None and str(tid) not in known:
             warnings.append(f"{tag} references unknown task_id {str(tid)!r}")
         c = d.get("spent_usd")
-        if isinstance(c, (int, float)) and not isinstance(c, bool):
-            spent += float(c)
+        if c is not None:
+            try:
+                spent += _numeric.non_negative_float(c)
+            except ValueError:
+                errors += 1
+                warnings.append(f"{tag} reported invalid non-finite spend")
         n = d.get("tokens")
         if isinstance(n, int) and not isinstance(n, bool):
             tok += n

--- a/src/venice/commands/_mcp.py
+++ b/src/venice/commands/_mcp.py
@@ -23,6 +23,7 @@ from pathlib import Path
 from types import SimpleNamespace
 from typing import List, Optional
 
+from .. import _numeric
 from ..client import VeniceAPIError
 from . import (
     _audio, _browser, _index, _memory, _models, _openai, _queue, _shared,
@@ -68,16 +69,10 @@ DEFAULT_MCP_MAX_SPEND = 0.10  # USD: auto-approve ceiling for a single tool call
 def resolve_max_spend(max_spend: Optional[float]) -> float:
     """Cap precedence: explicit arg -> $VENICE_MCP_MAX_SPEND -> DEFAULT."""
     if max_spend is not None:
-        try:
-            return float(max_spend)
-        except (TypeError, ValueError):
-            pass
+        return _numeric.non_negative_float(max_spend)
     env = os.environ.get("VENICE_MCP_MAX_SPEND")
     if env:
-        try:
-            return float(env)
-        except ValueError:
-            pass
+        return _numeric.non_negative_float(env)
     return DEFAULT_MCP_MAX_SPEND
 
 
@@ -90,9 +85,17 @@ def check_spend(
     cost is over the cap OR unknown (dynamic-priced upscale/bg-remove). Reuses
     `_shared.over_budget` for the comparison.
     """
+    try:
+        cap = resolve_max_spend(max_spend)
+    except ValueError as e:
+        return _err(f"{label}: invalid max_spend: {e}")
+    if cost is not None:
+        try:
+            cost = _numeric.non_negative_float(cost)
+        except ValueError as e:
+            return _err(f"{label}: invalid estimated cost: {e}")
     if confirm:
         return None
-    cap = resolve_max_spend(max_spend)
     if cost is None or _shared.over_budget(cost, cap):
         shown = f"${cost:.4f}" if cost is not None else "unknown"
         return {
@@ -211,8 +214,11 @@ def image_tool(
         )
 
     prompt = prompt.strip()
-    price = _image._fetch_image_price(client, model)
-    cost = _image._estimate_cost(price, variants)
+    try:
+        price = _image._fetch_image_price(client, model)
+        cost = _image._estimate_cost(price, variants)
+    except ValueError as e:
+        return _err(f"image: {e}")
     gate = check_spend(cost, confirm=confirm, max_spend=max_spend, label="image")
     if gate is not None:
         return gate
@@ -280,8 +286,11 @@ def tts_tool(
         return _err(f"tts: speed {speed} out of range (0.25-4.0)")
 
     text = text.strip()
-    price = _tts._fetch_tts_price_per_million(client, model)
-    cost = _tts._estimate_cost(len(text), price)
+    try:
+        price = _tts._fetch_tts_price_per_million(client, model)
+        cost = _tts._estimate_cost(len(text), price)
+    except ValueError as e:
+        return _err(f"tts: {e}")
     gate = check_spend(cost, confirm=confirm, max_spend=max_spend, label="tts")
     if gate is not None:
         return gate
@@ -341,6 +350,13 @@ def _queue_media(
     then return a `{"status": "queued", ...}` job handle *before* polling -- the
     caller fetches the file later via `venice_job_result`.
     """
+    try:
+        quote_value = _shared.quote_cost(quote_value)
+        max_wait = _numeric.non_negative_float(max_wait)
+        poll_interval = _numeric.non_negative_float(poll_interval)
+    except ValueError as e:
+        return _err(f"{label}: {e}")
+
     gate = check_spend(quote_value, confirm=confirm, max_spend=max_spend, label=label)
     if gate is not None:
         return gate
@@ -408,6 +424,10 @@ def sfx_tool(
     """
     if not prompt or not prompt.strip():
         return _err("sfx: prompt is required")
+    try:
+        max_wait = _numeric.non_negative_float(max_wait)
+    except ValueError as e:
+        return _err(f"sfx: invalid max_wait: {e}")
     if model not in _sfx.SFX_MODELS:
         return _err(f"sfx: unknown model {model!r}; choose from {', '.join(sorted(_sfx.SFX_MODELS))}")
 
@@ -459,6 +479,10 @@ def music_tool(
     """
     if not prompt or not prompt.strip():
         return _err("music: prompt is required")
+    try:
+        max_wait = _numeric.non_negative_float(max_wait)
+    except ValueError as e:
+        return _err(f"music: invalid max_wait: {e}")
 
     # NOTE: no `resolve_instrumental` here, deliberately. On this path a model's
     # explicit `instrumental=true` and an operator's defaults.music.instrumental
@@ -820,6 +844,10 @@ def video_tool(
     """
     if not prompt or not prompt.strip():
         return _err("video: prompt is required")
+    try:
+        max_wait = _numeric.non_negative_float(max_wait)
+    except ValueError as e:
+        return _err(f"video: invalid max_wait: {e}")
 
     ns = SimpleNamespace(
         image=image_url, end_image=end_image_url, video=video_url,
@@ -851,7 +879,10 @@ def video_tool(
         quote = client.post_json("/video/quote", quote_body)
     except VeniceAPIError as e:
         return _err(f"video quote rejected: {e}")
-    quote_value = quote.get("quote", quote)
+    try:
+        quote_value = _shared.quote_cost(quote)
+    except ValueError as e:
+        return _err(f"video: {e}")
 
     gate = check_spend(quote_value, confirm=confirm, max_spend=max_spend, label="video")
     if gate is not None:
@@ -1005,6 +1036,10 @@ def job_result_tool(
     """
     if not queue_id:
         return _err("job_result: queue_id is required")
+    try:
+        max_wait = _numeric.non_negative_float(max_wait)
+    except ValueError as e:
+        return _err(f"job_result: invalid max_wait: {e}")
     base = _job_route(type)
     if base is None:
         return _err(

--- a/src/venice/commands/_mcp_client.py
+++ b/src/venice/commands/_mcp_client.py
@@ -42,7 +42,7 @@ import sys
 import threading
 from typing import Dict, List, Optional, Tuple
 
-from .. import auth
+from .. import _numeric, auth
 from .. import userconfig
 from . import _agent
 
@@ -213,17 +213,11 @@ def _safe_errlog():
 
 def _resolve_timeout(explicit, env_name: str, default: float) -> float:
     if explicit is not None:
-        try:
-            return float(explicit)
-        except (TypeError, ValueError):
-            pass
+        return _numeric.non_negative_float(explicit)
     env = os.environ.get(env_name)
     if env:
-        try:
-            return float(env)
-        except ValueError:
-            pass
-    return default
+        return _numeric.non_negative_float(env)
+    return _numeric.non_negative_float(default)
 
 
 # --------------------------------------------------------------------------- #

--- a/src/venice/commands/_repl.py
+++ b/src/venice/commands/_repl.py
@@ -99,7 +99,8 @@ def _load_transcript(path: str) -> List[dict]:
 
 def _save_transcript(path: str, messages: List[dict]) -> None:
     Path(path).write_text(
-        json.dumps(messages, indent=2, default=str) + "\n", encoding="utf-8"
+        json.dumps(messages, indent=2, default=str, allow_nan=False) + "\n",
+        encoding="utf-8",
     )
 
 

--- a/src/venice/commands/_session.py
+++ b/src/venice/commands/_session.py
@@ -27,7 +27,7 @@ from datetime import datetime, timezone
 from pathlib import Path
 from typing import List, Optional, Tuple
 
-from .. import config
+from .. import _numeric, config
 from . import _index
 
 SESSION_VERSION = 1
@@ -162,7 +162,7 @@ def _read_json(path: str):
     except OSError as e:
         raise SessionError(f"cannot read session {path}: {e}")
     try:
-        return json.loads(raw)
+        return json.loads(raw, parse_constant=_numeric.reject_json_constant)
     except ValueError as e:
         raise SessionError(f"invalid session JSON in {path}: {e}")
 
@@ -244,15 +244,19 @@ def save(session: Session) -> Path:
     fd = os.open(str(tmp), os.O_WRONLY | os.O_CREAT | os.O_TRUNC, 0o600)
     try:
         with os.fdopen(fd, "w", encoding="utf-8") as f:
-            json.dump(session.to_envelope(), f, indent=2, default=str)
+            json.dump(
+                session.to_envelope(), f, indent=2, default=str, allow_nan=False
+            )
             f.write("\n")
             f.flush()
             os.fsync(f.fileno())
-    except Exception:
+    except Exception as e:
         try:
             os.unlink(tmp)
         except OSError:
             pass
+        if isinstance(e, ValueError):
+            raise OSError(f"session contains invalid non-finite JSON: {e}") from None
         raise
     os.replace(tmp, path)
     try:
@@ -270,7 +274,10 @@ def _iter_sessions():
         return
     for entry in entries:
         try:
-            data = json.loads(entry.read_text(encoding="utf-8"))
+            data = json.loads(
+                entry.read_text(encoding="utf-8"),
+                parse_constant=_numeric.reject_json_constant,
+            )
         except (OSError, ValueError):
             continue
         if not isinstance(data, dict):

--- a/src/venice/commands/_shared.py
+++ b/src/venice/commands/_shared.py
@@ -15,7 +15,7 @@ import sys
 from pathlib import Path
 from typing import Callable, Iterable, List, Optional, Tuple, Union
 
-from .. import billing
+from .. import _numeric, billing
 from ..client import VeniceAPIError
 from . import _index
 
@@ -220,13 +220,13 @@ def add_poll_flags(parser, *, section: str, interval: float, max_wait: float) ->
     fixed by those impls and stays CLI-only (the `no_cleanup` precedent).
     """
     parser.add_argument(
-        "--poll-interval", type=float, default=None, metavar="SEC",
+        "--poll-interval", type=_numeric.finite_float, default=None, metavar="SEC",
         help=f"Seconds between status polls (default {interval:g}). "
              f"Config-backable via defaults.{section}.poll_interval (CLI only -- "
              "the agent/MCP tools fix their own cadence).",
     )
     parser.add_argument(
-        "--max-wait", type=float, default=None, metavar="SEC",
+        "--max-wait", type=_numeric.finite_float, default=None, metavar="SEC",
         help=f"Give up waiting after this many seconds (default {max_wait:g}). "
              f"Config-backable via defaults.{section}.max_wait, which the "
              f"venice_{section} agent/MCP tool honors too.",
@@ -257,6 +257,8 @@ def resolve_poll(poll_interval, max_wait, *, label: str,
         poll_interval = interval
     if max_wait is None:
         max_wait = max_wait_default
+    poll_interval = _numeric.finite_float(poll_interval)
+    max_wait = _numeric.finite_float(max_wait)
     if poll_interval < 0:
         print(f"{label}: --poll-interval must be >= 0; using {interval:g}",
               file=sys.stderr)
@@ -352,12 +354,25 @@ def print_balance_and_remaining(client, cost: Optional[float], *, show: bool) ->
 
 
 def over_budget(cost: Optional[float], max_spend: Optional[float]) -> bool:
-    if max_spend is None or cost is None:
+    if max_spend is None:
         return False
+    cap = _numeric.non_negative_float(max_spend)
+    if cost is None:
+        return True
+    return _numeric.non_negative_float(cost) > cap
+
+
+def quote_cost(payload) -> float:
+    """Extract a finite, non-negative cost from a quote response."""
+    raw = (
+        payload.get("quote")
+        if isinstance(payload, dict) and "quote" in payload
+        else payload
+    )
     try:
-        return float(cost) > float(max_spend)
-    except (TypeError, ValueError):
-        return False
+        return _numeric.non_negative_float(raw)
+    except ValueError:
+        raise ValueError("quote response did not contain a finite non-negative cost") from None
 
 
 def confirm_or_exit(yes: bool) -> Optional[int]:

--- a/src/venice/commands/balance.py
+++ b/src/venice/commands/balance.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 import json
 import sys
 
-from .. import auth, userconfig
+from .. import _numeric, auth, userconfig
 from ..billing import SPEND_ORDER, fetch_balance, format_balance_breakdown, format_usd
 from ..client import VeniceAPIError
 
@@ -34,7 +34,7 @@ def register(subparsers) -> None:
     )
     p.add_argument(
         "--min",
-        type=float,
+        type=_numeric.finite_float,
         default=None,
         metavar="USD",
         help="Exit 1 if balance is below this USD threshold. Config-backable "
@@ -96,6 +96,7 @@ def _run(args) -> int:
             },
             sys.stdout,
             indent=2,
+            allow_nan=False,
         )
         sys.stdout.write("\n")
     elif args.verbose:

--- a/src/venice/commands/bg_remove.py
+++ b/src/venice/commands/bg_remove.py
@@ -13,7 +13,7 @@ import sys
 from pathlib import Path
 from typing import Optional
 
-from .. import auth, userconfig
+from .. import _numeric, auth, userconfig
 from ..client import build_client_from_auth
 from ._shared import (
     add_balance_flag,
@@ -55,7 +55,7 @@ def register(subparsers) -> None:
                    help="Show the planned output and exit; don't call the API.")
     p.add_argument(
         "--max-spend",
-        type=float,
+        type=_numeric.non_negative_float,
         default=None,
         metavar="USD",
         help="Refuse if the estimated cost exceeds this cap. Note: bg-remove "
@@ -98,7 +98,11 @@ def _run(args) -> int:
     cost = None  # dynamic pricing -- no reliable upfront quote
     print_estimate(cost, "background removal; dynamic $0.001-$10.00/call")
     print_balance_and_remaining(client, cost, show=not args.no_balance)
-    if over_budget(cost, args.max_spend):  # no-op while cost is unknown
+    if over_budget(cost, args.max_spend):
+        print(
+            "bg-remove: dynamic price cannot be bounded by --max-spend; aborting",
+            file=sys.stderr,
+        )
         return 1
 
     default_name = (

--- a/src/venice/commands/chat.py
+++ b/src/venice/commands/chat.py
@@ -19,7 +19,7 @@ import time
 from pathlib import Path
 from typing import Optional
 
-from .. import auth, userconfig
+from .. import _numeric, auth, userconfig
 from ..client import build_client_from_auth
 from . import (
     _agent, _browser, _compact, _mcp, _mcp_client, _models, _openai, _persona,
@@ -64,7 +64,7 @@ def register(subparsers) -> None:
         default=None,
         help="Text model id (default: the catalog's 'default'-trait model).",
     )
-    p.add_argument("--temperature", "-t", type=float, default=None)
+    p.add_argument("--temperature", "-t", type=_numeric.finite_float, default=None)
     p.add_argument("--max-tokens", type=int, default=None, dest="max_tokens")
 
     stream_grp = p.add_mutually_exclusive_group()
@@ -177,12 +177,12 @@ def register(subparsers) -> None:
         "(default: 8; 0 = unlimited, run until the model stops).",
     )
     ag.add_argument(
-        "--max-spend", type=float, default=None, metavar="USD",
+        "--max-spend", type=_numeric.non_negative_float, default=None, metavar="USD",
         help="Per-call auto-approve cap for paid tools (default: $0.10 / "
         "$VENICE_MCP_MAX_SPEND). Over-cap calls prompt on a TTY.",
     )
     ag.add_argument(
-        "--session-max-spend", type=float, default=None, metavar="USD",
+        "--session-max-spend", type=_numeric.finite_float, default=None, metavar="USD",
         dest="session_max_spend",
         help="Cap total chat-completion spend for this session (#66). Meters the "
         "model's own calls (not just paid tools) from server token usage; at the "
@@ -678,7 +678,9 @@ def _run_agent(args, oai, openai, client, models, model, kwargs) -> Optional[int
 def _run_once(oai, kwargs: dict, as_json: bool) -> int:
     resp = oai.chat.completions.create(**kwargs)
     if as_json:
-        json.dump(resp.model_dump(), sys.stdout, indent=2, default=str)
+        json.dump(
+            resp.model_dump(), sys.stdout, indent=2, default=str, allow_nan=False
+        )
         sys.stdout.write("\n")
         return 0
     content = ""

--- a/src/venice/commands/code.py
+++ b/src/venice/commands/code.py
@@ -39,7 +39,7 @@ import sys
 import time
 from typing import List, Optional
 
-from .. import auth, config, userconfig
+from .. import _numeric, auth, config, userconfig
 from ..client import build_client_from_auth
 from . import (_agent, _browser, _code, _compact, _mailbox, _models, _openai,
                _repl, _review, _session, _steer)
@@ -181,7 +181,7 @@ def register(subparsers) -> None:
         "--system", "-s", default=None,
         help="Extra project-specific instructions appended to the coding prompt.",
     )
-    p.add_argument("--temperature", "-t", type=float, default=None)
+    p.add_argument("--temperature", "-t", type=_numeric.finite_float, default=None)
     p.add_argument("--max-tokens", type=int, default=None, dest="max_tokens")
     p.add_argument(
         "--json", action="store_true",
@@ -302,7 +302,8 @@ def register(subparsers) -> None:
         "can't spawn further subagents or widen roots (#52).",
     )
     grp.add_argument(
-        "--spawn-max-spend", type=float, default=None, dest="spawn_max_spend",
+        "--spawn-max-spend", type=_numeric.finite_float, default=None,
+        dest="spawn_max_spend",
         metavar="USD",
         help="Per-worker USD cap on the cumulative estimated media spend of an 'asset' "
         "venice_spawn worker (default $2.00; <= 0 disables). A worker runs auto-approved, "
@@ -383,7 +384,7 @@ def register(subparsers) -> None:
         "runs stay within the context window (#48; costs a summarization call).",
     )
     grp.add_argument(
-        "--session-max-spend", type=float, default=None, metavar="USD",
+        "--session-max-spend", type=_numeric.finite_float, default=None, metavar="USD",
         dest="session_max_spend",
         help="Cap total chat-completion spend for this run (#66): meters the "
         "model's calls from server token usage and stops starting new turns at "
@@ -604,7 +605,7 @@ def _emit_plan_only(args, root, task, plan_text, *, usage=None) -> int:
         doc = {"root": root, "task": task, "plan": plan_text, "mode": "plan_only"}
         if usage is not None:
             doc["usage"] = usage  # #81: a plan turn is a real call and a real wait
-        json.dump(doc, sys.stdout, indent=2, default=str)
+        json.dump(doc, sys.stdout, indent=2, default=str, allow_nan=False)
         sys.stdout.write("\n")
     else:
         print(plan_text)  # the plan is the deliverable -> stdout
@@ -1076,7 +1077,7 @@ def _run_oneshot(args, oai, openai, model, tools, system, gen_kwargs, root, task
             envelope["planner"] = _code.merge_summary(dispatches)
         if unprocessed:  # #78: steers that arrived post-run (not fed to the model)
             envelope["unprocessed_steering"] = unprocessed
-        json.dump(envelope, sys.stdout, indent=2, default=str)
+        json.dump(envelope, sys.stdout, indent=2, default=str, allow_nan=False)
         sys.stdout.write("\n")
 
     return {None: 0, "pass": 0, "fail": 1, "unknown": 10}[verdict]

--- a/src/venice/commands/config.py
+++ b/src/venice/commands/config.py
@@ -12,7 +12,7 @@ exits 2 (the intermediate parser keeps its own default handler).
 import json
 import sys
 
-from .. import userconfig
+from .. import _numeric, userconfig
 
 
 def register(subparsers) -> None:
@@ -126,8 +126,12 @@ def _summary(entry) -> str:
 def _coerce_value(s: str):
     """JSON-parse a `set` value so numbers/bools/null get real types; fall back
     to the raw string for barewords like a model id."""
+    if s.strip().lower() in (
+        "nan", "infinity", "+infinity", "-infinity", "inf", "+inf", "-inf",
+    ):
+        raise ValueError("non-finite numbers are not permitted")
     try:
-        return json.loads(s)
+        return json.loads(s, parse_constant=_numeric.reject_json_constant)
     except ValueError:
         return s
 
@@ -176,7 +180,7 @@ def _run_add(args) -> int:
     userconfig.mcp_add(doc, args.name, entry)
     try:
         path = userconfig.save_config(doc)
-    except OSError as e:
+    except (OSError, ValueError) as e:
         print(f"config add: cannot write config: {e}", file=sys.stderr)
         return 9
     print(f"added MCP server {args.name!r} to {path}")
@@ -187,7 +191,7 @@ def _run_list(args) -> int:
     doc = userconfig.load_config()
     servers = userconfig.mcp_map(doc)
     if args.json:
-        print(json.dumps(servers, indent=2, sort_keys=True))
+        print(json.dumps(servers, indent=2, sort_keys=True, allow_nan=False))
         return 0
     if not servers:
         print("(no MCP servers registered)")
@@ -210,7 +214,7 @@ def _run_remove(args) -> int:
         return 2
     try:
         userconfig.save_config(doc)
-    except OSError as e:
+    except (OSError, ValueError) as e:
         print(f"config remove: cannot write config: {e}", file=sys.stderr)
         return 9
     print(f"removed MCP server {args.name!r}")
@@ -224,9 +228,9 @@ def _run_show(args) -> int:
         if entry is None:
             print(f"config show: no MCP server named {args.name!r}", file=sys.stderr)
             return 2
-        print(json.dumps(entry, indent=2, sort_keys=True))
+        print(json.dumps(entry, indent=2, sort_keys=True, allow_nan=False))
         return 0
-    print(json.dumps(doc, indent=2, sort_keys=True))
+    print(json.dumps(doc, indent=2, sort_keys=True, allow_nan=False))
     return 0
 
 
@@ -243,12 +247,16 @@ def _run_get(args) -> int:
     if isinstance(val, str):
         print(val)
     else:
-        print(json.dumps(val, indent=2, sort_keys=True))
+        print(json.dumps(val, indent=2, sort_keys=True, allow_nan=False))
     return 0
 
 
 def _run_set(args) -> int:
-    value = _coerce_value(args.value)
+    try:
+        value = _coerce_value(args.value)
+    except ValueError as e:
+        print(f"config set: {e}", file=sys.stderr)
+        return 2
     try:
         doc = userconfig.load_config_for_write()
         userconfig.set_value(doc, args.key, value)
@@ -257,10 +265,10 @@ def _run_set(args) -> int:
         return 2
     try:
         userconfig.save_config(doc)
-    except OSError as e:
+    except (OSError, ValueError) as e:
         print(f"config set: cannot write config: {e}", file=sys.stderr)
         return 9
-    print(f"set {args.key} = {json.dumps(value)}")
+    print(f"set {args.key} = {json.dumps(value, allow_nan=False)}")
     return 0
 
 
@@ -275,7 +283,7 @@ def _run_unset(args) -> int:
         return 2
     try:
         userconfig.save_config(doc)
-    except OSError as e:
+    except (OSError, ValueError) as e:
         print(f"config unset: cannot write config: {e}", file=sys.stderr)
         return 9
     print(f"unset {args.key}")

--- a/src/venice/commands/image.py
+++ b/src/venice/commands/image.py
@@ -29,7 +29,7 @@ import sys
 from pathlib import Path
 from typing import List, Optional, Tuple
 
-from .. import auth, billing, config, userconfig
+from .. import _numeric, auth, billing, config, userconfig
 from ..client import VeniceAPIError, build_client_from_auth
 from ._shared import (
     add_balance_flag as _add_balance_flag,
@@ -143,7 +143,7 @@ def register(subparsers) -> None:
                    help="What to exclude from the image.")
     p.add_argument("--seed", type=int, default=None,
                    help="Seed for reproducibility.")
-    p.add_argument("--cfg-scale", type=float, default=None, metavar="N",
+    p.add_argument("--cfg-scale", type=_numeric.finite_float, default=None, metavar="N",
                    help="Prompt adherence 0-20 (higher = stricter).")
     p.add_argument("--steps", type=int, default=None,
                    help="Inference steps (model-dependent).")
@@ -194,7 +194,7 @@ def register(subparsers) -> None:
                    help="Estimate cost and exit; don't call /image/generate.")
     p.add_argument(
         "--max-spend",
-        type=float,
+        type=_numeric.non_negative_float,
         default=None,
         metavar="USD",
         help="Refuse to generate if the estimated cost exceeds this USD cap.",
@@ -312,15 +312,15 @@ def _usd_from_pricing(pricing) -> Optional[float]:
             continue
         if isinstance(v, dict) and "usd" in v:
             try:
-                return float(v["usd"])
-            except (TypeError, ValueError):
-                return None
+                return _numeric.non_negative_float(v["usd"])
+            except ValueError:
+                raise ValueError("model catalog contains an invalid image price") from None
     # Fall back to a top-level "usd" key.
     if "usd" in pricing:
         try:
-            return float(pricing["usd"])
-        except (TypeError, ValueError):
-            return None
+            return _numeric.non_negative_float(pricing["usd"])
+        except ValueError:
+            raise ValueError("model catalog contains an invalid image price") from None
     return None
 
 
@@ -329,7 +329,7 @@ def _estimate_cost(
 ) -> Optional[float]:
     if price is None:
         return None
-    return price * variants * n_prompts
+    return _numeric.non_negative_float(price * variants * n_prompts)
 
 
 # ---- output paths ------------------------------------------------------------
@@ -417,7 +417,7 @@ def _write_sidecar(json_path: Path, params: dict) -> None:
     the image is already on disk; the sidecar is reproducibility metadata."""
     try:
         with json_path.open("w", encoding="utf-8") as fh:
-            json.dump(params, fh, indent=2, sort_keys=True)
+            json.dump(params, fh, indent=2, sort_keys=True, allow_nan=False)
             fh.write("\n")
     except OSError as e:
         print(f"warning: could not write sidecar {json_path}: {e}", file=sys.stderr)
@@ -617,15 +617,20 @@ def _run(args) -> int:
 
 def _run_single(client, args) -> int:
     prompt = args.prompt.strip()
-    price = _fetch_image_price(client, args.model)
+    try:
+        price = _fetch_image_price(client, args.model)
+    except ValueError as e:
+        print(f"image: {e}", file=sys.stderr)
+        return 2
     cost = _estimate_cost(price, args.variants)
     desc = f"{args.variants} image" + ("s" if args.variants != 1 else "")
     _print_estimate(cost, f"{desc}, model={args.model}")
     _print_balance_and_remaining(client, cost, show=not args.no_balance)
 
     if _over_budget(cost, args.max_spend):
+        shown = billing.format_usd(cost) if cost is not None else "unknown"
         print(
-            f"image: estimate {billing.format_usd(cost)} exceeds "
+            f"image: estimate {shown} cannot be kept within "
             f"--max-spend {billing.format_usd(args.max_spend)}; aborting",
             file=sys.stderr,
         )
@@ -650,15 +655,20 @@ def _run_batch(client, args) -> int:
         return rc
 
     n = len(items)
-    price = _fetch_image_price(client, args.model)
+    try:
+        price = _fetch_image_price(client, args.model)
+    except ValueError as e:
+        print(f"image: {e}", file=sys.stderr)
+        return 2
     cost = _estimate_cost(price, args.variants, n)
     desc = f"{n} prompt" + ("s" if n != 1 else "") + f" x {args.variants}"
     _print_estimate(cost, f"{desc}, model={args.model}")
     _print_balance_and_remaining(client, cost, show=not args.no_balance)
 
     if _over_budget(cost, args.max_spend):
+        shown = billing.format_usd(cost) if cost is not None else "unknown"
         print(
-            f"image: estimate {billing.format_usd(cost)} exceeds "
+            f"image: estimate {shown} cannot be kept within "
             f"--max-spend {billing.format_usd(args.max_spend)}; aborting",
             file=sys.stderr,
         )

--- a/src/venice/commands/image_edit.py
+++ b/src/venice/commands/image_edit.py
@@ -16,7 +16,7 @@ import sys
 from pathlib import Path
 from typing import List, Optional
 
-from .. import auth, userconfig
+from .. import _numeric, auth, userconfig
 from ..client import build_client_from_auth
 from ._shared import (
     add_balance_flag,
@@ -98,7 +98,7 @@ def register(subparsers) -> None:
                    help="Show the planned output and exit; don't call the API.")
     p.add_argument(
         "--max-spend",
-        type=float,
+        type=_numeric.non_negative_float,
         default=None,
         metavar="USD",
         help="Refuse if the estimated cost exceeds this cap. Note: image-edit "
@@ -181,7 +181,11 @@ def _run(args) -> int:
     cost = None  # dynamic pricing -- no reliable upfront quote
     print_estimate(cost, "image edit; dynamic $0.001-$10.00/call")
     print_balance_and_remaining(client, cost, show=not args.no_balance)
-    if over_budget(cost, args.max_spend):  # no-op while cost is unknown
+    if over_budget(cost, args.max_spend):
+        print(
+            "image-edit: dynamic price cannot be bounded by --max-spend; aborting",
+            file=sys.stderr,
+        )
         return 1
 
     ext = EXT_BY_FORMAT.get(args.output_format or "png", ".png")

--- a/src/venice/commands/music.py
+++ b/src/venice/commands/music.py
@@ -14,7 +14,7 @@ import sys
 from pathlib import Path
 from typing import Optional
 
-from .. import audio_post, billing, config, userconfig
+from .. import _numeric, audio_post, billing, config, userconfig
 from ..client import VeniceAPIError
 from . import _audio, _queue, _shared
 
@@ -53,7 +53,10 @@ def register(subparsers) -> None:
         "config-sourced value, and --instrumental/--no-instrumental still wins.",
     )
     p.add_argument("--lyrics", default=None, metavar="TXT", help="Lyrics prompt (lyric-capable models only).")
-    p.add_argument("--speed", type=float, default=None, help="Playback speed multiplier.")
+    p.add_argument(
+        "--speed", type=_numeric.finite_float, default=None,
+        help="Playback speed multiplier.",
+    )
     p.add_argument("--output", "-o", type=Path, default=None)
     play_grp = p.add_mutually_exclusive_group()
     play_grp.add_argument("--play", dest="play", action="store_true", default=None)
@@ -64,7 +67,7 @@ def register(subparsers) -> None:
     _shared.add_cleanup_flag(p, section="music", endpoint="/audio/complete")
     p.add_argument(
         "--max-spend",
-        type=float,
+        type=_numeric.non_negative_float,
         default=None,
         metavar="USD",
         help="Refuse to queue if the quote exceeds this USD cap.",
@@ -292,7 +295,11 @@ def _run_generate(args) -> int:
         print(f"quote rejected: {e}", file=sys.stderr)
         return _queue.status_to_exit(e)
 
-    quote_value = quote.get("quote", quote)
+    try:
+        quote_value = _shared.quote_cost(quote)
+    except ValueError as e:
+        print(f"music: {e}", file=sys.stderr)
+        return 2
     label = f"model={args.model}"
     if args.duration is not None:
         label += f", duration={args.duration}s"

--- a/src/venice/commands/review.py
+++ b/src/venice/commands/review.py
@@ -27,7 +27,7 @@ import json
 import os
 import sys
 
-from .. import auth, config, userconfig
+from .. import _numeric, auth, config, userconfig
 from ..client import build_client_from_auth
 from . import _agent, _exec, _models, _openai, _review
 
@@ -73,7 +73,7 @@ def register(subparsers) -> None:
         "function-calling model from a DIFFERENT family than the catalog default, so "
         "the reviewer's blind spots are not the author's. Config: defaults.review.model.",
     )
-    p.add_argument("--temperature", "-t", type=float, default=None)
+    p.add_argument("--temperature", "-t", type=_numeric.finite_float, default=None)
     p.add_argument("--max-tokens", type=int, default=None, dest="max_tokens")
     p.add_argument(
         "--json", action="store_true",
@@ -204,7 +204,7 @@ def _run(args) -> int:
     if skip:
         env = _review.skipped_envelope(collected, reason=skip, fail_on=args.fail_on)
         if args.json:
-            json.dump(env, sys.stdout, indent=2, default=str)
+            json.dump(env, sys.stdout, indent=2, default=str, allow_nan=False)
             sys.stdout.write("\n")
         else:
             print(f"review: {skip} -- no review run", file=sys.stderr)
@@ -261,7 +261,7 @@ def _run(args) -> int:
     env = _review.envelope(collected, result, model=model,
                            decorrelated=decorrelated, fail_on=args.fail_on)
     if args.json:
-        json.dump(env, sys.stdout, indent=2, default=str)
+        json.dump(env, sys.stdout, indent=2, default=str, allow_nan=False)
         sys.stdout.write("\n")
     else:
         _print_report(env)

--- a/src/venice/commands/sessions.py
+++ b/src/venice/commands/sessions.py
@@ -90,7 +90,7 @@ def _run_ls(args) -> int:
             }
             for sid, command, updated, n_msgs, model in rows
         ]
-        json.dump(out, sys.stdout, indent=2)
+        json.dump(out, sys.stdout, indent=2, allow_nan=False)
         sys.stdout.write("\n")
         return 0
     if not rows:

--- a/src/venice/commands/sfx.py
+++ b/src/venice/commands/sfx.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 import sys
 from pathlib import Path
 
-from .. import audio_post, billing, config, userconfig
+from .. import _numeric, audio_post, billing, config, userconfig
 from ..client import VeniceAPIError
 from . import _audio, _queue, _shared
 
@@ -50,7 +50,7 @@ def register(subparsers) -> None:
     _shared.add_cleanup_flag(p, section="sfx", endpoint="/audio/complete")
     p.add_argument(
         "--max-spend",
-        type=float,
+        type=_numeric.non_negative_float,
         default=None,
         metavar="USD",
         help="Refuse to queue if the quote exceeds this USD cap.",
@@ -157,7 +157,11 @@ def _run_generate(args) -> int:
         print(f"quote rejected: {e}", file=sys.stderr)
         return _queue.status_to_exit(e)
 
-    quote_value = quote.get("quote", quote)
+    try:
+        quote_value = _shared.quote_cost(quote)
+    except ValueError as e:
+        print(f"sfx: {e}", file=sys.stderr)
+        return 2
     _shared.print_estimate(quote_value, f"model={args.model}, duration={duration}s")
     _shared.print_balance_and_remaining(client, quote_value, show=not args.no_balance)
 

--- a/src/venice/commands/tts.py
+++ b/src/venice/commands/tts.py
@@ -12,7 +12,7 @@ import sys
 from pathlib import Path
 from typing import Optional, Tuple
 
-from .. import audio_player, auth, billing, config, userconfig
+from .. import _numeric, audio_player, auth, billing, config, userconfig
 from ..client import VeniceAPIError, build_client_from_auth
 from . import _shared
 
@@ -94,7 +94,7 @@ def register(subparsers) -> None:
     )
     p.add_argument(
         "--speed",
-        type=float,
+        type=_numeric.finite_float,
         default=None,
         metavar="N",
         help="Playback speed (0.25-4.0). Omit to use server default (1.0).",
@@ -108,7 +108,7 @@ def register(subparsers) -> None:
                    help="Estimate cost and exit; don't call /audio/speech.")
     p.add_argument(
         "--max-spend",
-        type=float,
+        type=_numeric.non_negative_float,
         default=None,
         metavar="USD",
         help="Refuse to synthesize if the estimated cost exceeds this USD cap.",
@@ -167,16 +167,22 @@ def _fetch_tts_price_per_million(client, model: str) -> Optional[float]:
     for m in data:
         if isinstance(m, dict) and m.get("id") == model:
             try:
-                return float(m["model_spec"]["pricing"]["input"]["usd"])
-            except (KeyError, TypeError, ValueError):
+                return _numeric.non_negative_float(
+                    m["model_spec"]["pricing"]["input"]["usd"]
+                )
+            except (KeyError, TypeError):
                 return None
+            except ValueError:
+                raise ValueError("model catalog contains an invalid TTS price") from None
     return None
 
 
 def _estimate_cost(char_count: int, price_per_million: Optional[float]) -> Optional[float]:
     if price_per_million is None:
         return None
-    return (char_count / 1_000_000.0) * price_per_million
+    return _numeric.non_negative_float(
+        (char_count / 1_000_000.0) * price_per_million
+    )
 
 
 # ---- output path -------------------------------------------------------------
@@ -298,22 +304,23 @@ def _run(args) -> int:
         print(str(e), file=sys.stderr)
         return 2
 
-    price = _fetch_tts_price_per_million(client, args.model)
+    try:
+        price = _fetch_tts_price_per_million(client, args.model)
+    except ValueError as e:
+        print(f"tts: {e}", file=sys.stderr)
+        return 2
     cost = _estimate_cost(len(text), price)
     _print_estimate(cost, len(text), args.model)
     _print_balance_and_remaining(client, cost, show=not args.no_balance)
 
-    if args.max_spend is not None and cost is not None:
-        try:
-            if float(cost) > float(args.max_spend):
-                print(
-                    f"tts: estimate {billing.format_usd(cost)} exceeds "
-                    f"--max-spend {billing.format_usd(args.max_spend)}; aborting",
-                    file=sys.stderr,
-                )
-                return 1
-        except (TypeError, ValueError):
-            pass
+    if _shared.over_budget(cost, args.max_spend):
+        shown = billing.format_usd(cost) if cost is not None else "unknown"
+        print(
+            f"tts: estimate {shown} cannot be kept within "
+            f"--max-spend {billing.format_usd(args.max_spend)}; aborting",
+            file=sys.stderr,
+        )
+        return 1
 
     if args.dry_run:
         return 0

--- a/src/venice/commands/upscale.py
+++ b/src/venice/commands/upscale.py
@@ -14,7 +14,7 @@ import sys
 from pathlib import Path
 from typing import Optional
 
-from .. import auth, userconfig
+from .. import _numeric, auth, userconfig
 from ..client import build_client_from_auth
 from ._shared import (
     add_balance_flag,
@@ -47,7 +47,7 @@ def register(subparsers) -> None:
     p.add_argument("input", type=Path, help="Image file to upscale.")
     p.add_argument(
         "--scale",
-        type=float,
+        type=_numeric.finite_float,
         default=None,
         metavar="N",
         help=f"Upscale factor 1-4 (default {DEFAULT_SCALE:g}). Scale 1 only runs "
@@ -64,7 +64,7 @@ def register(subparsers) -> None:
     )
     p.add_argument(
         "--enhance-creativity",
-        type=float,
+        type=_numeric.finite_float,
         default=None,
         metavar="F",
         help="0-1 (default 0.5); higher lets the enhancer change the image more.",
@@ -77,7 +77,7 @@ def register(subparsers) -> None:
     )
     p.add_argument(
         "--replication",
-        type=float,
+        type=_numeric.finite_float,
         default=None,
         metavar="R",
         help="0-1 (default 0.35); how strongly base-image lines/noise are kept.",
@@ -89,7 +89,7 @@ def register(subparsers) -> None:
                    help="Show the planned output and exit; don't call the API.")
     p.add_argument(
         "--max-spend",
-        type=float,
+        type=_numeric.non_negative_float,
         default=None,
         metavar="USD",
         help="Refuse if the estimated cost exceeds this cap. Note: upscale "
@@ -161,7 +161,11 @@ def _run(args) -> int:
     cost = None  # dynamic pricing -- no reliable upfront quote
     print_estimate(cost, f"×{_fmt_scale(args.scale)} upscale; dynamic $0.001-$10.00/call")
     print_balance_and_remaining(client, cost, show=not args.no_balance)
-    if over_budget(cost, args.max_spend):  # no-op while cost is unknown
+    if over_budget(cost, args.max_spend):
+        print(
+            "upscale: dynamic price cannot be bounded by --max-spend; aborting",
+            file=sys.stderr,
+        )
         return 1
 
     out_path = resolve_output(args.output, f"{args.input.stem}-upscaled.png")

--- a/src/venice/commands/video.py
+++ b/src/venice/commands/video.py
@@ -19,7 +19,7 @@ import time
 from pathlib import Path
 from typing import Optional, Tuple, Union
 
-from .. import billing, config, userconfig
+from .. import _numeric, billing, config, userconfig
 from ..client import VeniceAPIError
 from . import _models, _queue, _shared, _video_jobs
 
@@ -147,7 +147,7 @@ def register(subparsers) -> None:
         help=f"Scene reference image (@Image1.., repeatable, up to {SCENE_MAX}).",
     )
     p.add_argument(
-        "--reference-video-duration", type=float, default=None,
+        "--reference-video-duration", type=_numeric.finite_float, default=None,
         dest="reference_video_duration", metavar="SECONDS",
         help="Aggregate reference-video duration (s); sent to the quote for R2V pricing.",
     )
@@ -164,7 +164,7 @@ def register(subparsers) -> None:
     _shared.add_cleanup_flag(p, section="video", endpoint="/video/complete")
     p.add_argument(
         "--max-spend",
-        type=float,
+        type=_numeric.non_negative_float,
         default=None,
         metavar="USD",
         help="Refuse to queue if the quote exceeds this USD cap.",
@@ -422,7 +422,11 @@ def _run_generate(args) -> int:
         print(f"quote rejected: {e}", file=sys.stderr)
         return _queue.status_to_exit(e)
 
-    quote_value = quote.get("quote", quote)
+    try:
+        quote_value = _shared.quote_cost(quote)
+    except ValueError as e:
+        print(f"video: {e}", file=sys.stderr)
+        return 2
     label = f"model={model}, duration={args.duration}"
     if args.resolution:
         label += f", {args.resolution}"

--- a/src/venice/userconfig.py
+++ b/src/venice/userconfig.py
@@ -19,7 +19,7 @@ import os
 import sys
 from pathlib import Path
 
-from . import config
+from . import _numeric, config
 
 
 class ConfigError(Exception):
@@ -42,7 +42,10 @@ def load_config() -> dict:
     if not p.exists():
         return _default_doc()
     try:
-        doc = json.loads(p.read_text(encoding="utf-8"))
+        doc = json.loads(
+            p.read_text(encoding="utf-8"),
+            parse_constant=_numeric.reject_json_constant,
+        )
     except (OSError, ValueError) as e:
         print(f"warning: ignoring unreadable {p}: {e}", file=sys.stderr)
         return _default_doc()
@@ -59,7 +62,10 @@ def load_config_for_write() -> dict:
     if not p.exists():
         return _default_doc()
     try:
-        doc = json.loads(p.read_text(encoding="utf-8"))
+        doc = json.loads(
+            p.read_text(encoding="utf-8"),
+            parse_constant=_numeric.reject_json_constant,
+        )
     except (OSError, ValueError) as e:
         raise ConfigError(f"{p} is unreadable ({e}); fix or remove it first") from None
     if not isinstance(doc, dict):
@@ -80,7 +86,7 @@ def save_config(doc: dict) -> Path:
     fd = os.open(str(tmp), os.O_WRONLY | os.O_CREAT | os.O_TRUNC, 0o600)
     try:
         with os.fdopen(fd, "w", encoding="utf-8") as f:
-            json.dump(doc, f, indent=2, sort_keys=True)
+            json.dump(doc, f, indent=2, sort_keys=True, allow_nan=False)
             f.write("\n")
             f.flush()
             os.fsync(f.fileno())
@@ -372,7 +378,7 @@ def _one_of(module: str, attr: str, cast=str):
 # declares the flag; a per-command section overrides them.
 _GLOBAL_MAP = {
     "output_dir": ("output", _as_path),
-    "max_spend": ("max_spend", float),
+    "max_spend": ("max_spend", _numeric.non_negative_float),
     "yes": ("yes", _as_bool),
     # #57 Class B: `--no-balance`/`--balance` is tri-state (default None) on all
     # eight spend-incurring commands. A global rather than eight sections -- the
@@ -394,20 +400,20 @@ _GLOBAL_MAP = {
     # same post-spend path as the poll cadence -- `defaults.sample_rate = 0`
     # lands in the pass-2 argv as `-ar 0` only AFTER a sfx/music job has been
     # queued, charged and downloaded. (#57 Class C2)
-    "lufs": ("lufs", float),
-    "true_peak": ("true_peak", float),
+    "lufs": ("lufs", _numeric.finite_float),
+    "true_peak": ("true_peak", _numeric.finite_float),
     "sample_rate": ("sample_rate", _positive(_exact_int)),
     # `--bit-depth` is the only flag in the tree whose `choices=` are ints, hence
     # the cast -- see `_one_of`.
     "bit_depth": ("bit_depth", _one_of("venice.audio_post", "BIT_DEPTHS", _exact_int)),
-    "loop_crossfade": ("loop_crossfade", _non_negative(float)),
+    "loop_crossfade": ("loop_crossfade", _non_negative(_numeric.finite_float)),
 }
 _COMMAND_MAP = {
     "chat": {
         "model": ("model", str),
         "system": ("system", str),
         "persona": ("persona", str),
-        "temperature": ("temperature", float),
+        "temperature": ("temperature", _numeric.finite_float),
         "max_tokens": ("max_tokens", int),
         "web_search": ("web_search", _one_of("venice.commands.chat", "WEB_SEARCH_CHOICES")),
         "character": ("character", str),
@@ -417,7 +423,7 @@ _COMMAND_MAP = {
         "auto_compact": ("auto_compact", _as_bool),
         "compact_threshold": ("compact_threshold", int),
         "compact_keep_turns": ("compact_keep_turns", int),
-        "session_max_spend": ("session_max_spend", float),
+        "session_max_spend": ("session_max_spend", _numeric.finite_float),
     },
     "embed": {
         "model": ("model", str),
@@ -450,7 +456,7 @@ _COMMAND_MAP = {
         "assets": ("assets", _as_bool),
         "scout": ("scout", _as_bool),  # #52: opt-in read-only scout subagent
         "spawn": ("spawn", _as_bool),  # #52 slice 2: opt-in write-capable worker subagent
-        "spawn_max_spend": ("spawn_max_spend", float),  # #52: per-worker media USD cap
+        "spawn_max_spend": ("spawn_max_spend", _numeric.finite_float),  # #52: per-worker media USD cap
         "subagent_max_tokens": ("subagent_max_tokens", int),  # #52: per-subagent token cap
         "planner": ("planner", _as_bool),  # #52: planner harness (implies scout/spawn/memory)
         "parallel": ("parallel", _as_bool),  # #52: concurrent scout/spawn dispatch
@@ -461,7 +467,7 @@ _COMMAND_MAP = {
         "auto_compact": ("auto_compact", _as_bool),
         "compact_threshold": ("compact_threshold", int),
         "compact_keep_turns": ("compact_keep_turns", int),
-        "session_max_spend": ("session_max_spend", float),
+        "session_max_spend": ("session_max_spend", _numeric.finite_float),
         # #80 part 1a: the cold-context reviewer rail. `review_model` is the
         # decorrelation knob -- the reviewer should not be the model that authored.
         "review": ("review", _as_bool),
@@ -497,7 +503,7 @@ _COMMAND_MAP = {
         "preset": ("preset", str),
         "preset_file": ("preset_file", _as_path),
         "negative_prompt": ("negative_prompt", str),
-        "cfg_scale": ("cfg_scale", float),
+        "cfg_scale": ("cfg_scale", _numeric.finite_float),
         "steps": ("steps", int),
         "style_preset": ("style_preset", str),
         # #57 Class C: the valued generation knobs. Their argparse defaults moved
@@ -522,7 +528,7 @@ _COMMAND_MAP = {
         "model": ("model", _one_of("venice.commands.tts", "TTS_MODELS")),
         "format": ("format", _one_of("venice.commands.tts", "FORMATS")),
         "voice": ("voice", str),
-        "speed": ("speed", float),
+        "speed": ("speed", _numeric.finite_float),
         # `--play`/`--no-play` is a tri-stated store_true(None)/store_false pair.
         "play": ("play", _as_bool),
     },
@@ -547,8 +553,8 @@ _COMMAND_MAP = {
         # `_non_negative`, not bare float: these rows also feed the agent/MCP
         # tool impls via `config_defaults_for`, where a negative max_wait
         # abandons an already-charged job.
-        "poll_interval": ("poll_interval", _non_negative(float)),
-        "max_wait": ("max_wait", _non_negative(float)),
+        "poll_interval": ("poll_interval", _non_negative(_numeric.finite_float)),
+        "max_wait": ("max_wait", _non_negative(_numeric.finite_float)),
     },
     "music": {
         # #57 Class C: literal now lives in `music._run_generate`. Generate
@@ -558,7 +564,7 @@ _COMMAND_MAP = {
         # `lyrics` is deliberately CLI-only -- it's per-song content, not a
         # persistent preference.
         "duration": ("duration", int),
-        "speed": ("speed", float),
+        "speed": ("speed", _numeric.finite_float),
         "play": ("play", _as_bool),
         "no_cleanup": ("no_cleanup", _as_bool),  # #57 Class B
         "instrumental": ("instrumental", _as_bool),
@@ -573,8 +579,8 @@ _COMMAND_MAP = {
         # `_non_negative`, not bare float: these rows also feed the agent/MCP
         # tool impls via `config_defaults_for`, where a negative max_wait
         # abandons an already-charged job.
-        "poll_interval": ("poll_interval", _non_negative(float)),
-        "max_wait": ("max_wait", _non_negative(float)),
+        "poll_interval": ("poll_interval", _non_negative(_numeric.finite_float)),
+        "max_wait": ("max_wait", _non_negative(_numeric.finite_float)),
     },
     # #57 Class B: the standalone `venice master` command. Only `loop` -- the
     # valued knobs (--lufs/--true-peak/--sample-rate/--bit-depth/
@@ -610,8 +616,8 @@ _COMMAND_MAP = {
         # `_non_negative`, not bare float: these rows also feed the agent/MCP
         # tool impls via `config_defaults_for`, where a negative max_wait
         # abandons an already-charged job.
-        "poll_interval": ("poll_interval", _non_negative(float)),
-        "max_wait": ("max_wait", _non_negative(float)),
+        "poll_interval": ("poll_interval", _non_negative(_numeric.finite_float)),
+        "max_wait": ("max_wait", _non_negative(_numeric.finite_float)),
     },
     # #57 Class D: `venice balance`, which had no `apply_defaults` call. Only
     # `min` -- `--json`/`--verbose` are per-invocation OUTPUT MODES, not
@@ -621,7 +627,7 @@ _COMMAND_MAP = {
     # `defaults.min` does NOT reach this: globals are an explicit allow-list
     # (see `resolve_default`), and `min` is a per-command preference.
     "balance": {
-        "min": ("min", float),
+        "min": ("min", _numeric.finite_float),
     },
     # #57 Class D: `venice contact-sheet`, which had no `apply_defaults` call at
     # all until now. Section name uses an UNDERSCORE (the `image_edit`
@@ -643,11 +649,11 @@ _COMMAND_MAP = {
     },
     "upscale": {
         # #57 Class C: literal now lives in `upscale._run`.
-        "scale": ("scale", float),
+        "scale": ("scale", _numeric.finite_float),
         "enhance": ("enhance", _as_bool),  # #57 Class B: tri-stated --enhance
-        "enhance_creativity": ("enhance_creativity", float),
+        "enhance_creativity": ("enhance_creativity", _numeric.finite_float),
         "enhance_prompt": ("enhance_prompt", str),
-        "replication": ("replication", float),
+        "replication": ("replication", _numeric.finite_float),
     },
     # #71 compatibility-only browser defaults. The tools are security-disabled for
     # GHSA-mqjr-2vh8-6fvg, but these keys remain readable so existing configs survive and

--- a/tests/test_agent.py
+++ b/tests/test_agent.py
@@ -447,6 +447,31 @@ class TestCostLedger(unittest.TestCase):
         L2.record({"prompt_tokens": 2000, "completion_tokens": 0})  # $0.002 > cap
         self.assertTrue(L2.over())
 
+    def test_non_finite_session_caps_are_rejected_not_uncapped(self):
+        for bad in (float("nan"), float("inf"), float("-inf")):
+            with self.subTest(value=bad), self.assertRaises(ValueError):
+                _agent.CostLedger(max_spend=bad)
+
+    def test_non_finite_catalog_pricing_trips_a_configured_cap(self):
+        for bad in (float("nan"), float("inf"), float("-inf")):
+            ledger = _agent.CostLedger(max_spend=1.0)
+            ledger.bind_pricing({"input": {"usd": bad}})
+            with self.subTest(value=bad):
+                self.assertTrue(ledger.invalid_pricing)
+                self.assertTrue(ledger.over())
+
+    def test_non_finite_usage_and_restored_values_degrade_to_zero(self):
+        ledger = _agent.CostLedger()
+        ledger.bind_pricing({"input": {"usd": 1.0}, "output": {"usd": 1.0}})
+        ledger.record({
+            "prompt_tokens": float("inf"),
+            "completion_tokens": float("nan"),
+        })
+        ledger.restore({"total": float("inf"), "elapsed_seconds": float("nan")})
+        self.assertEqual(ledger.total, 0.0)
+        self.assertEqual(ledger.prompt_tokens, 0)
+        self.assertEqual(ledger.completion_tokens, 0)
+
     def test_unpriced_model_counts_tokens_without_charge(self):
         L = _agent.CostLedger(max_spend=0.0)
         # no bind_pricing -> unknown rate
@@ -2391,6 +2416,22 @@ class TestRunLoopSpendGate(unittest.TestCase):
             )
         self.assertEqual(rc, 0)
         self.assertEqual(len(calls), 1)  # no forced final despite huge usage
+
+    def test_invalid_catalog_pricing_aborts_without_a_model_call(self):
+        fake, calls = _fake_oai([])
+        ledger = _agent.CostLedger(max_spend=1.0)
+        ledger.bind_pricing({"input": {"usd": float("nan")}})
+        err = io.StringIO()
+        with mock.patch.object(sys, "stdout", io.StringIO()), \
+             mock.patch.object(sys, "stderr", err):
+            rc = _agent.run_loop(
+                fake, "m", [{"role": "user", "content": "go"}], {},
+                [self._tool()], max_tool_calls=0, yes=True, json_out=False,
+                ledger=ledger,
+            )
+        self.assertEqual(rc, 2)
+        self.assertEqual(calls, [])
+        self.assertIn("invalid non-finite pricing", err.getvalue())
 
     def test_unpriced_ledger_never_gates_but_counts(self):
         usage = {"prompt_tokens": 5000, "completion_tokens": 500}

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -406,6 +406,28 @@ class TestVeniceClient(unittest.TestCase):
                     interval=0, max_wait=10,
                 )
 
+    def test_request_rejects_non_finite_json_before_urlopen(self):
+        c = VeniceClient(api_key="k")
+        for bad in (float("nan"), float("inf"), float("-inf")):
+            with self.subTest(value=bad), mock.patch(
+                "venice.client.urllib.request.urlopen"
+            ) as opened:
+                with self.assertRaisesRegex(VeniceAPIError, "strict JSON"):
+                    c.post_json("/paid", {"cost": bad})
+                opened.assert_not_called()
+
+    def test_poll_retrieve_rejects_non_finite_controls_before_urlopen(self):
+        c = VeniceClient(api_key="k")
+        for field in ("interval", "max_wait"):
+            for bad in (float("nan"), float("inf"), float("-inf")):
+                kwargs = {"interval": 0.0, "max_wait": 1.0, field: bad}
+                with self.subTest(field=field, value=bad), mock.patch(
+                    "venice.client.urllib.request.urlopen"
+                ) as opened:
+                    with self.assertRaises(ValueError):
+                        c.poll_retrieve("/poll", {}, **kwargs)
+                    opened.assert_not_called()
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -109,6 +109,20 @@ class TestUserConfigIO(_Base):
         reloaded = json.loads(self.cfg_file.read_text())
         self.assertEqual(reloaded["future_thing"], {"k": 1})  # not dropped
 
+    def test_strict_json_rejects_non_finite_loads_and_saves(self):
+        self.cfg_dir.mkdir(parents=True)
+        self.cfg_file.write_text('{"defaults":{"max_spend":NaN}}')
+        _, _, err = _capture(uc.load_config)
+        self.assertIn("non-finite JSON number", err)
+        with self.assertRaises(uc.ConfigError):
+            uc.load_config_for_write()
+
+        self.cfg_file.unlink()
+        with self.assertRaises(ValueError):
+            uc.save_config({"defaults": {"max_spend": float("inf")}})
+        self.assertFalse(self.cfg_file.exists())
+        self.assertEqual(list(self.cfg_dir.glob("*.tmp")), [])
+
 
 # --------------------------------------------------------------------------- #
 # resolve_default / apply_defaults (#17)
@@ -161,6 +175,35 @@ class TestApplyDefaults(_Base):
         args2 = argparse.Namespace(spawn_max_spend=0.5, model=None, system=None)
         uc.apply_defaults(args2, "code", doc)
         self.assertEqual(args2.spawn_max_spend, 0.5)  # explicit wins
+
+    def test_non_finite_spend_defaults_are_warned_and_skipped(self):
+        for key, command, dest in (
+            ("max_spend", "sfx", "max_spend"),
+            ("session_max_spend", "chat", "session_max_spend"),
+            ("spawn_max_spend", "code", "spawn_max_spend"),
+        ):
+            for bad in (float("nan"), float("inf"), float("-inf")):
+                args = argparse.Namespace(**{dest: None})
+                doc = {"defaults": {command: {key: bad}}}
+                if key == "max_spend":
+                    doc = {"defaults": {key: bad}}
+                with self.subTest(key=key, value=bad):
+                    rc, _, err = _capture(uc.apply_defaults, args, command, doc)
+                    self.assertIsNone(rc)
+                    self.assertIsNone(getattr(args, dest))
+                    self.assertIn("must be finite", err)
+
+    def test_non_finite_spend_flags_are_rejected_by_argparse(self):
+        cases = (
+            (sfx, ["sfx", "p", "--max-spend"]),
+            (chat, ["chat", "p", "--session-max-spend"]),
+            (code, ["code", "p", "--spawn-max-spend"]),
+        )
+        for module, prefix in cases:
+            for spelling in ("nan", "inf", "-inf"):
+                with self.subTest(command=module.__name__, value=spelling):
+                    with contextlib.redirect_stderr(io.StringIO()), self.assertRaises(SystemExit):
+                        _build_parser(module).parse_args(prefix + [spelling])
 
     def test_code_parser_has_spawn_max_spend_dest_config_fills_it(self):
         # Guards the config key against the real argparser's dest: a wrong dest name
@@ -1259,6 +1302,23 @@ class TestPollCadenceParity(unittest.TestCase):
             got = uc.config_defaults_for("sfx", _mcp.sfx_tool, doc)
         self.assertNotIn("max_wait", got)
 
+    def test_non_finite_cadence_is_rejected_by_config_and_cli(self):
+        for bad in (float("nan"), float("inf"), float("-inf")):
+            doc = {"defaults": {"sfx": {"poll_interval": bad, "max_wait": bad}}}
+            args = _build_parser(sfx).parse_args(["sfx", "p"])
+            err = io.StringIO()
+            with self.subTest(source="config", value=bad), contextlib.redirect_stderr(err):
+                uc.apply_defaults(args, "sfx", doc)
+            self.assertIsNone(args.poll_interval)
+            self.assertIsNone(args.max_wait)
+            self.assertIn("must be finite", err.getvalue())
+
+        for spelling in ("nan", "inf", "-inf"):
+            for flag in ("--poll-interval", "--max-wait"):
+                with self.subTest(source="cli", flag=flag, value=spelling):
+                    with contextlib.redirect_stderr(io.StringIO()), self.assertRaises(SystemExit):
+                        _build_parser(sfx).parse_args(["sfx", "p", flag, spelling])
+
     def test_negative_cadence_typed_on_the_cli_falls_back(self):
         """A value the user TYPED never passes through a coercer, so the handler
         still clamps it -- `time.sleep(-1)` is a ValueError traceback."""
@@ -1293,6 +1353,17 @@ class TestPollCadenceParity(unittest.TestCase):
 # config subcommands
 # --------------------------------------------------------------------------- #
 class TestConfigCommand(_Base):
+    def test_set_rejects_non_finite_numbers_without_writing(self):
+        for spelling in ("NaN", "Infinity", "-Infinity", "inf"):
+            with self.subTest(value=spelling):
+                rc, _, err = _capture(
+                    cfgcmd._run_set,
+                    argparse.Namespace(key="defaults.max_spend", value=spelling),
+                )
+                self.assertEqual(rc, 2)
+                self.assertIn("non-finite", err)
+                self.assertFalse(self.cfg_file.exists())
+
     def test_add_stdio_roundtrip(self):
         rc, _, _ = _capture(cfgcmd._run_add,
                             _add_args("venice", server_command="venice", arg=["mcp-serve"]))

--- a/tests/test_image.py
+++ b/tests/test_image.py
@@ -94,6 +94,17 @@ def _image_models_payload():
     }).encode()
 
 
+def _unpriced_image_models_payload():
+    return json.dumps({
+        "object": "list",
+        "data": [{
+            "id": "venice-sd35",
+            "type": "image",
+            "model_spec": {"name": "Venice SD3.5", "pricing": {}},
+        }],
+    }).encode()
+
+
 def _gen_payload(n=1):
     b64 = base64.b64encode(FAKE_PNG).decode()
     return json.dumps({
@@ -222,6 +233,23 @@ class TestImageFlow(unittest.TestCase):
                         lambda *a, **kw: next(responses)):
             rc = image._run(_build_args(variants=4, max_spend=0.02))
         self.assertEqual(rc, 1)
+        self.assertEqual(list(Path(".").glob("*.png")), [])
+
+    def test_max_spend_with_unknown_price_fails_closed_before_generate(self):
+        from venice.commands import image
+
+        calls = []
+
+        def fake_urlopen(req, timeout=None):
+            calls.append(req.full_url)
+            return FakeResp(200, _unpriced_image_models_payload(), "application/json")
+
+        with mock.patch.dict(os.environ, {"VENICE_API_KEY": "fake"}), \
+             mock.patch("venice.client.urllib.request.urlopen", fake_urlopen):
+            rc = image._run(_build_args(max_spend=0.02))
+        self.assertEqual(rc, 1)
+        self.assertEqual(len(calls), 1)
+        self.assertTrue(calls[0].endswith("/models?type=image"))
         self.assertEqual(list(Path(".").glob("*.png")), [])
 
     def test_missing_prompt_returns_exit_2(self):
@@ -805,6 +833,17 @@ class TestSafeModeConfig(unittest.TestCase):
         args = self._parse()
         userconfig.apply_defaults(args, "image", doc)
         self.assertFalse(args.safe_mode)  # _as_bool coerces "false"
+
+
+class TestImagePricingValidation(unittest.TestCase):
+    def test_non_finite_catalog_price_is_rejected(self):
+        from venice.commands import image
+
+        for bad in (float("nan"), float("inf"), float("-inf")):
+            with self.subTest(value=bad), self.assertRaisesRegex(
+                ValueError, "invalid image price"
+            ):
+                image._usd_from_pricing({"image": {"usd": bad}})
 
 
 if __name__ == "__main__":

--- a/tests/test_mcp_client.py
+++ b/tests/test_mcp_client.py
@@ -165,6 +165,14 @@ class TestPureHelpers(unittest.TestCase):
             self.assertEqual(mc._resolve_timeout(None, "T_ENV", 30), 7.0)
         self.assertEqual(mc._resolve_timeout(None, "MISSING_ENV", 30), 30.0)
 
+    def test_resolve_timeout_rejects_non_finite_selected_value(self):
+        for bad in (float("nan"), float("inf"), float("-inf")):
+            with self.subTest(source="explicit", value=bad), self.assertRaises(ValueError):
+                mc._resolve_timeout(bad, "MISSING_ENV", 30)
+        with mock.patch.dict(os.environ, {"T_ENV": "nan"}):
+            with self.assertRaises(ValueError):
+                mc._resolve_timeout(None, "T_ENV", 30)
+
 
 class TestImportClean(unittest.TestCase):
     def test_imports_without_the_mcp_sdk(self):

--- a/tests/test_mcp_tools.py
+++ b/tests/test_mcp_tools.py
@@ -1053,6 +1053,59 @@ class TestSpendHelpers(unittest.TestCase):
         gate2 = _mcp.check_spend(None, confirm=False, max_spend=0.10, label="x")
         self.assertEqual(gate2["status"], "confirmation_required")  # unknown -> confirm
 
+    def test_non_finite_caps_are_errors_and_never_fall_through(self):
+        for bad in (float("nan"), float("inf"), float("-inf")):
+            with self.subTest(value=bad):
+                result = _mcp.check_spend(
+                    0.01, confirm=True, max_spend=bad, label="x"
+                )
+                self.assertEqual(result["status"], "error")
+                self.assertIn("invalid max_spend", result["message"])
+        with mock.patch.dict(
+            os.environ, {"VENICE_MCP_MAX_SPEND": "nan"}, clear=False
+        ):
+            with self.assertRaises(ValueError):
+                _mcp.resolve_max_spend(None)
+
+    def test_non_finite_cost_is_an_error_even_when_confirmed(self):
+        for bad in (float("nan"), float("inf"), float("-inf")):
+            with self.subTest(value=bad):
+                result = _mcp.check_spend(
+                    bad, confirm=True, max_spend=0.10, label="x"
+                )
+                self.assertEqual(result["status"], "error")
+                self.assertIn("invalid estimated cost", result["message"])
+
+    def test_non_finite_results_remain_strict_json_serializable(self):
+        result = _mcp.check_spend(
+            float("nan"), confirm=True, max_spend=0.10, label="x"
+        )
+        json.dumps(result, allow_nan=False)
+
+    def test_sfx_rejects_invalid_wait_before_requesting_a_quote(self):
+        client = mock.Mock()
+        result = _mcp.sfx_tool(client, "boom", max_wait=float("nan"))
+        self.assertEqual(result["status"], "error")
+        self.assertIn("invalid max_wait", result["message"])
+        client.post_json.assert_not_called()
+
+    def test_sfx_rejects_non_finite_quote_before_queue(self):
+        client = mock.Mock()
+        client.post_json.return_value = {"quote": float("inf")}
+        result = _mcp.sfx_tool(client, "boom", confirm=True)
+        self.assertEqual(result["status"], "error")
+        self.assertIn("quote response", result["message"])
+        self.assertEqual(client.post_json.call_count, 1)
+
+    def test_job_result_rejects_invalid_wait_before_retrieve(self):
+        client = mock.Mock()
+        result = _mcp.job_result_tool(
+            client, queue_id="q", type="sfx", model="m", max_wait=float("-inf")
+        )
+        self.assertEqual(result["status"], "error")
+        self.assertIn("invalid max_wait", result["message"])
+        client.post_json.assert_not_called()
+
     def test_output_dir_env_default(self):
         with mock.patch.dict(os.environ, {"VENICE_MCP_OUTPUT_DIR": "/tmp/venice-x"}):
             self.assertEqual(_mcp.resolve_output_dir(None), Path("/tmp/venice-x"))

--- a/tests/test_sessions.py
+++ b/tests/test_sessions.py
@@ -62,6 +62,24 @@ class TestStore(_Base):
         self.assertEqual(r.usage["cache_read_tokens"], 4)
         self.assertEqual([m["content"] for m in r.messages], ["hi"])
 
+    def test_save_rejects_non_finite_usage_without_replacing_destination(self):
+        sess = self._mk()
+        path = S.save(sess)
+        original = path.read_bytes()
+        sess.usage = {"total": float("nan")}
+        with self.assertRaisesRegex(OSError, "non-finite JSON"):
+            S.save(sess)
+        self.assertEqual(path.read_bytes(), original)
+        self.assertFalse(path.with_suffix(".tmp").exists())
+
+    def test_load_rejects_non_standard_non_finite_json(self):
+        sess = self._mk()
+        self.zone.mkdir(parents=True)
+        path = self.zone / f"{sess.id}.json"
+        path.write_text('{"version":1,"usage":{"total":Infinity}}')
+        with self.assertRaisesRegex(S.SessionError, "non-finite JSON number"):
+            S.load(sess.id, "chat")
+
     def test_reasoning_extension_round_trips_without_schema_loss(self):
         sess = self._mk(messages=[
             {"role": "user", "content": "question"},

--- a/tests/test_shared.py
+++ b/tests/test_shared.py
@@ -37,6 +37,41 @@ class TestEncodeBase64(unittest.TestCase):
             self.assertEqual(_shared.encode_base64(p), "")
 
 
+class TestNumericSpendRails(unittest.TestCase):
+
+    def test_quote_cost_accepts_only_finite_non_negative_numbers(self):
+        self.assertEqual(_shared.quote_cost({"quote": "0.125"}), 0.125)
+        for bad in (float("nan"), float("inf"), float("-inf"), -0.01, {}, None):
+            with self.subTest(value=bad):
+                with self.assertRaisesRegex(ValueError, "finite non-negative"):
+                    _shared.quote_cost({"quote": bad})
+
+    def test_budget_with_unknown_cost_fails_closed_when_a_cap_exists(self):
+        self.assertFalse(_shared.over_budget(None, None))
+        self.assertTrue(_shared.over_budget(None, 0.10))
+
+    def test_non_finite_budget_values_are_rejected(self):
+        for bad in (float("nan"), float("inf"), float("-inf")):
+            with self.subTest(value=bad):
+                with self.assertRaises(ValueError):
+                    _shared.over_budget(0.01, bad)
+
+    def test_resolve_poll_rejects_non_finite_but_keeps_zero(self):
+        self.assertEqual(
+            _shared.resolve_poll(
+                0.0, 0.0, label="test", interval=1.0, max_wait_default=10.0
+            ),
+            (0.0, 0.0),
+        )
+        for bad in (float("nan"), float("inf"), float("-inf")):
+            with self.subTest(value=bad):
+                with self.assertRaises(ValueError):
+                    _shared.resolve_poll(
+                        bad, 1.0, label="test", interval=1.0,
+                        max_wait_default=10.0,
+                    )
+
+
 class TestCheckImageFile(unittest.TestCase):
 
     def _check(self, path, *, label="upscale", max_bytes=_shared.MAX_IMAGE_BYTES):

--- a/tests/test_spawn.py
+++ b/tests/test_spawn.py
@@ -749,6 +749,29 @@ class TestSpawnTool(_ScoutBase):
         self.assertNotIn("spent_usd", out)
         self.assertNotIn("spend_cap_usd", out)
 
+    def test_non_finite_spawn_cap_is_an_error_not_uncapped(self):
+        tool, seen = _fake_paid_tool(cost=0.90)
+        for bad in (float("nan"), float("inf"), float("-inf")):
+            with self.subTest(value=bad):
+                out = _code.spawn_tool(
+                    None, "m", {}, [tool], max_spend=bad
+                ).invoke({"task": "x", "role": "asset"})
+                self.assertEqual(out["status"], "error")
+                self.assertIn("invalid max_spend", out["message"])
+        self.assertEqual(seen["calls"], 0)
+
+    def test_non_finite_paid_tool_cost_closes_worker_cap(self):
+        tool, seen = _fake_paid_tool(cost=float("nan"))
+        with mock.patch.object(
+            _agent, "run_spawn", self._spend_run("venice_image", 2)
+        ):
+            out = _code.spawn_tool(
+                None, "m", {}, [tool], max_spend=2.00
+            ).invoke({"task": "make art", "role": "asset"})
+        self.assertEqual(out["_statuses"], ["error", "blocked"])
+        self.assertEqual(seen["calls"], 1)
+        self.assertEqual(out["spent_usd"], 2.00)
+
 
 class TestSpawnWiring(_ScoutBase):
     """`venice code --spawn` folds the tool in and advertises it in the prompt."""

--- a/tests/test_tts.py
+++ b/tests/test_tts.py
@@ -206,5 +206,21 @@ class TestTtsFlow(unittest.TestCase):
         self.assertEqual(captured["body"]["speed"], 1.25)
 
 
+class TestTtsPricingValidation(unittest.TestCase):
+    def test_non_finite_catalog_price_is_rejected(self):
+        from venice.commands import tts
+
+        class Client:
+            @staticmethod
+            def get_json(*args, **kwargs):
+                return {"data": [{
+                    "id": "m",
+                    "model_spec": {"pricing": {"input": {"usd": float("nan")}}},
+                }]}
+
+        with self.assertRaisesRegex(ValueError, "invalid TTS price"):
+            tts._fetch_tts_price_per_million(Client(), "m")
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary

- add shared finite and non-negative numeric coercers across CLI, config, environment, MCP, agent, and client boundaries
- fail closed on invalid or unknown spend estimates and reject invalid polling controls before quote, queue, or paid calls
- enforce strict JSON for requests and persisted control-bearing state, with regression coverage for NaN and infinities

## Validation

- `VENICE_API_KEY=test-fake-key make test` (1,696 tests)
- `make lint`
- `make scan`
- `VENICE_API_KEY=test-fake-key make drive` (37 tests)
- targeted unknown-price fail-closed regression (6 tests)

Closes #142