### PR TITLE
fix(upscale): align current API contract

### DIFF
--- a/README.md
+++ b/README.md
@@ -334,25 +334,26 @@ forces it back on for a single call.
 ## Upscale images
 
 `venice image` caps output at 1280px, so take art larger by upscaling it
-(1-4x, default 2x) via `/image/upscale`:
+(2x or 4x, default 2x) via `/image/upscale`:
 
 ```sh
 # 2x upscale -> ./env-upscaled.png (960x540 -> 1920x1080).
 venice upscale env.png --scale 2 --yes
 
-# Enhance-only pass (scale 1 requires --enhance) with a style hint.
-venice upscale portrait.png --scale 1 --enhance --enhance-prompt gold --yes
-# ...or set `defaults.upscale.enhance true` once and --scale 1 works bare.
-
-# Custom output, tune how much the enhancer may change the image.
-venice upscale card.png --scale 4 --enhance --enhance-creativity 0.3 \
+# Custom output; creativity controls added detail/texture (0-0.02).
+venice upscale card.png --scale 4 --creativity 0.01 \
     -o card-4k.png --yes
 
 # Dry-run: show the planned output + balance, spend nothing.
 venice upscale env.png --dry-run
 ```
 
-Input is a PNG/JPEG file under 25 MB. Pricing is **dynamic** (Venice bills
+Input is a PNG/JPEG file under 25 MB. Venice's retired enhancer controls are no
+longer accepted; the current request contains only the image, scale, and optional
+creativity. The upstream contract changed after the original #1 workflow. Older
+configs containing `defaults.upscale.enhance`, `enhance_creativity`,
+`enhance_prompt`, or `replication` fail closed with `venice config unset` cleanup
+guidance instead of silently changing a paid request. Pricing is **dynamic** (Venice bills
 $0.001-$10.00 per call by input size and scale), so there's no reliable
 pre-charge estimate; the balance is shown and you confirm (or `--yes`).
 
@@ -1774,7 +1775,7 @@ The server exposes nine tools:
 | `venice_sfx` | sound effect (async queue) → audio file | yes (quoted) |
 | `venice_music` | long-form music/ambience (async queue) → audio file | yes (quoted) |
 | `venice_video` | text/image-to-video (async queue, long-running) → video file | yes (quoted) |
-| `venice_upscale` | upscale/enhance a local image → image file | yes (dynamic) |
+| `venice_upscale` | upscale a local image → image file | yes (dynamic) |
 | `venice_bg_remove` | remove a background → transparent PNG | yes (dynamic) |
 | `venice_image_edit` | edit/inpaint an image (+ optional mask layers) → image file | yes (dynamic) |
 | `venice_chat` | one-shot chat completion → reply text | no |
@@ -1901,8 +1902,7 @@ safety), it should be settable in config." Currently config-backable:
   `defaults.sfx.master` / `defaults.music.master`, not this table
 - `defaults.video.*` — `model`, `duration`, `resolution`, `aspect_ratio`,
   `negative_prompt`, `no_audio`, `no_cleanup`, `poll_interval`, `max_wait`
-- `defaults.upscale.*` — `scale`, `enhance`, `enhance_creativity`,
-  `enhance_prompt`, `replication`
+- `defaults.upscale.*` — `scale`, `creativity`
 - `defaults.contact_sheet.*` — `cols`, `cell`, `label`, `background`, `padding`,
   `engine`. Note the **underscore**: the command is `contact-sheet`, but config
   keys are addressed with dots, so the section is `contact_sheet` (as with

--- a/src/venice/commands/_agent.py
+++ b/src/venice/commands/_agent.py
@@ -49,6 +49,7 @@ from . import _models
 from . import _compact
 from . import _openai
 from . import _shared
+from . import upscale as _upscale
 from .models import MODEL_TYPES
 
 
@@ -1964,11 +1965,17 @@ _JOB_RESULT_SCHEMA = _obj(
 _UPSCALE_SCHEMA = _obj(
     {
         "input_path": _p("string", "Path to a local image file to upscale."),
-        "scale": _p("number", "Upscale factor, 1-4."),
-        "enhance": _p("boolean"),
-        "enhance_creativity": _p("number"),
-        "enhance_prompt": _p("string"),
-        "replication": _p("number"),
+        "scale": {
+            "type": "number",
+            "enum": list(_upscale.SCALES),
+            "description": "Upscale factor: 2 or 4.",
+        },
+        "creativity": {
+            "type": "number",
+            "minimum": _upscale.MIN_CREATIVITY,
+            "maximum": _upscale.MAX_CREATIVITY,
+            "description": "Detail/texture creativity (server default 0.01).",
+        },
     },
     required=["input_path"],
 )
@@ -2244,7 +2251,7 @@ _BUILTINS = [
     ToolSpec(
         "venice_upscale",
         "upscale_tool",
-        "Upscale/enhance a local image (factor 1-4) via Venice /image/upscale. Writes "
+        "Upscale a local image (factor 2 or 4) via Venice /image/upscale. Writes "
         "the result and returns its path. Dynamic pricing, so it always needs "
         "confirmation.",
         _UPSCALE_SCHEMA,
@@ -2641,8 +2648,26 @@ def builtin_tools(
 
     def _make_paid(impl, section, impl_name):
         defaults = _config_defaults(section, impl)
+        retired_config = (
+            _upscale.retired_config_keys(config) if section == "upscale" else ()
+        )
 
         def invoke(arguments, *, confirm: bool = False):
+            if section == "upscale":
+                retired_args = tuple(
+                    key for key in _upscale.RETIRED_CONFIG_KEYS if key in arguments
+                )
+                if retired_args:
+                    names = ", ".join(retired_args)
+                    return {
+                        "status": "error",
+                        "message": f"upscale: retired argument(s): {names}",
+                    }
+                if retired_config:
+                    return {
+                        "status": "error",
+                        "message": _upscale.retired_config_message(retired_config),
+                    }
             controlled = {
                 "confirm": confirm,
                 "max_spend": max_spend,

--- a/src/venice/commands/_mcp.py
+++ b/src/venice/commands/_mcp.py
@@ -584,16 +584,13 @@ def upscale_tool(
     input_path: str,
     *,
     scale: float = _upscale.DEFAULT_SCALE,
-    enhance: Optional[bool] = None,
-    enhance_creativity: Optional[float] = None,
-    enhance_prompt: Optional[str] = None,
-    replication: Optional[float] = None,
+    creativity: Optional[float] = None,
     output_dir: Optional[str] = None,
     confirm: bool = False,
     max_spend: Optional[float] = None,
     path_authority=None,
 ) -> dict:
-    """Upscale/enhance an image via /image/upscale (dynamic price -> needs confirm)."""
+    """Upscale an image via /image/upscale (dynamic price -> needs confirm)."""
     resolved = _model_media_path(
         path_authority, input_path, kind="image",
         max_bytes=_shared.MAX_IMAGE_BYTES, label="upscale",
@@ -601,11 +598,7 @@ def upscale_tool(
     if isinstance(resolved, dict):
         return resolved
     inp, _mime = resolved
-    ns = SimpleNamespace(
-        input=inp, scale=scale, enhance=enhance,
-        enhance_creativity=enhance_creativity, enhance_prompt=enhance_prompt,
-        replication=replication,
-    )
+    ns = SimpleNamespace(input=inp, scale=scale, creativity=creativity)
     rc = _upscale._validate(ns)  # stderr warnings only
     if rc is not None:
         return _err(f"upscale: invalid arguments (exit {rc})")

--- a/src/venice/commands/upscale.py
+++ b/src/venice/commands/upscale.py
@@ -1,4 +1,4 @@
-"""`venice upscale` -- upscale/enhance an image via /image/upscale (sync).
+"""`venice upscale` -- upscale an image via /image/upscale (sync).
 
 `/image/generate` caps width/height at 1280, so large environment art is made
 ≤1280 then upscaled here (e.g. ×2: 960×540 -> 1920×1080). The input image is
@@ -9,7 +9,6 @@ so there is no reliable upfront quote -- we show the balance and confirm.
 """
 from __future__ import annotations
 
-import argparse
 import sys
 from pathlib import Path
 from typing import Optional
@@ -29,17 +28,57 @@ from ._shared import (
 )
 
 ENDPOINT = "/image/upscale"
-MAX_ENHANCE_PROMPT = 1500
 DEFAULT_SCALE = 2.0
+SCALES = (2.0, 4.0)
+MIN_CREATIVITY = 0.0
+MAX_CREATIVITY = 0.02
+SERVER_DEFAULT_CREATIVITY = 0.01
+RETIRED_CONFIG_KEYS = (
+    "enhance",
+    "enhance_creativity",
+    "enhance_prompt",
+    "replication",
+)
+
+
+def retired_config_keys(doc) -> tuple[str, ...]:
+    """Retired ``defaults.upscale`` keys present in a config document.
+
+    Unknown config keys deliberately survive normal config round-trips.  These
+    four cannot merely become unknown: silently ignoring an old paid-operation
+    preference would make a request whose output no longer matches the user's
+    stated intent.  Callers therefore fail the upscale operation closed while
+    leaving unrelated commands/tools usable.
+    """
+    if not isinstance(doc, dict):
+        return ()
+    defaults = doc.get("defaults")
+    if not isinstance(defaults, dict):
+        return ()
+    section = defaults.get("upscale")
+    if not isinstance(section, dict):
+        return ()
+    return tuple(key for key in RETIRED_CONFIG_KEYS if key in section)
+
+
+def retired_config_message(keys) -> str:
+    joined = ", ".join(f"defaults.upscale.{key}" for key in keys)
+    commands = "; ".join(
+        f"venice config unset defaults.upscale.{key}" for key in keys
+    )
+    return (
+        f"upscale: retired config setting(s): {joined}; Venice no longer accepts "
+        f"the enhancer controls. Remove them with: {commands}"
+    )
 
 
 def register(subparsers) -> None:
     p = subparsers.add_parser(
         "upscale",
-        help="Upscale/enhance an image via /image/upscale (sync).",
+        help="Upscale an image via /image/upscale (sync).",
         description=(
-            "Upscales an image by a factor of 1-4 (default 2), optionally running "
-            "Venice's enhancer. Use this to take generated art above the 1280px "
+            "Upscales an image by a factor of 2 or 4 (default 2). Use this to "
+            "take generated art above the 1280px "
             "generate cap, e.g. `venice upscale env.png --scale 2` -> 2x. Pricing "
             "is dynamic; the balance is shown and you confirm before the charge."
         ),
@@ -50,37 +89,18 @@ def register(subparsers) -> None:
         type=_numeric.finite_float,
         default=None,
         metavar="N",
-        help=f"Upscale factor 1-4 (default {DEFAULT_SCALE:g}). Scale 1 only runs "
-        "the enhancer and requires --enhance. Config-backable via "
-        "defaults.upscale.scale; an explicit --scale still wins.",
+        help=f"Upscale factor: 2 or 4 (default {DEFAULT_SCALE:g}). "
+        "Config-backable via defaults.upscale.scale; an explicit --scale still wins.",
     )
     p.add_argument(
-        "--enhance",
-        action=argparse.BooleanOptionalAction,
-        default=None,
-        help="Run Venice's enhancer during upscaling (required when --scale 1). "
-        "Config-backable via defaults.upscale.enhance; an explicit "
-        "--enhance/--no-enhance still wins.",
-    )
-    p.add_argument(
-        "--enhance-creativity",
+        "--creativity",
         type=_numeric.finite_float,
         default=None,
         metavar="F",
-        help="0-1 (default 0.5); higher lets the enhancer change the image more.",
-    )
-    p.add_argument(
-        "--enhance-prompt",
-        default=None,
-        metavar="TEXT",
-        help="Short style to steer enhancement, e.g. 'gold' (<=1500 chars).",
-    )
-    p.add_argument(
-        "--replication",
-        type=_numeric.finite_float,
-        default=None,
-        metavar="R",
-        help="0-1 (default 0.35); how strongly base-image lines/noise are kept.",
+        help=f"Detail/texture creativity from {MIN_CREATIVITY:g} to "
+        f"{MAX_CREATIVITY:g} (server default {SERVER_DEFAULT_CREATIVITY:g}). "
+        "Config-backable via defaults.upscale.creativity; omitted values are "
+        "left to the server.",
     )
     p.add_argument("--output", "-o", type=Path, default=None,
                    help="Output file or directory. Default: cwd/<input>-upscaled.png.")
@@ -103,22 +123,17 @@ def _validate(args) -> Optional[int]:
     rc = check_image_file(args.input, label="upscale")
     if rc is not None:
         return rc
-    if not (1 <= args.scale <= 4):
-        print(f"upscale: --scale {args.scale} out of range (1-4)", file=sys.stderr)
+    if args.scale not in SCALES:
+        print(f"upscale: --scale must be 2 or 4 (got {args.scale})", file=sys.stderr)
         return 2
-    if args.scale == 1 and not args.enhance:
-        print("upscale: --scale 1 only runs the enhancer; pass --enhance "
-              "(or use --scale >1)", file=sys.stderr)
-        return 2
-    if args.enhance_creativity is not None and not (0 <= args.enhance_creativity <= 1):
-        print("upscale: --enhance-creativity must be between 0 and 1", file=sys.stderr)
-        return 2
-    if args.replication is not None and not (0 <= args.replication <= 1):
-        print("upscale: --replication must be between 0 and 1", file=sys.stderr)
-        return 2
-    if args.enhance_prompt is not None and len(args.enhance_prompt) > MAX_ENHANCE_PROMPT:
-        print(f"upscale: --enhance-prompt exceeds {MAX_ENHANCE_PROMPT} chars",
-              file=sys.stderr)
+    if args.creativity is not None and not (
+        MIN_CREATIVITY <= args.creativity <= MAX_CREATIVITY
+    ):
+        print(
+            f"upscale: --creativity must be between {MIN_CREATIVITY:g} and "
+            f"{MAX_CREATIVITY:g}",
+            file=sys.stderr,
+        )
         return 2
     return None
 
@@ -127,14 +142,9 @@ def _build_body(args, image_b64: str) -> dict:
     body: dict = {
         "image": image_b64,
         "scale": args.scale,
-        "enhance": bool(args.enhance),
     }
-    if args.enhance_creativity is not None:
-        body["enhanceCreativity"] = args.enhance_creativity
-    if args.enhance_prompt is not None:
-        body["enhancePrompt"] = args.enhance_prompt
-    if args.replication is not None:
-        body["replication"] = args.replication
+    if args.creativity is not None:
+        body["creativity"] = args.creativity
     return body
 
 
@@ -143,7 +153,12 @@ def _fmt_scale(scale: float) -> str:
 
 
 def _run(args) -> int:
-    userconfig.apply_defaults(args, "upscale")
+    doc = userconfig.load_config()
+    retired = retired_config_keys(doc)
+    if retired:
+        print(retired_config_message(retired), file=sys.stderr)
+        return 2
+    userconfig.apply_defaults(args, "upscale", doc)
     # #57 Class C1: built-in literal last, before `_validate`'s range check,
     # which cannot compare None. A config-set `scale: 0` deliberately survives
     # this to reach that check's own out-of-range message.

--- a/src/venice/mcp_server.py
+++ b/src/venice/mcp_server.py
@@ -11,12 +11,13 @@ input schema via typing.get_type_hints, so the annotations must stay concrete
 (`typing.Optional[int]`, not stringized `int | None`).
 """
 import os
-from typing import List, Optional
+from typing import Annotated, List, Literal, Optional
 
 from mcp.server.fastmcp import FastMCP
+from pydantic import Field
 
 from . import userconfig
-from .commands import _mcp, _shared
+from .commands import _mcp, _shared, upscale as _upscale
 
 
 def _merged(defaults: dict, host: dict) -> dict:
@@ -53,6 +54,7 @@ def build_server(client, doc=None, root=None) -> FastMCP:
         "image_edit": userconfig.config_defaults_for("image_edit", _mcp.image_edit_tool, doc),
         "chat": userconfig.config_defaults_for("chat", _mcp.chat_tool, doc),
     }
+    _retired_upscale_config = _upscale.retired_config_keys(doc)
 
     @server.tool()
     def venice_image(
@@ -166,25 +168,29 @@ def build_server(client, doc=None, root=None) -> FastMCP:
     @server.tool()
     def venice_upscale(
         input_path: str,
-        scale: Optional[float] = None,
-        enhance: Optional[bool] = None,
-        enhance_creativity: Optional[float] = None,
-        enhance_prompt: Optional[str] = None,
-        replication: Optional[float] = None,
+        scale: Optional[Literal[2, 4]] = None,
+        creativity: Optional[
+            Annotated[float, Field(ge=_upscale.MIN_CREATIVITY,
+                                   le=_upscale.MAX_CREATIVITY)]
+        ] = None,
         output_dir: Optional[str] = None,
         confirm: bool = False,
         max_spend: Optional[float] = None,
     ) -> dict:
-        """Upscale/enhance a local image (factor 1-4) via Venice /image/upscale. Writes
+        """Upscale a local image (factor 2 or 4) via Venice /image/upscale. Writes
         the result and returns its path. Pricing is dynamic (no up-front estimate), so
         this ALWAYS requires confirm=true. An omitted scale falls back to
         defaults.upscale.scale, then to 2.0."""
+        if _retired_upscale_config:
+            return {
+                "status": "error",
+                "message": _upscale.retired_config_message(_retired_upscale_config),
+            }
         return _mcp.upscale_tool(
             client, input_path,
             **_merged(_defaults["upscale"], dict(
-                scale=scale, enhance=enhance,
-                enhance_creativity=enhance_creativity, enhance_prompt=enhance_prompt,
-                replication=replication, output_dir=output_dir, confirm=confirm,
+                scale=scale, creativity=creativity,
+                output_dir=output_dir, confirm=confirm,
                 max_spend=max_spend, path_authority=path_authority,
             )),
         )

--- a/src/venice/userconfig.py
+++ b/src/venice/userconfig.py
@@ -650,10 +650,7 @@ _COMMAND_MAP = {
     "upscale": {
         # #57 Class C: literal now lives in `upscale._run`.
         "scale": ("scale", _numeric.finite_float),
-        "enhance": ("enhance", _as_bool),  # #57 Class B: tri-stated --enhance
-        "enhance_creativity": ("enhance_creativity", _numeric.finite_float),
-        "enhance_prompt": ("enhance_prompt", str),
-        "replication": ("replication", _numeric.finite_float),
+        "creativity": ("creativity", _numeric.finite_float),
     },
     # #71 compatibility-only browser defaults. The tools are security-disabled for
     # GHSA-mqjr-2vh8-6fvg, but these keys remain readable so existing configs survive and

--- a/tests/test_agent.py
+++ b/tests/test_agent.py
@@ -2719,6 +2719,43 @@ class TestMediaPathAuthorityWiring(unittest.TestCase):
         self.assertIs(vision.call_args.kwargs["path_authority"], authority)
         self.assertIs(upscale.call_args.kwargs["path_authority"], authority)
 
+    def test_upscale_schema_matches_current_contract(self):
+        tool = next(t for t in _agent.builtin_tools(
+            object(), only={"venice_upscale"}
+        ) if t.name == "venice_upscale")
+        props = tool.parameters["properties"]
+        self.assertEqual(set(props), {"input_path", "scale", "creativity"})
+        self.assertEqual(props["scale"]["enum"], [2.0, 4.0])
+        self.assertEqual(props["creativity"]["minimum"], 0.0)
+        self.assertEqual(props["creativity"]["maximum"], 0.02)
+
+    def test_replayed_retired_upscale_argument_fails_before_impl(self):
+        with mock.patch.object(_agent._mcp, "upscale_tool") as impl:
+            tool = next(t for t in _agent.builtin_tools(
+                object(), only={"venice_upscale"}
+            ) if t.name == "venice_upscale")
+            result = tool.invoke({"input_path": "frame.png", "enhance": True})
+        self.assertEqual(result["status"], "error")
+        self.assertIn("retired argument", result["message"])
+        impl.assert_not_called()
+
+    def test_retired_upscale_config_blocks_only_upscale(self):
+        doc = {"defaults": {"upscale": {"replication": 0.3}}}
+        with mock.patch.object(_agent._mcp, "upscale_tool") as upscale_impl, \
+             mock.patch.object(
+                 _agent._mcp, "bg_remove_tool", return_value={"status": "ok"}
+             ) as bg_impl:
+            tools = {t.name: t for t in _agent.builtin_tools(
+                object(), only={"venice_upscale", "venice_bg_remove"}, config=doc
+            )}
+            blocked = tools["venice_upscale"].invoke({"input_path": "frame.png"})
+            allowed = tools["venice_bg_remove"].invoke({"image_url": "https://x/y"})
+        self.assertEqual(blocked["status"], "error")
+        self.assertIn("defaults.upscale.replication", blocked["message"])
+        self.assertEqual(allowed["status"], "ok")
+        upscale_impl.assert_not_called()
+        bg_impl.assert_called_once()
+
 
 class TestReindexBuiltin(unittest.TestCase):
     """#44: reindex is a paid, no-arg builtin advertised by chat's default set."""

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -420,12 +420,10 @@ _CLASS_A_CASES = [
     ),
     dict(
         mod=upscale, argv=["upscale", "in.png"], key="upscale",
-        config={"enhance_creativity": "0.5", "enhance_prompt": "gold",
-                "replication": "0.3"},
-        expected={"enhance_creativity": 0.5, "enhance_prompt": "gold",
-                  "replication": 0.3},
-        explicit=["upscale", "in.png", "--replication", "0.9"],
-        edest="replication", eval=0.9,
+        config={"creativity": "0.01"},
+        expected={"creativity": 0.01},
+        explicit=["upscale", "in.png", "--creativity", "0.02"],
+        edest="creativity", eval=0.02,
     ),
     dict(
         mod=index, argv=["index"], key="index",
@@ -554,7 +552,7 @@ class TestClassAParity(unittest.TestCase):
 # collides with an existing flag -- fails here rather than at runtime.
 #
 # `on`/`off` are the two spellings that must produce True/False. Positive-sense
-# flags use BooleanOptionalAction (--enhance/--no-enhance); negative-sense dests
+# flags use BooleanOptionalAction; negative-sense dests
 # keep their name and gain a positive counterpart (--no-audio/--with-audio), so
 # the config key stays honest and no tool-argument name changes.
 # --------------------------------------------------------------------------- #
@@ -562,9 +560,6 @@ _CLASS_B_CASES = [
     dict(key="image_edit", mod=image_edit, argv=["image-edit", "p"],
          dest="safe_mode", on="--safe-mode", off="--no-safe-mode",
          cfg=False, want=False, explicit="--safe-mode", eval=True),
-    dict(key="upscale", mod=upscale, argv=["upscale", "in.png"],
-         dest="enhance", on="--enhance", off="--no-enhance",
-         cfg="yes", want=True, explicit="--no-enhance", eval=False),
     dict(key="video", mod=video, argv=["video", "p"],
          dest="no_audio", on="--no-audio", off="--with-audio",
          cfg=True, want=True, explicit="--with-audio", eval=False),

--- a/tests/test_mcp_serve.py
+++ b/tests/test_mcp_serve.py
@@ -81,6 +81,42 @@ class TestServerWiring(unittest.TestCase):
                     denied, kind="image", max_bytes=1024
                 )
 
+    def test_upscale_schema_matches_current_contract(self):
+        from venice.mcp_server import build_server
+
+        class FakeClient:
+            api_key = "fake"
+            base_url = "https://api.venice.ai/api/v1"
+
+        server = build_server(FakeClient(), doc={})
+        props = server._tool_manager.get_tool("venice_upscale").parameters["properties"]
+        self.assertEqual(
+            set(props),
+            {"input_path", "scale", "creativity", "output_dir", "confirm", "max_spend"},
+        )
+        self.assertEqual(props["scale"]["anyOf"][0]["enum"], [2, 4])
+        creativity = props["creativity"]["anyOf"][0]
+        self.assertEqual(creativity["minimum"], 0.0)
+        self.assertEqual(creativity["maximum"], 0.02)
+
+    def test_retired_upscale_config_returns_error_without_delegating(self):
+        from venice.mcp_server import build_server
+        from venice.commands import _mcp
+
+        class FakeClient:
+            api_key = "fake"
+            base_url = "https://api.venice.ai/api/v1"
+
+        doc = {"defaults": {"upscale": {"enhance_creativity": 0.5}}}
+        with mock.patch.object(_mcp, "upscale_tool") as impl:
+            server = build_server(FakeClient(), doc=doc)
+            result = server._tool_manager.get_tool("venice_upscale").fn(
+                input_path="frame.png"
+            )
+        self.assertEqual(result["status"], "error")
+        self.assertIn("defaults.upscale.enhance_creativity", result["message"])
+        impl.assert_not_called()
+
 
 @unittest.skipUnless(_HAS_MCP, "mcp SDK not installed (expected on Python 3.9)")
 class TestConfigDefaultsWiring(unittest.TestCase):
@@ -141,8 +177,6 @@ class TestConfigDefaultsWiring(unittest.TestCase):
     _CLASS_B_TOOLS = [
         ("music", "venice_music", "music_tool", "instrumental", dict(prompt="p")),
         ("video", "venice_video", "video_tool", "no_audio", dict(prompt="p")),
-        ("upscale", "venice_upscale", "upscale_tool", "enhance",
-         dict(input_path="in.png")),
         ("image_edit", "venice_image_edit", "image_edit_tool", "safe_mode",
          dict(prompt="p")),
     ]

--- a/tests/test_mcp_tools.py
+++ b/tests/test_mcp_tools.py
@@ -349,17 +349,42 @@ class TestBinaryTools(_ToolTest):
 
     def test_upscale_ok_with_confirm(self):
         ip = self._png()
-        with mock.patch(
-            "venice.client.urllib.request.urlopen",
-            _seq(FakeResp(200, b"UPSCALED", "image/png")),
-        ), self.stdout_guard():
+        captured = {}
+
+        def fake(req, timeout=None):
+            captured["body"] = json.loads(req.data.decode())
+            return FakeResp(200, b"UPSCALED", "image/png")
+
+        with mock.patch("venice.client.urllib.request.urlopen", fake), \
+             self.stdout_guard():
             res = _mcp.upscale_tool(
-                _client(), str(ip), output_dir=self.td, confirm=True,
+                _client(), str(ip), creativity=0.02,
+                output_dir=self.td, confirm=True,
                 path_authority=self.media_authority(),
             )
         self.assertEqual(res["status"], "ok")
         self.assertEqual(Path(res["path"]).read_bytes(), b"UPSCALED")
         self.assertTrue(res["path"].endswith("-upscaled.png"))
+        self.assertEqual(set(captured["body"]), {"image", "scale", "creativity"})
+        self.assertEqual(captured["body"]["scale"], 2.0)
+        self.assertEqual(captured["body"]["creativity"], 0.02)
+        self.assertEqual(base64.b64decode(captured["body"]["image"]), ip.read_bytes())
+
+    def test_upscale_invalid_contract_values_stop_before_http(self):
+        ip = self._png()
+
+        def boom(*a, **kw):
+            raise AssertionError("invalid upscale input must not hit the network")
+
+        for kwargs in ({"scale": 3.0}, {"creativity": 0.021}):
+            with self.subTest(kwargs=kwargs), \
+                 mock.patch("venice.client.urllib.request.urlopen", boom), \
+                 self.stdout_guard():
+                res = _mcp.upscale_tool(
+                    _client(), str(ip), output_dir=self.td, confirm=True,
+                    path_authority=self.media_authority(), **kwargs,
+                )
+            self.assertEqual(res["status"], "error")
 
     def test_bg_remove_from_url_ok(self):
         with mock.patch(

--- a/tests/test_upscale.py
+++ b/tests/test_upscale.py
@@ -21,10 +21,7 @@ def _args(**ov):
         input=Path("in.png"),
         # #57 Class C1: None on the parser now; `_run` resolves it.
         scale=None,
-        enhance=False,
-        enhance_creativity=None,
-        enhance_prompt=None,
-        replication=None,
+        creativity=None,
         output=None,
         yes=True,
         dry_run=False,
@@ -102,13 +99,16 @@ class TestUpscaleFlow(unittest.TestCase):
         self.assertEqual(rc, 0)
         self.assertTrue(captured["url"].endswith("/image/upscale"))
         self.assertEqual(base64.b64decode(captured["body"]["image"]), SOURCE_PNG)
+        self.assertEqual(
+            set(captured["body"]), {"image", "scale"},
+            "default request must match the current API contract exactly",
+        )
         self.assertEqual(captured["body"]["scale"], 2.0)
-        self.assertEqual(captured["body"]["enhance"], False)
         out = Path("in-upscaled.png")
         self.assertTrue(out.exists())
         self.assertEqual(out.read_bytes(), UPSCALED_PNG)
 
-    def test_optional_params_included_when_set(self):
+    def test_creativity_included_when_set(self):
         from venice.commands import upscale
 
         captured = {}
@@ -119,17 +119,12 @@ class TestUpscaleFlow(unittest.TestCase):
 
         with mock.patch.dict(os.environ, {"VENICE_API_KEY": "fake"}), \
              mock.patch("venice.client.urllib.request.urlopen", fake_urlopen):
-            rc = upscale._run(_args(
-                enhance=True, enhance_creativity=0.7,
-                enhance_prompt="gold", replication=0.2,
-            ))
+            rc = upscale._run(_args(creativity=0.01))
 
         self.assertEqual(rc, 0)
         b = captured["body"]
-        self.assertEqual(b["enhance"], True)
-        self.assertEqual(b["enhanceCreativity"], 0.7)
-        self.assertEqual(b["enhancePrompt"], "gold")
-        self.assertEqual(b["replication"], 0.2)
+        self.assertEqual(set(b), {"image", "scale", "creativity"})
+        self.assertEqual(b["creativity"], 0.01)
 
     def test_output_flag_names_file(self):
         from venice.commands import upscale
@@ -168,63 +163,99 @@ class TestUpscaleFlow(unittest.TestCase):
 
         self.assertEqual(rc, 2)
 
-    def test_scale_out_of_range_returns_2(self):
+    def test_unsupported_scales_return_2_before_network(self):
         from venice.commands import upscale
 
-        with mock.patch.dict(os.environ, {"VENICE_API_KEY": "fake"}):
-            rc = upscale._run(_args(scale=5.0))
-        self.assertEqual(rc, 2)
+        def explode(*a, **kw):
+            raise AssertionError("invalid scale must not hit the network")
 
-    def test_scale_one_without_enhance_returns_2(self):
+        for value in (1.0, 2.5, 3.0, 5.0):
+            with self.subTest(scale=value), \
+                 mock.patch.dict(os.environ, {"VENICE_API_KEY": "fake"}), \
+                 mock.patch("venice.client.urllib.request.urlopen", explode):
+                rc = upscale._run(_args(scale=value))
+            self.assertEqual(rc, 2)
+
+    def test_stale_enhancer_config_fails_closed_with_cleanup_guidance(self):
         from venice.commands import upscale
 
-        with mock.patch.dict(os.environ, {"VENICE_API_KEY": "fake"}):
-            rc = upscale._run(_args(scale=1.0, enhance=False))
-        self.assertEqual(rc, 2)
+        doc = {"version": 1, "mcpServers": {}, "defaults": {"upscale": {
+            "enhance": True,
+            "enhance_prompt": "gold",
+        }}}
+        err = io.StringIO()
 
-    def test_config_enhance_unlocks_scale_one(self):
-        """#57 Class B: apply_defaults runs before _validate, so setting
-        defaults.upscale.enhance once makes --scale 1 usable with no inline flag
-        -- previously an unavoidable exit 2."""
-        from venice.commands import upscale
+        def explode(*a, **kw):
+            raise AssertionError("retired config must not hit the network")
 
-        doc = {"version": 1, "mcpServers": {},
-               "defaults": {"upscale": {"enhance": True}}}
         with mock.patch.dict(os.environ, {"VENICE_API_KEY": "fake"}), \
-             mock.patch("venice.userconfig.load_config", lambda *a, **k: doc), \
-             mock.patch("venice.client.urllib.request.urlopen",
-                        lambda *a, **kw: FakeResp(200, UPSCALED_PNG, "image/png")):
-            rc = upscale._run(_args(scale=1.0, enhance=None))
-        self.assertEqual(rc, 0)
+             mock.patch("venice.userconfig.load_config", return_value=doc), \
+             mock.patch("venice.client.urllib.request.urlopen", explode), \
+             mock.patch("sys.stderr", err):
+            rc = upscale._run(_args())
+        self.assertEqual(rc, 2)
+        self.assertIn("defaults.upscale.enhance", err.getvalue())
+        self.assertIn(
+            "venice config unset defaults.upscale.enhance_prompt", err.getvalue()
+        )
 
-    def test_explicit_no_enhance_beats_config_and_still_gates(self):
+    def test_retired_cli_flags_are_not_parsed(self):
+        from venice.cli import build_parser
+
+        for flag in (
+            "--enhance",
+            "--no-enhance",
+            "--enhance-creativity",
+            "--enhance-prompt",
+            "--replication",
+        ):
+            with self.subTest(flag=flag), mock.patch("sys.stderr", io.StringIO()):
+                with self.assertRaises(SystemExit) as raised:
+                    build_parser().parse_args(["upscale", "in.png", flag])
+            self.assertEqual(raised.exception.code, 2)
+
+    def test_unset_creativity_is_omitted(self):
         from venice.commands import upscale
-
-        doc = {"version": 1, "mcpServers": {},
-               "defaults": {"upscale": {"enhance": True}}}
-        with mock.patch.dict(os.environ, {"VENICE_API_KEY": "fake"}), \
-             mock.patch("venice.userconfig.load_config", lambda *a, **k: doc):
-            rc = upscale._run(_args(scale=1.0, enhance=False))
-        self.assertEqual(rc, 2)  # explicit --no-enhance wins, gate still fires
-
-    def test_unset_enhance_sends_false_not_none(self):
-        from venice.commands import upscale
-        body = upscale._build_body(_resolved_args(enhance=None), "b64")
+        body = upscale._build_body(_resolved_args(creativity=None), "b64")
         # `_build_body` reads args.scale raw, with no fallback of its own -- so a
         # namespace that never went through `_run` must be resolved here or this
         # silently builds {"scale": null}. (#57 Class C1)
         self.assertEqual(body["scale"], upscale.DEFAULT_SCALE)
-        self.assertIs(body["enhance"], False)
+        self.assertNotIn("creativity", body)
 
-    def test_scale_one_with_enhance_ok(self):
+    def test_scale_four_ok(self):
         from venice.commands import upscale
 
         with mock.patch.dict(os.environ, {"VENICE_API_KEY": "fake"}), \
              mock.patch("venice.client.urllib.request.urlopen",
                         lambda *a, **kw: FakeResp(200, UPSCALED_PNG, "image/png")):
-            rc = upscale._run(_args(scale=1.0, enhance=True))
+            rc = upscale._run(_args(scale=4.0))
         self.assertEqual(rc, 0)
         self.assertTrue(Path("in-upscaled.png").exists())
+
+    def test_creativity_boundaries_are_accepted(self):
+        from venice.commands import upscale
+
+        for value in (0.0, 0.02):
+            with self.subTest(creativity=value), \
+                 mock.patch.dict(os.environ, {"VENICE_API_KEY": "fake"}), \
+                 mock.patch("venice.client.urllib.request.urlopen",
+                            lambda *a, **kw: FakeResp(200, UPSCALED_PNG, "image/png")):
+                rc = upscale._run(_args(creativity=value))
+            self.assertEqual(rc, 0)
+
+    def test_out_of_range_creativity_returns_2_before_network(self):
+        from venice.commands import upscale
+
+        def explode(*a, **kw):
+            raise AssertionError("invalid creativity must not hit the network")
+
+        for value in (-0.001, 0.021, float("inf"), float("nan")):
+            with self.subTest(creativity=value), \
+                 mock.patch.dict(os.environ, {"VENICE_API_KEY": "fake"}), \
+                 mock.patch("venice.client.urllib.request.urlopen", explode):
+                rc = upscale._run(_args(creativity=value))
+            self.assertEqual(rc, 2)
 
     def test_402_maps_to_1(self):
         from venice.commands import upscale


### PR DESCRIPTION
## Summary

- restrict upscale to the current supported scale values, 2 and 4
- replace retired enhancer controls with bounded optional creativity
- align CLI, config, MCP, agent/replay schemas, request bodies, and documentation
- fail closed on retired saved config or replayed tool arguments before any paid request

## Validation

- `VENICE_API_KEY=test-fake-key make test` (1,718 tests)
- `VENICE_API_KEY=test-fake-key make drive` (37 tests)
- focused upscale/config/MCP/agent suite (500+ tests across passes)
- `make lint`
- `make scan`
- isolated `python -m build` plus `twine check --strict` for wheel and sdist
- `git diff --check`

No live Venice endpoint or real credential was used.

Closes #144.