### PR TITLE
fix(client): stabilize async media failures

### DIFF
--- a/src/venice/client.py
+++ b/src/venice/client.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 import json
 import math
 import os
+import socket
 import tempfile
 import time
 import urllib.error
@@ -52,6 +53,17 @@ class VeniceAPIError(Exception):
 
 
 ResponseType = Union[dict, bytes]
+
+
+def _content_type_base(content_type: str) -> str:
+    """Return a normalized MIME type without parameters."""
+    return (content_type or "").split(";", 1)[0].strip().lower()
+
+
+def _is_json_content_type(content_type: str) -> bool:
+    """Recognize JSON and RFC structured-suffix JSON media types."""
+    base = _content_type_base(content_type)
+    return base == "application/json" or base.endswith("+json")
 
 
 class VeniceClient:
@@ -121,7 +133,15 @@ class VeniceClient:
                 pass
             self._raise_api_error(e.code, url, err_body, err_ctype)
         except urllib.error.URLError as e:
-            raise VeniceAPIError(0, url, f"connection error: {e.reason}") from None
+            if isinstance(e.reason, (TimeoutError, socket.timeout)):
+                detail = "request timed out"
+            else:
+                detail = f"connection error: {e.reason}"
+            raise VeniceAPIError(0, url, detail) from None
+        except (TimeoutError, socket.timeout):
+            raise VeniceAPIError(0, url, "request timed out") from None
+        except OSError as e:
+            raise VeniceAPIError(0, url, f"connection error: {e}") from None
 
     def post_json(self, path: str, body: dict) -> dict:
         status, ctype, raw = self.request("POST", path, json_body=body)
@@ -141,16 +161,33 @@ class VeniceClient:
           - ("application/json", {...}) while still processing
         """
         status, ctype, raw = self.request("POST", path, json_body=body)
-        ct_low = (ctype or "").lower()
-        if ct_low.startswith("application/json"):
-            return ctype, (json.loads(raw.decode("utf-8")) if raw else {})
+        if not raw:
+            raise VeniceAPIError(
+                status,
+                path,
+                f"empty async response ({ctype or 'missing Content-Type'})",
+            )
+        if _is_json_content_type(ctype):
+            return ctype, self._decode_json(status, path, ctype, raw)
+        ct_base = _content_type_base(ctype)
         if (
-            ct_low.startswith("audio/")
-            or ct_low.startswith("image/")
-            or ct_low.startswith("video/")
+            ct_base.startswith("audio/")
+            or ct_base.startswith("image/")
+            or ct_base.startswith("video/")
         ):
             return ctype, raw
-        return ctype, raw
+
+        # A proxy or origin may omit or misstate Content-Type.  JSON is safe to
+        # recognize by actually decoding it; arbitrary bytes are not safe to
+        # bless as paid media without a declared media family.
+        try:
+            return ctype, self._decode_json(status, path, ctype, raw)
+        except VeniceAPIError:
+            raise VeniceAPIError(
+                status,
+                path,
+                f"unexpected async content type: {ctype or '(missing)'}",
+            ) from None
 
     def poll_retrieve(
         self,
@@ -309,12 +346,16 @@ class VeniceClient:
         except urllib.error.URLError as e:
             if isinstance(e.reason, _egress.EgressPolicyError):
                 detail = str(e.reason)
+            elif isinstance(e.reason, (TimeoutError, socket.timeout)):
+                detail = "video download timed out"
             else:
                 detail = "video download connection failed"
             raise VeniceAPIError(0, url, detail) from None
         except _egress.EgressPolicyError as e:
             raise VeniceAPIError(0, url, str(e)) from None
-        except (TimeoutError, OSError):
+        except (TimeoutError, socket.timeout):
+            raise VeniceAPIError(0, url, "video download timed out") from None
+        except OSError:
             raise VeniceAPIError(0, url, "video download connection failed") from None
 
     @staticmethod
@@ -349,7 +390,7 @@ class VeniceClient:
         try:
             text = body.decode("utf-8", errors="replace")
             excerpt = text[:2048]
-            if (ctype or "").lower().startswith("application/json"):
+            if _is_json_content_type(ctype):
                 doc: Any = json.loads(text)
                 if isinstance(doc, dict):
                     code = doc.get("code")

--- a/src/venice/commands/_audio.py
+++ b/src/venice/commands/_audio.py
@@ -80,7 +80,10 @@ def retrieve_and_save(
         )
     except VeniceAPIError as e:
         sys.stderr.write("\n")
-        print(f"retrieve failed: {e}", file=sys.stderr)
+        print(
+            f"retrieve failed: {e}; check later with: {retry_hint}",
+            file=sys.stderr,
+        )
         return _queue.status_to_exit(e)
     except TimeoutError as e:
         sys.stderr.write("\n")
@@ -96,7 +99,10 @@ def retrieve_and_save(
     try:
         out_path.write_bytes(audio)
     except OSError as e:
-        print(f"could not write {out_path}: {e}", file=sys.stderr)
+        print(
+            f"could not write {out_path}: {e}; retry with: {retry_hint}",
+            file=sys.stderr,
+        )
         return 9
 
     abs_path = out_path.resolve()

--- a/src/venice/commands/_mcp.py
+++ b/src/venice/commands/_mcp.py
@@ -176,6 +176,14 @@ def _job_handle(queue_id: str, *, type: str, model: str, quote_value) -> dict:
     return handle
 
 
+def _job_retry_hint(queue_id: str, *, type: str, model: str) -> str:
+    """Return model-facing recovery guidance without exposing private URLs."""
+    return (
+        "retry venice_job_result with "
+        f"queue_id={queue_id!r}, type={type!r}, and model={model!r}"
+    )
+
+
 # ---- tools -------------------------------------------------------------------
 
 def image_tool(
@@ -378,9 +386,15 @@ def _queue_media(
             poll_interval=poll_interval, max_wait=max_wait,
         )
     except VeniceAPIError as e:
-        return _err(f"{label} retrieve failed: {e}")
+        return _err(
+            f"{label} retrieve failed: {e}; "
+            f"{_job_retry_hint(queue_id, type=label, model=model)}"
+        )
     except TimeoutError as e:
-        return _err(f"{label}: {e}; the job {queue_id} may still finish server-side")
+        return _err(
+            f"{label}: {e}; the job may still finish server-side; "
+            f"{_job_retry_hint(queue_id, type=label, model=model)}"
+        )
 
     ext, _unknown = _audio.ext_for(ctype)
     out_path = _queue.resolve_output_path(
@@ -388,7 +402,10 @@ def _queue_media(
     )
     werr = _write(out_path, audio)
     if werr:
-        return _err(f"{label}: could not write {out_path}: {werr}")
+        return _err(
+            f"{label}: could not write {out_path}: {werr}; "
+            f"{_job_retry_hint(queue_id, type=label, model=model)}"
+        )
 
     try:  # best-effort cleanup; the file is already saved
         client.post_json("/audio/complete", {"model": model, "queue_id": queue_id})
@@ -909,7 +926,8 @@ def video_tool(
             except _video_jobs.VideoJobStoreError as e:
                 return _err(
                     f"video: queued as {queue_id}, but could not save private "
-                    f"retrieval metadata: {e}"
+                    f"retrieval metadata: {e}; "
+                    f"{_job_retry_hint(queue_id, type='video', model=model)}"
                 )
         return _job_handle(queue_id, type="video", model=model, quote_value=quote_value)
 
@@ -917,7 +935,10 @@ def video_tool(
     try:
         output_root.mkdir(parents=True, exist_ok=True)
     except OSError as e:
-        return _err(f"video: could not create output directory {output_root}: {e}")
+        return _err(
+            f"video: could not create output directory {output_root}: {e}; "
+            f"{_job_retry_hint(queue_id, type='video', model=model)}"
+        )
     try:
         ctype, payload, byte_count = _video.retrieve_bytes(
             client, model, queue_id,
@@ -926,11 +947,20 @@ def video_tool(
             download_dir=output_root,
         )
     except VeniceAPIError as e:
-        return _err(f"video retrieve failed: {e}")
+        return _err(
+            f"video retrieve failed: {e}; "
+            f"{_job_retry_hint(queue_id, type='video', model=model)}"
+        )
     except TimeoutError as e:
-        return _err(f"video: {e}; the job {queue_id} may still finish server-side")
+        return _err(
+            f"video: {e}; the job may still finish server-side; "
+            f"{_job_retry_hint(queue_id, type='video', model=model)}"
+        )
     except _video.NoVideoStream:
-        return _err(f"video: job {queue_id} completed but returned no video stream")
+        return _err(
+            f"video: job {queue_id} completed but returned no video stream; "
+            f"{_job_retry_hint(queue_id, type='video', model=model)}"
+        )
 
     ext, _unknown = _queue.ext_for(ctype, _video.VIDEO_EXT_BY_CTYPE, default=".mp4")
     out_path = _queue.resolve_output_path(
@@ -944,11 +974,17 @@ def video_tool(
                 payload.unlink()
             except OSError:
                 pass
-            return _err(f"video: could not write {out_path}: {e}")
+            return _err(
+                f"video: could not write {out_path}: {e}; "
+                f"{_job_retry_hint(queue_id, type='video', model=model)}"
+            )
     else:
         werr = _write(out_path, payload)
         if werr:
-            return _err(f"video: could not write {out_path}: {werr}")
+            return _err(
+                f"video: could not write {out_path}: {werr}; "
+                f"{_job_retry_hint(queue_id, type='video', model=model)}"
+            )
 
     try:  # best-effort cleanup; the file is already saved
         client.post_json("/video/complete", {"model": model, "queue_id": queue_id})
@@ -999,7 +1035,10 @@ def job_status_tool(client, *, queue_id: str, type: str, model: str) -> dict:
                 "queue_id": queue_id,
                 "message": f"job {queue_id} not found (expired, wrong type, or bad id)",
             }
-        return _err(f"job_status: {e}")
+        return _err(
+            f"job_status: {e}; "
+            f"{_job_retry_hint(queue_id, type=type, model=model)}"
+        )
 
     if isinstance(payload, (bytes, bytearray)):
         return {"status": "done", "ready": True, "queue_id": queue_id,
@@ -1063,12 +1102,18 @@ def job_result_tool(
             try:
                 download_url = _video_jobs.lookup(queue_id, model)
             except _video_jobs.VideoJobStoreError as e:
-                return _err(f"job_result: cannot read private retrieval metadata: {e}")
+                return _err(
+                    f"job_result: cannot read private retrieval metadata: {e}; "
+                    f"{_job_retry_hint(queue_id, type=type, model=model)}"
+                )
             output_root = resolve_output_dir(None)
             try:
                 output_root.mkdir(parents=True, exist_ok=True)
             except OSError as e:
-                return _err(f"job_result: could not create output directory: {e}")
+                return _err(
+                    f"job_result: could not create output directory: {e}; "
+                    f"{_job_retry_hint(queue_id, type=type, model=model)}"
+                )
             ctype, data, byte_count = _video.retrieve_bytes(
                 client, model, queue_id,
                 poll_interval=_video.config.VIDEO_POLL_INTERVAL_SEC,
@@ -1086,10 +1131,14 @@ def job_result_tool(
     except _video.NoVideoStream:
         return _err(
             f"job_result: video job {queue_id} completed but returned no stream; "
-            "no private download metadata is available"
+            "no private download metadata is available; "
+            f"{_job_retry_hint(queue_id, type=type, model=model)}"
         )
     except VeniceAPIError as e:
-        return _err(f"job_result: retrieve failed: {e}")
+        return _err(
+            f"job_result: retrieve failed: {e}; "
+            f"{_job_retry_hint(queue_id, type=type, model=model)}"
+        )
 
     out_path = _queue.resolve_output_path(
         resolve_output_dir(None), queue_id, ext, prefix=name_prefix
@@ -1102,11 +1151,17 @@ def job_result_tool(
                 data.unlink()
             except OSError:
                 pass
-            return _err(f"job_result: could not write {out_path}: {e}")
+            return _err(
+                f"job_result: could not write {out_path}: {e}; "
+                f"{_job_retry_hint(queue_id, type=type, model=model)}"
+            )
     else:
         werr = _write(out_path, data)
         if werr:
-            return _err(f"job_result: could not write {out_path}: {werr}")
+            return _err(
+                f"job_result: could not write {out_path}: {werr}; "
+                f"{_job_retry_hint(queue_id, type=type, model=model)}"
+            )
 
     try:  # best-effort cleanup; the file is already saved
         client.post_json(f"/{base}/complete", {"model": model, "queue_id": queue_id})

--- a/src/venice/commands/video.py
+++ b/src/venice/commands/video.py
@@ -14,6 +14,7 @@ from __future__ import annotations
 
 import json
 import os
+import shlex
 import sys
 import time
 from pathlib import Path
@@ -28,6 +29,13 @@ VIDEO_EXT_BY_CTYPE = {
     "video/webm": ".webm",
     "video/quicktime": ".mov",
 }
+
+
+def _status_retry_hint(queue_id: str, model: str) -> str:
+    return (
+        f"venice video-status {shlex.quote(queue_id)} "
+        f"--model {shlex.quote(model)}"
+    )
 
 # Media inputs (issue #18): a value is passed through when it is already an
 # http(s)/data URL, otherwise it is treated as a local file, size-checked, and
@@ -474,7 +482,8 @@ def _run_generate(args) -> int:
             except _video_jobs.VideoJobStoreError as e:
                 print(
                     f"video: queued as {queue_id}, but could not save private "
-                    f"retrieval metadata: {e}",
+                    f"retrieval metadata: {e}; check later with: "
+                    f"{_status_retry_hint(queue_id, model)}",
                     file=sys.stderr,
                 )
                 return 9
@@ -524,7 +533,11 @@ def _run_status(args) -> int:
         try:
             download_url = _video_jobs.lookup(args.queue_id, model)
         except _video_jobs.VideoJobStoreError as e:
-            print(f"video-status: cannot read private retrieval metadata: {e}", file=sys.stderr)
+            print(
+                "video-status: cannot read private retrieval metadata: "
+                f"{e}; retry with: {_status_retry_hint(args.queue_id, model)}",
+                file=sys.stderr,
+            )
             return 9
     return _retrieve_and_save(
         client, model, args.queue_id, download_url,
@@ -577,6 +590,7 @@ def _retrieve_and_save(
     poll_interval, max_wait, no_cleanup,
 ) -> int:
     start = time.monotonic()
+    retry_hint = _status_retry_hint(queue_id, model)
     staging_hint = _queue.resolve_output_path(
         out_arg, queue_id, ".mp4", prefix="venice-video"
     )
@@ -592,22 +606,21 @@ def _retrieve_and_save(
             staged_path = payload
     except VeniceAPIError as e:
         sys.stderr.write("\n")
-        print(f"retrieve failed: {e}", file=sys.stderr)
+        print(
+            f"retrieve failed: {e}; check later with: {retry_hint}",
+            file=sys.stderr,
+        )
         return _queue.status_to_exit(e)
     except TimeoutError as e:
         sys.stderr.write("\n")
-        print(
-            f"{e}; check later with: venice video-status {queue_id} --model {model}",
-            file=sys.stderr,
-        )
+        print(f"{e}; check later with: {retry_hint}", file=sys.stderr)
         return 7
     except NoVideoStream:
         sys.stderr.write("\n")
         print(
             "video: job completed but returned no video stream and no "
             "private download metadata is known; for a pre-v0.83.10 job, re-run "
-            f"`venice video-status {queue_id} --model {model} "
-            "--download-url <url>`.",
+            f"`{retry_hint} --download-url <url>`.",
             file=sys.stderr,
         )
         return 2
@@ -625,7 +638,10 @@ def _retrieve_and_save(
         else:
             out_path.write_bytes(payload)
     except OSError as e:
-        print(f"could not write {out_path}: {e}", file=sys.stderr)
+        print(
+            f"could not write {out_path}: {e}; retry with: {retry_hint}",
+            file=sys.stderr,
+        )
         return 9
     finally:
         if staged_path is not None:

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -1,13 +1,15 @@
 """Unit tests for VeniceClient. Mocks urllib.request.urlopen."""
 import io
 import json
+import socket
 import tempfile
 import threading
+import time
 import unittest
 from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 from pathlib import Path
 from unittest import mock
-from urllib.error import HTTPError
+from urllib.error import HTTPError, URLError
 
 from venice import __version__
 from venice.client import VeniceAPIError, VeniceClient
@@ -172,6 +174,52 @@ class TestVeniceClient(unittest.TestCase):
             self.assertIn("timed out", str(cm.exception))
             self.assertEqual(list(Path(td).iterdir()), [])
 
+    def test_download_open_timeout_and_oserror_become_api_errors(self):
+        c = VeniceClient(api_key="test-fake-key")
+
+        class Opener:
+            def __init__(self, error):
+                self.error = error
+
+            def open(self, req, timeout=None):
+                raise self.error
+
+        with tempfile.TemporaryDirectory() as td:
+            for error, text in (
+                (socket.timeout("slow"), "timed out"),
+                (ConnectionResetError("reset"), "connection failed"),
+            ):
+                with self.subTest(error=type(error).__name__), mock.patch(
+                    "venice.client._egress.build_https_opener",
+                    return_value=Opener(error),
+                ), self.assertRaises(VeniceAPIError) as cm:
+                    c.download_url_to_temp(
+                        "https://example.test/video", Path(td)
+                    )
+                self.assertEqual(cm.exception.status, 0)
+                self.assertIn(text, str(cm.exception))
+                self.assertEqual(list(Path(td).iterdir()), [])
+
+    def test_download_read_timeout_cleans_partial_file(self):
+        c = VeniceClient(api_key="test-fake-key")
+
+        class SlowResp(FakeResp):
+            def read(self, n=-1):
+                raise socket.timeout("slow body")
+
+        class Opener:
+            def open(self, req, timeout=None):
+                return SlowResp(200, b"", "video/mp4")
+
+        with tempfile.TemporaryDirectory() as td, mock.patch(
+            "venice.client._egress.build_https_opener", return_value=Opener()
+        ):
+            with self.assertRaisesRegex(VeniceAPIError, "timed out"):
+                c.download_url_to_temp(
+                    "https://example.test/video", Path(td)
+                )
+            self.assertEqual(list(Path(td).iterdir()), [])
+
     def test_download_error_redacts_userinfo_query_and_fragment(self):
         c = VeniceClient(api_key="test-fake-key")
         url = "https://user:pass@example.test/video?signature=secret#fragment"
@@ -328,6 +376,56 @@ class TestVeniceClient(unittest.TestCase):
         self.assertTrue(ct.startswith("application/json"))
         self.assertEqual(payload, {"status": "PROCESSING"})
 
+    def test_post_for_bytes_or_json_accepts_structured_json_type(self):
+        c = VeniceClient(api_key="k")
+        body = b'{"status":"PROCESSING"}'
+        with mock.patch(
+            "venice.client.urllib.request.urlopen",
+            lambda *a, **kw: FakeResp(
+                200, body, "application/vnd.venice.status+json; charset=utf-8"
+            ),
+        ):
+            _ct, payload = c.post_for_bytes_or_json("/audio/retrieve", {})
+        self.assertEqual(payload, {"status": "PROCESSING"})
+
+    def test_async_malformed_and_empty_bodies_become_api_errors(self):
+        c = VeniceClient(api_key="k")
+        cases = (
+            (b"{broken", "application/json", "non-JSON response"),
+            (b"", "application/json", "empty async response"),
+            (b"", "audio/mpeg", "empty async response"),
+        )
+        for body, ctype, message in cases:
+            with self.subTest(body=body, ctype=ctype), mock.patch(
+                "venice.client.urllib.request.urlopen",
+                lambda *a, _body=body, _ctype=ctype, **kw: FakeResp(
+                    200, _body, _ctype
+                ),
+            ), self.assertRaisesRegex(VeniceAPIError, message) as cm:
+                c.post_for_bytes_or_json("/audio/retrieve", {})
+            self.assertEqual(cm.exception.status, 200)
+
+    def test_async_missing_or_misdeclared_json_is_decoded_conservatively(self):
+        c = VeniceClient(api_key="k")
+        body = b'{"status":"PROCESSING"}'
+        for ctype in ("", "text/plain"):
+            with self.subTest(ctype=ctype), mock.patch(
+                "venice.client.urllib.request.urlopen",
+                lambda *a, _ctype=ctype, **kw: FakeResp(200, body, _ctype),
+            ):
+                _ct, payload = c.post_for_bytes_or_json(
+                    "/audio/retrieve", {}
+                )
+            self.assertEqual(payload, {"status": "PROCESSING"})
+
+    def test_async_unknown_binary_type_fails_closed(self):
+        c = VeniceClient(api_key="k")
+        with mock.patch(
+            "venice.client.urllib.request.urlopen",
+            lambda *a, **kw: FakeResp(200, b"binary", "application/octet-stream"),
+        ), self.assertRaisesRegex(VeniceAPIError, "unexpected async content type"):
+            c.post_for_bytes_or_json("/audio/retrieve", {})
+
     def test_http_error_becomes_venice_api_error_with_code(self):
         c = VeniceClient(api_key="k")
         err_body = json.dumps({"code": "INSUFFICIENT_BALANCE", "message": "broke"}).encode()
@@ -347,9 +445,24 @@ class TestVeniceClient(unittest.TestCase):
         self.assertEqual(cm.exception.status, 402)
         self.assertEqual(cm.exception.code, "INSUFFICIENT_BALANCE")
 
-    def test_url_error_becomes_venice_api_error_status_zero(self):
-        from urllib.error import URLError
+    def test_structured_json_http_error_extracts_code(self):
+        c = VeniceClient(api_key="k")
 
+        def boom(*a, **kw):
+            raise HTTPError(
+                url="https://api.venice.ai/api/v1/audio/queue",
+                code=409,
+                msg="Conflict",
+                hdrs={"Content-Type": "application/problem+json"},  # type: ignore[arg-type]
+                fp=io.BytesIO(b'{"code":"JOB_CONFLICT"}'),
+            )
+
+        with mock.patch("venice.client.urllib.request.urlopen", boom), \
+             self.assertRaises(VeniceAPIError) as cm:
+            c.post_json("/audio/queue", {})
+        self.assertEqual(cm.exception.code, "JOB_CONFLICT")
+
+    def test_url_error_becomes_venice_api_error_status_zero(self):
         c = VeniceClient(api_key="k")
 
         def boom(*a, **kw):
@@ -359,6 +472,71 @@ class TestVeniceClient(unittest.TestCase):
             with self.assertRaises(VeniceAPIError) as cm:
                 c.post_json("/whatever", {})
         self.assertEqual(cm.exception.status, 0)
+
+    def test_direct_timeout_and_oserror_become_api_errors_status_zero(self):
+        c = VeniceClient(api_key="k")
+        for error, message in (
+            (socket.timeout("slow"), "request timed out"),
+            (ConnectionResetError("reset"), "connection error"),
+        ):
+            with self.subTest(error=type(error).__name__), mock.patch(
+                "venice.client.urllib.request.urlopen", side_effect=error
+            ), self.assertRaisesRegex(VeniceAPIError, message) as cm:
+                c.post_json("/whatever", {})
+            self.assertEqual(cm.exception.status, 0)
+
+    def test_urlerror_wrapped_timeout_becomes_api_error_status_zero(self):
+        c = VeniceClient(api_key="k")
+        with mock.patch(
+            "venice.client.urllib.request.urlopen",
+            side_effect=URLError(socket.timeout("slow")),
+        ), self.assertRaisesRegex(VeniceAPIError, "request timed out") as cm:
+            c.post_json("/whatever", {})
+        self.assertEqual(cm.exception.status, 0)
+
+    def test_loopback_timeouts_before_headers_and_during_body_are_normalized(self):
+        stages = []
+
+        class Handler(BaseHTTPRequestHandler):
+            def do_GET(self):
+                if self.path == "/headers":
+                    time.sleep(0.1)
+                    return
+                self.send_response(200)
+                self.send_header("Content-Type", "application/json")
+                self.end_headers()
+                self.wfile.flush()
+                time.sleep(0.1)
+                try:
+                    self.wfile.write(b'{"ok":true}')
+                except (BrokenPipeError, ConnectionResetError):
+                    pass
+
+            def log_message(self, format, *args):
+                pass
+
+        with ThreadingHTTPServer(("127.0.0.1", 0), Handler) as server:
+            thread = threading.Thread(target=server.serve_forever)
+            thread.start()
+            try:
+                client = VeniceClient(
+                    api_key="test-fake-key",
+                    base_url=f"http://127.0.0.1:{server.server_port}",
+                    timeout=0.02,
+                )
+                for path in ("/headers", "/body"):
+                    with self.subTest(path=path), self.assertRaises(
+                        VeniceAPIError
+                    ) as cm:
+                        client.get_json(path)
+                    stages.append((path, cm.exception.status, str(cm.exception)))
+            finally:
+                server.shutdown()
+                thread.join()
+
+        self.assertEqual([status for _path, status, _text in stages], [0, 0])
+        for _path, _status, text in stages:
+            self.assertIn("timed out", text)
 
     def test_poll_retrieve_returns_audio_after_processing_then_done(self):
         c = VeniceClient(api_key="k")

--- a/tests/test_mcp_tools.py
+++ b/tests/test_mcp_tools.py
@@ -246,6 +246,22 @@ class TestSfxTool(_ToolTest):
         self.assertEqual(os.listdir(self.td), [])            # nothing written
         self.assertTrue(all("/audio/retrieve" not in u for u in seen))
 
+    def test_malformed_retrieve_returns_retryable_error(self):
+        responses = _seq(
+            FakeResp(200, b'{"quote": 0.0027}'),
+            FakeResp(200, b'{"queue_id":"sfxretry123"}'),
+            FakeResp(200, b"{broken", "application/json"),
+        )
+        with mock.patch(
+            "venice.client.urllib.request.urlopen", responses
+        ), self.stdout_guard():
+            res = _mcp.sfx_tool(
+                _client(), "thunder", output_dir=self.td, confirm=True
+            )
+        self.assertEqual(res["status"], "error")
+        self.assertIn("sfxretry123", res["message"])
+        self.assertIn("retry venice_job_result", res["message"])
+
 
 class TestMusicTool(_ToolTest):
     def test_ok_queue_poll_save(self):

--- a/tests/test_music.py
+++ b/tests/test_music.py
@@ -9,6 +9,7 @@ import contextlib
 import io
 import json
 import os
+import socket
 import sys
 import tempfile
 import unittest
@@ -318,6 +319,34 @@ class TestMusicFlow(unittest.TestCase):
         self.assertEqual(rc, 0)
         writes = "".join(c.args[0] for c in out.write.call_args_list)
         self.assertIn("BGMUSIC99", writes)
+
+    def test_transport_timeout_keeps_queue_recovery_hint_and_exit(self):
+        from venice.commands import music
+
+        responses = iter([
+            FakeResp(200, _models_payload(), "application/json"),
+            _quote(),
+            _queue("musicqueue123456"),
+        ])
+
+        def urlopen(req, timeout=None):
+            try:
+                return next(responses)
+            except StopIteration:
+                raise socket.timeout("slow retrieve")
+
+        err = io.StringIO()
+        with mock.patch.dict(os.environ, {"VENICE_API_KEY": "fake"}), \
+             mock.patch("venice.client.urllib.request.urlopen", urlopen), \
+             contextlib.redirect_stderr(err):
+            rc = music._run_generate(_build_args())
+
+        self.assertEqual(rc, 8)
+        self.assertIn(
+            "venice music-status musicqueue123456 --model elevenlabs-music",
+            err.getvalue(),
+        )
+        self.assertNotIn("Traceback", err.getvalue())
 
     def test_config_model_reaches_the_body_and_the_status_hint(self):
         """#57 Class C1. Mirror of the sfx guard: `defaults.music.model` must

--- a/tests/test_sfx.py
+++ b/tests/test_sfx.py
@@ -139,6 +139,34 @@ class TestSfxFullFlow(unittest.TestCase):
         writes = "".join(c.args[0] for c in out.write.call_args_list)
         self.assertIn("BGID12345", writes)
 
+    def test_malformed_retrieve_keeps_queue_recovery_hint(self):
+        from venice.commands import sfx
+
+        responses = iter([
+            FakeResp(200, b'{"quote": 0.0027}', "application/json"),
+            FakeResp(
+                200,
+                b'{"queue_id":"abcdef1234567890","status":"QUEUED"}',
+                "application/json",
+            ),
+            FakeResp(200, b"{broken", "application/json"),
+        ])
+        err = io.StringIO()
+        with mock.patch.dict(os.environ, {"VENICE_API_KEY": "fake"}), \
+             mock.patch(
+                 "venice.client.urllib.request.urlopen",
+                 lambda *a, **kw: next(responses),
+             ), contextlib.redirect_stderr(err):
+            rc = sfx._run_generate(_build_args())
+
+        self.assertEqual(rc, 2)
+        self.assertIn(
+            "venice sfx-status abcdef1234567890 "
+            "--model elevenlabs-sound-effects-v2",
+            err.getvalue(),
+        )
+        self.assertNotIn("Traceback", err.getvalue())
+
     def test_master_flag_masters_saved_file(self):
         from venice.commands import sfx
 

--- a/tests/test_video.py
+++ b/tests/test_video.py
@@ -5,6 +5,7 @@ to resolve the default model (mirrors test_chat.py's catalog mock).
 """
 import argparse
 import base64
+import contextlib
 import io
 import json
 import os
@@ -219,6 +220,34 @@ class TestVideoFlow(unittest.TestCase):
         self.assertEqual(rc, 0)
         writes = "".join(c.args[0] for c in out.write.call_args_list)
         self.assertIn("BGVID99999", writes)
+
+    def test_malformed_retrieve_keeps_queue_recovery_hint(self):
+        from venice.commands import video
+
+        responses = iter([
+            _catalog(DEFAULT_MODEL),
+            FakeResp(200, b'{"quote": 0.5}', "application/json"),
+            FakeResp(
+                200,
+                b'{"queue_id":"vid12345678"}',
+                "application/json",
+            ),
+            FakeResp(200, b"{broken", "application/json"),
+        ])
+        err = io.StringIO()
+        with mock.patch.dict(os.environ, {"VENICE_API_KEY": "fake"}), \
+             mock.patch(
+                 "venice.client.urllib.request.urlopen",
+                 lambda *a, **kw: next(responses),
+             ), contextlib.redirect_stderr(err):
+            rc = video._run_generate(_build_args())
+
+        self.assertEqual(rc, 2)
+        self.assertIn(
+            f"venice video-status vid12345678 --model {DEFAULT_MODEL}",
+            err.getvalue(),
+        )
+        self.assertNotIn("Traceback", err.getvalue())
 
     def test_background_vps_url_is_stored_but_never_printed(self):
         from venice.commands import _video_jobs, video


### PR DESCRIPTION
## Summary

- normalize direct and wrapped request timeouts, connection errors, and download failures as `VeniceAPIError`
- decode JSON and structured `+json` async responses through the bounded decoder while rejecting empty or ambiguous binary bodies
- retain actionable queue-id recovery guidance across CLI and MCP post-queue failures
- cover loopback header/body timeouts, malformed or misdeclared responses, download cleanup, stable exits, and retry messages

## Validation

- `VENICE_API_KEY=test-fake-key make test` (1,710 tests)
- `VENICE_API_KEY=test-fake-key make drive` (37 tests)
- focused client/media/MCP suite (177 tests)
- `make lint`
- `make scan`
- `git diff --check`

No live Venice endpoint or real credential was used.

Closes #143.