### PR TITLE
fix(tts): resolve live model formats

### DIFF
--- a/README.md
+++ b/README.md
@@ -222,28 +222,18 @@ venice tts "Fast talker." --speed 1.4 --yes
 venice tts "How much will this cost?" --dry-run
 ```
 
-### TTS models and pricing (per 1M characters)
+### TTS models, formats, and pricing
 
-| slug | price | voices |
-|---|---|---|
-| `tts-kokoro` (default) | $3.50 | 54 |
-| `tts-inworld-1-5-max` | $12.50 | 14 |
-| `tts-xai-v1` | $18.75 | 5 |
-| `tts-chatterbox-hd` | $50.00 | 9 |
-| `tts-orpheus` | $62.50 | 8 |
-| `tts-elevenlabs-turbo-v2-5` | $62.50 | 21 |
-| `tts-qwen3-0-6b` | $87.50 | 9 |
-| `tts-qwen3-1-7b` | $112.50 | 9 |
-| `tts-minimax-speech-02-hd` | $125.00 | 15 |
-| `tts-gemini-3-1-flash` | $187.50 | 30 |
+Models, voices, formats, defaults, and prices are resolved from the live TTS
+catalog so newly added models do not require a CLI release. To inspect one model:
 
-To see the voice list for any TTS model:
 ```sh
-venice models tts-kokoro | jq '.model_spec.voices'
+venice models tts-kokoro | jq '.model_spec | {voices, supported_formats, default_format, pricing}'
 ```
 
 If `--voice` is omitted Venice uses each model's built-in default.
-Formats supported: `mp3` (default), `opus`, `aac`, `flac`, `wav`, `pcm`.
+If `--format` is omitted Venice uses that model's advertised `default_format`;
+an explicit format is validated against its `supported_formats` before confirmation.
 
 ## Image generation
 
@@ -1944,7 +1934,7 @@ CLI-only because the tool implementations fix their own polling cadence, and
 their sections apply only on the command line.
 
 **Any** config value whose flag has a fixed set of choices is validated against
-that set — `defaults.image.format`, `defaults.tts.{model,format}`,
+that set — `defaults.image.format`,
 `defaults.sfx.model`, `defaults.video.{duration,resolution,aspect_ratio}`,
 `defaults.image_edit.{aspect_ratio,output_format}`, `defaults.chat.web_search`,
 `defaults.bit_depth` and `defaults.contact_sheet.engine`.
@@ -1968,10 +1958,8 @@ venice models elevenlabs-sound-effects-v2   # full JSON for one model
 venice models --type all --json        # everything, raw
 ```
 
-At time of writing the catalog spans ~258 models across text (80),
-code (30), image (26), **video (92)**, music+sfx (10), tts (10),
-embedding (9), and upscale (1). The video models include Sora 2,
-Veo 3.1, Kling, Runway Gen4, LTX-2, Wan 2.7, Seedance 2.0, and more.
+The catalog is live and may add or retire models without a CLI release. Use
+`--type`, `--type all`, or a slug lookup instead of relying on a frozen count.
 
 ### Exit codes
 

--- a/src/venice/commands/_agent.py
+++ b/src/venice/commands/_agent.py
@@ -1900,9 +1900,12 @@ _IMAGE_SCHEMA = _obj(
 _TTS_SCHEMA = _obj(
     {
         "text": _p("string", "The text to speak."),
-        "model": _p("string"),
+        "model": _p("string", "Live TTS catalog model id; defaults to tts-kokoro."),
         "voice": _p("string"),
-        "format": _p("string", "Audio format, e.g. mp3, opus, wav."),
+        "format": _p(
+            "string",
+            "Model-specific audio format. Omit to use the model's catalog default.",
+        ),
         "speed": _p("number", "0.25-4.0."),
     },
     required=["text"],
@@ -2294,7 +2297,8 @@ _BUILTINS = [
         "Get one model's details: pricing (cost), capabilities (text models: "
         "supportsVision/supportsFunctionCalling/...), constraints (image/media "
         "models: aspectRatios, resolutions, qualities, promptCharacterLimit), and "
-        "voices (TTS models: the valid voice ids for venice_tts) -- plus "
+        "voices and formats (TTS models: valid voice ids plus supported/default "
+        "formats for venice_tts) -- plus "
         "the full model_spec. Use it to budget input and confirm a model fits before "
         "using it. Read-only; not spend-gated.",
         _MODEL_DETAILS_SCHEMA,

--- a/src/venice/commands/_mcp.py
+++ b/src/venice/commands/_mcp.py
@@ -275,7 +275,7 @@ def tts_tool(
     *,
     model: str = _tts.DEFAULT_TTS_MODEL,
     voice: Optional[str] = None,
-    format: str = _tts.DEFAULT_FORMAT,
+    format: Optional[str] = None,
     speed: Optional[float] = None,
     output_dir: Optional[str] = None,
     confirm: bool = False,
@@ -284,39 +284,38 @@ def tts_tool(
     """Synthesize speech via /audio/speech; write an audio file, return its path."""
     if not text or not text.strip():
         return _err("tts: text is required")
-    if model not in _tts.TTS_MODELS:
-        return _err(f"tts: unknown model {model!r}")
-    if format not in _tts.FORMATS:
-        return _err(
-            f"tts: unknown format {format!r}; choose from {', '.join(_tts.FORMATS)}"
-        )
     if speed is not None and not (0.25 <= speed <= 4.0):
         return _err(f"tts: speed {speed} out of range (0.25-4.0)")
 
     text = text.strip()
     try:
-        price = _tts._fetch_tts_price_per_million(client, model)
-        cost = _tts._estimate_cost(len(text), price)
+        resolved = _tts._resolve_tts(client, model, format)
+        cost = _tts._estimate_cost(len(text), resolved.price_per_million)
     except ValueError as e:
         return _err(f"tts: {e}")
     gate = check_spend(cost, confirm=confirm, max_spend=max_spend, label="tts")
     if gate is not None:
         return gate
 
-    body: dict = {"input": text, "model": model, "response_format": format}
+    body: dict = {"input": text, "model": model}
+    if resolved.requested_format is not None:
+        body["response_format"] = resolved.requested_format
     if voice:
         body["voice"] = voice
     if speed is not None:
         body["speed"] = speed
     try:
-        _status, _ctype, audio = client.request("POST", "/audio/speech", json_body=body)
+        _status, ctype, audio = client.request("POST", "/audio/speech", json_body=body)
     except VeniceAPIError as e:
         return _err(f"tts failed: {e}")
     if not audio:
         return _err("tts: server returned empty body")
 
     short = _tts._short_id(text, model, voice)
-    out_path = _tts._resolve_output_path(resolve_output_dir(output_dir), short, format)
+    output_format = _tts._response_format(ctype, resolved.output_format)
+    out_path = _tts._resolve_output_path(
+        resolve_output_dir(output_dir), short, output_format
+    )
     werr = _write(out_path, audio)
     if werr:
         return _err(f"tts: could not write {out_path}: {werr}")
@@ -325,6 +324,7 @@ def tts_tool(
         "path": str(out_path.resolve()),
         "bytes": len(audio),
         "model": model,
+        "format": output_format,
         "cost_estimate_usd": cost,
     }
 
@@ -1449,8 +1449,8 @@ def model_details_tool(client, *, model: str) -> dict:
     `capabilities` (supportsVision/supportsFunctionCalling/... ) is populated only
     for text/LLM models. Image/media models expose their metadata under
     `constraints` (aspectRatios, resolutions, qualities, promptCharacterLimit).
-    `voices` lists the voice ids available for TTS models (null otherwise), so the
-    agent can pick a valid `voice` for venice_tts without guessing.
+    `voices`, `supported_formats`, and `default_format` expose the selection data
+    needed for TTS calls (null for models where they do not apply).
     The full `model_spec` is returned too so nothing is dropped. Read-only; not
     spend-gated. May scan the catalog by type to locate the id.
     """
@@ -1483,6 +1483,8 @@ def model_details_tool(client, *, model: str) -> dict:
         "traits": spec.get("traits"),
         # TTS voice-id list (flat list of strings); null for non-voice models.
         "voices": spec.get("voices"),
+        "supported_formats": spec.get("supported_formats"),
+        "default_format": spec.get("default_format"),
         # Full spec so nothing curated-away is lost (#59 / kimi-k3 feedback).
         "model_spec": spec,
     }

--- a/src/venice/commands/tts.py
+++ b/src/venice/commands/tts.py
@@ -10,29 +10,13 @@ from __future__ import annotations
 import hashlib
 import sys
 from pathlib import Path
-from typing import Optional, Tuple
+from typing import NamedTuple, Optional, Tuple
 
 from .. import _numeric, audio_player, auth, billing, config, userconfig
 from ..client import VeniceAPIError, build_client_from_auth
 from . import _shared
 
-# Slugs verified against /models?type=tts on 2026-05-22.
-TTS_MODELS = (
-    "tts-kokoro",
-    "tts-qwen3-0-6b",
-    "tts-qwen3-1-7b",
-    "tts-xai-v1",
-    "tts-inworld-1-5-max",
-    "tts-chatterbox-hd",
-    "tts-orpheus",
-    "tts-elevenlabs-turbo-v2-5",
-    "tts-minimax-speech-02-hd",
-    "tts-gemini-3-1-flash",
-)
-DEFAULT_TTS_MODEL = "tts-kokoro"  # cheapest ($3.50/1M chars), 54 voices
-
-FORMATS = ("mp3", "opus", "aac", "flac", "wav", "pcm")
-DEFAULT_FORMAT = "mp3"
+DEFAULT_TTS_MODEL = "tts-kokoro"
 
 EXT_BY_FORMAT = {
     "mp3": ".mp3",
@@ -42,6 +26,27 @@ EXT_BY_FORMAT = {
     "wav": ".wav",
     "pcm": ".pcm",
 }
+
+FORMAT_BY_CTYPE = {
+    "audio/mpeg": "mp3",
+    "audio/mp3": "mp3",
+    "audio/opus": "opus",
+    "audio/ogg": "opus",
+    "audio/aac": "aac",
+    "audio/flac": "flac",
+    "audio/wav": "wav",
+    "audio/wave": "wav",
+    "audio/x-wav": "wav",
+    "audio/pcm": "pcm",
+    "audio/l16": "pcm",
+}
+
+
+class ResolvedTTS(NamedTuple):
+    price_per_million: Optional[float]
+    supported_formats: Tuple[str, ...]
+    requested_format: Optional[str]
+    output_format: str
 
 
 def register(subparsers) -> None:
@@ -75,10 +80,10 @@ def register(subparsers) -> None:
     )
     p.add_argument(
         "--model",
-        choices=TTS_MODELS,
         default=None,
-        help=f"TTS model id (default {DEFAULT_TTS_MODEL}). Config-backable via "
-        "defaults.tts.model; an explicit --model still wins.",
+        help=f"TTS model id, validated against the live catalog (default "
+        f"{DEFAULT_TTS_MODEL}). Config-backable via defaults.tts.model; an "
+        "explicit --model still wins.",
     )
     p.add_argument(
         "--voice",
@@ -87,10 +92,10 @@ def register(subparsers) -> None:
     )
     p.add_argument(
         "--format",
-        choices=FORMATS,
         default=None,
-        help=f"Output audio format (default {DEFAULT_FORMAT}). Config-backable "
-        "via defaults.tts.format; an explicit --format still wins.",
+        help="Model-specific output audio format. If omitted, Venice uses the "
+        "selected model's live catalog default. Config-backable via "
+        "defaults.tts.format; an explicit --format still wins.",
     )
     p.add_argument(
         "--speed",
@@ -153,28 +158,73 @@ def _read_input(args) -> Tuple[Optional[str], int]:
     return text, 0
 
 
-# ---- pricing + cost estimation ----------------------------------------------
+# ---- live model resolution + cost estimation --------------------------------
 
-def _fetch_tts_price_per_million(client, model: str) -> Optional[float]:
-    """Look up `model_spec.pricing.input.usd` for the given TTS model. Best-effort."""
+def _resolve_tts(client, model: str, requested_format: Optional[str]) -> ResolvedTTS:
+    """Resolve one TTS model and its format before confirmation or spend."""
     try:
         doc = client.get_json("/models", params={"type": "tts"})
-    except VeniceAPIError:
-        return None
+    except VeniceAPIError as e:
+        raise ValueError(f"could not fetch live TTS catalog: {e}") from None
     data = doc.get("data") if isinstance(doc, dict) else None
     if not isinstance(data, list):
-        return None
+        raise ValueError("live TTS catalog has no data list")
+    found = None
     for m in data:
         if isinstance(m, dict) and m.get("id") == model:
-            try:
-                return _numeric.non_negative_float(
-                    m["model_spec"]["pricing"]["input"]["usd"]
-                )
-            except (KeyError, TypeError):
-                return None
-            except ValueError:
-                raise ValueError("model catalog contains an invalid TTS price") from None
-    return None
+            found = m
+            break
+    if found is None:
+        raise ValueError(f"model {model!r} is not in the live TTS catalog")
+
+    spec = found.get("model_spec")
+    if not isinstance(spec, dict):
+        raise ValueError(f"live TTS catalog entry for {model!r} has no model_spec")
+    raw_formats = spec.get("supported_formats")
+    if (
+        not isinstance(raw_formats, list)
+        or not raw_formats
+        or any(not isinstance(v, str) or not v.strip() for v in raw_formats)
+    ):
+        raise ValueError(
+            f"live TTS catalog entry for {model!r} has invalid supported_formats"
+        )
+    supported = tuple(v.strip() for v in raw_formats)
+
+    chosen = requested_format.strip() if isinstance(requested_format, str) else None
+    if requested_format is not None and not chosen:
+        raise ValueError("format must not be empty")
+    if chosen is not None:
+        if chosen not in supported:
+            raise ValueError(
+                f"format {chosen!r} is not supported by {model!r}; choose from "
+                f"{', '.join(supported)}"
+            )
+        output_format = chosen
+    else:
+        default_format = spec.get("default_format")
+        if not isinstance(default_format, str) or not default_format.strip():
+            raise ValueError(
+                f"live TTS catalog entry for {model!r} has no default_format"
+            )
+        output_format = default_format.strip()
+        if output_format not in supported:
+            raise ValueError(
+                f"live TTS catalog default_format {output_format!r} for {model!r} "
+                "is not in supported_formats"
+            )
+
+    price = None
+    try:
+        raw_price = spec["pricing"]["input"]["usd"]
+    except (KeyError, TypeError):
+        pass
+    else:
+        try:
+            price = _numeric.non_negative_float(raw_price)
+        except (TypeError, ValueError):
+            raise ValueError("model catalog contains an invalid TTS price") from None
+    return ResolvedTTS(price, supported, chosen, output_format)
 
 
 def _estimate_cost(char_count: int, price_per_million: Optional[float]) -> Optional[float]:
@@ -205,6 +255,11 @@ def _resolve_output_path(arg_output: Optional[Path], short: str, fmt: str) -> Pa
     if arg_output.is_dir():
         return arg_output / default_name
     return arg_output
+
+
+def _response_format(ctype: str, fallback: str) -> str:
+    base = (ctype or "").split(";", 1)[0].strip().lower()
+    return FORMAT_BY_CTYPE.get(base, fallback)
 
 
 # ---- main flow ---------------------------------------------------------------
@@ -288,8 +343,9 @@ def _validate_speed(speed: Optional[float]) -> Optional[int]:
 
 def _run(args) -> int:
     userconfig.apply_defaults(args, "tts")
-    # #57 Class C1: the built-in literals, after config has had its turn.
-    userconfig.apply_literals(args, model=DEFAULT_TTS_MODEL, format=DEFAULT_FORMAT)
+    # #57 Class C1: the built-in model literal, after config has had its turn.
+    # Format deliberately stays None so the API can apply the model-specific default.
+    userconfig.apply_literals(args, model=DEFAULT_TTS_MODEL)
     rc = _validate_speed(args.speed)
     if rc is not None:
         return rc
@@ -305,11 +361,11 @@ def _run(args) -> int:
         return 2
 
     try:
-        price = _fetch_tts_price_per_million(client, args.model)
+        resolved = _resolve_tts(client, args.model, args.format)
     except ValueError as e:
         print(f"tts: {e}", file=sys.stderr)
         return 2
-    cost = _estimate_cost(len(text), price)
+    cost = _estimate_cost(len(text), resolved.price_per_million)
     _print_estimate(cost, len(text), args.model)
     _print_balance_and_remaining(client, cost, show=not args.no_balance)
 
@@ -332,8 +388,9 @@ def _run(args) -> int:
     body: dict = {
         "input": text,
         "model": args.model,
-        "response_format": args.format,
     }
+    if resolved.requested_format is not None:
+        body["response_format"] = resolved.requested_format
     if args.voice:
         body["voice"] = args.voice
     if args.speed is not None:
@@ -352,7 +409,8 @@ def _run(args) -> int:
         return 5
 
     short = _short_id(text, args.model, args.voice)
-    out_path = _resolve_output_path(args.output, short, args.format)
+    output_format = _response_format(ctype, resolved.output_format)
+    out_path = _resolve_output_path(args.output, short, output_format)
 
     try:
         out_path.write_bytes(audio)

--- a/src/venice/mcp_server.py
+++ b/src/venice/mcp_server.py
@@ -109,7 +109,8 @@ def build_server(client, doc=None, root=None) -> FastMCP:
         """Synthesize speech from text via Venice /audio/speech. Writes an audio file
         and returns its path. Paid: cost is estimated per character; over-cap calls
         need confirm=true. Omitted args fall back to defaults.tts.* in the user's
-        config, then to the built-ins (model=tts-kokoro, format=mp3)."""
+        config, then to model=tts-kokoro and the selected model's live catalog
+        format default."""
         return _mcp.tts_tool(
             client, text,
             **_merged(_defaults["tts"], dict(

--- a/src/venice/userconfig.py
+++ b/src/venice/userconfig.py
@@ -524,9 +524,9 @@ _COMMAND_MAP = {
         "output_format": ("output_format", _one_of("venice.commands.image_edit", "OUTPUT_FORMATS")),
     },
     "tts": {
-        # #57 Class C: literals now live in `tts._run`'s `apply_literals` call.
-        "model": ("model", _one_of("venice.commands.tts", "TTS_MODELS")),
-        "format": ("format", _one_of("venice.commands.tts", "FORMATS")),
+        # Model and format are validated against the live TTS catalog before spend.
+        "model": ("model", str),
+        "format": ("format", str),
         "voice": ("voice", str),
         "speed": ("speed", _numeric.finite_float),
         # `--play`/`--no-play` is a tri-stated store_true(None)/store_false pair.

--- a/tests/test_agent.py
+++ b/tests/test_agent.py
@@ -2977,6 +2977,11 @@ class TestToolRegistry(unittest.TestCase):
         self.assertTrue(spec.paid)
         self.assertIsNone(_agent.get("venice_nope"))
 
+    def test_tts_schema_documents_live_format_default(self):
+        spec = _agent.get("venice_tts")
+        desc = spec.parameters["properties"]["format"]["description"]
+        self.assertIn("catalog default", desc)
+
     def test_every_registry_tool_has_a_category(self):
         # drift guard: a new tool with no/empty category fails here.
         for spec in _agent._REGISTRY:

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -146,6 +146,22 @@ class TestApplyDefaults(_Base):
         uc.apply_defaults(args2, "chat", doc)
         self.assertEqual(args2.model, "explicit")
 
+    def test_tts_live_catalog_values_remain_config_backable(self):
+        doc = {"defaults": {"tts": {
+            "model": "tts-gradium-v1", "format": "opus",
+        }}}
+        args = _build_parser(tts).parse_args(["tts", "hello"])
+        uc.apply_defaults(args, "tts", doc)
+        self.assertEqual(args.model, "tts-gradium-v1")
+        self.assertEqual(args.format, "opus")
+
+        explicit = _build_parser(tts).parse_args([
+            "tts", "hello", "--model", "tts-inworld-1-5-max", "--format", "wav"
+        ])
+        uc.apply_defaults(explicit, "tts", doc)
+        self.assertEqual(explicit.model, "tts-inworld-1-5-max")
+        self.assertEqual(explicit.format, "wav")
+
     def test_apply_fills_chat_persona(self):
         # #68: defaults.chat.persona is a plain-string key like system/character.
         doc = {"defaults": {"chat": {"persona": "pirate"}}}
@@ -767,9 +783,6 @@ _CLASS_C_CASES = [
     dict(key="tts", mod=tts, argv=["tts", "hi"], dest="model",
          literal=tts.DEFAULT_TTS_MODEL, cfg="tts-orpheus", want="tts-orpheus",
          explicit=["--model", "tts-xai-v1"], eval="tts-xai-v1"),
-    dict(key="tts", mod=tts, argv=["tts", "hi"], dest="format",
-         literal=tts.DEFAULT_FORMAT, cfg="wav", want="wav",
-         explicit=["--format", "flac"], eval="flac"),
     dict(key="sfx", mod=sfx, argv=["sfx", "p"], dest="model",
          literal=sfx.DEFAULT_SFX_MODEL, cfg="mmaudio-v2-text-to-audio",
          want="mmaudio-v2-text-to-audio",
@@ -993,8 +1006,6 @@ class TestClassCParity(unittest.TestCase):
         reaches SFX_MODELS[model] as a raw KeyError traceback."""
         cases = [
             ("image", image, ["image", "p"], "format", "gif"),
-            ("tts", tts, ["tts", "hi"], "model", "tts-nope"),
-            ("tts", tts, ["tts", "hi"], "format", "ogg"),
             ("sfx", sfx, ["sfx", "p"], "model", "bogus"),
             ("video", video, ["video", "p"], "duration", "99s"),
             # #57 C2/D: the first int choice set, and the first choices row

--- a/tests/test_mcp_tools.py
+++ b/tests/test_mcp_tools.py
@@ -168,16 +168,89 @@ class TestTtsTool(_ToolTest):
     def test_ok_writes_audio(self):
         price = json.dumps(
             {"data": [{"id": "tts-kokoro",
-                       "model_spec": {"pricing": {"input": {"usd": 3.5}}}}]}
+                       "model_spec": {
+                           "pricing": {"input": {"usd": 3.5}},
+                           "supported_formats": ["mp3", "wav"],
+                           "default_format": "mp3",
+                       }}]}
         ).encode()
+        captured = {}
+
+        def responses(req, timeout=None):
+            if req.full_url.endswith("/models?type=tts"):
+                return FakeResp(200, price)
+            captured["body"] = json.loads(req.data.decode("utf-8"))
+            return FakeResp(200, b"AUDIO", "audio/mpeg")
+
         with mock.patch(
             "venice.client.urllib.request.urlopen",
-            _seq(FakeResp(200, price), FakeResp(200, b"AUDIO", "audio/mpeg")),
+            responses,
         ), self.stdout_guard():
             res = _mcp.tts_tool(_client(), "hello world", output_dir=self.td, confirm=True)
         self.assertEqual(res["status"], "ok")
         self.assertEqual(Path(res["path"]).read_bytes(), b"AUDIO")
         self.assertTrue(res["path"].endswith(".mp3"))
+        self.assertEqual(res["format"], "mp3")
+        self.assertNotIn("response_format", captured["body"])
+
+    def test_explicit_supported_format_is_sent(self):
+        catalog = json.dumps({"data": [{
+            "id": "tts-kokoro",
+            "model_spec": {
+                "pricing": {"input": {"usd": 3.5}},
+                "supported_formats": ["mp3", "wav"],
+                "default_format": "mp3",
+            },
+        }]}).encode()
+        captured = {}
+
+        def responses(req, timeout=None):
+            if req.full_url.endswith("/models?type=tts"):
+                return FakeResp(200, catalog)
+            captured["body"] = json.loads(req.data.decode("utf-8"))
+            return FakeResp(200, b"WAV", "audio/wav")
+
+        with mock.patch(
+            "venice.client.urllib.request.urlopen", responses,
+        ), self.stdout_guard():
+            res = _mcp.tts_tool(
+                _client(), "hello", format="wav", output_dir=self.td, confirm=True
+            )
+        self.assertEqual(res["status"], "ok")
+        self.assertEqual(captured["body"]["response_format"], "wav")
+        self.assertEqual(res["format"], "wav")
+
+    def test_wav_only_default_and_unsupported_explicit_format(self):
+        catalog = json.dumps({"data": [{
+            "id": "tts-inworld-1-5-max",
+            "model_spec": {
+                "pricing": {"input": {"usd": 12.5}},
+                "supported_formats": ["wav"],
+                "default_format": "wav",
+            },
+        }]}).encode()
+        with mock.patch(
+            "venice.client.urllib.request.urlopen",
+            _seq(FakeResp(200, catalog), FakeResp(200, b"WAV", "audio/wav")),
+        ), self.stdout_guard():
+            res = _mcp.tts_tool(
+                _client(), "hello", model="tts-inworld-1-5-max",
+                output_dir=self.td, confirm=True,
+            )
+        self.assertEqual(res["status"], "ok")
+        self.assertEqual(res["format"], "wav")
+        self.assertTrue(res["path"].endswith(".wav"))
+
+        with mock.patch(
+            "venice.client.urllib.request.urlopen",
+            _seq(FakeResp(200, catalog)),
+        ), self.stdout_guard():
+            bad = _mcp.tts_tool(
+                _client(), "hello", model="tts-inworld-1-5-max", format="mp3",
+                output_dir=self.td, confirm=True,
+            )
+        self.assertEqual(bad["status"], "error")
+        self.assertIn("not supported", bad["message"])
 
     def test_bad_speed_is_error(self):
         res = _mcp.tts_tool(_client(), "hi", speed=9.0, confirm=True)
@@ -1262,9 +1335,13 @@ class TestModelDetailsTool(_ToolTest):
         # #64: TTS models expose model_spec.voices (flat list of ids); surface it so
         # the agent can pick a valid voice for venice_tts without guessing.
         spec = {"name": "Kokoro", "pricing": {"input": {"usd": 3.5}},
-                "voices": ["Achernar", "Aiden", "Alex"]}
+                "voices": ["Achernar", "Aiden", "Alex"],
+                "supported_formats": ["mp3", "wav"],
+                "default_format": "mp3"}
         out = self._details(spec, mtype="tts")
         self.assertEqual(out["voices"], ["Achernar", "Aiden", "Alex"])
+        self.assertEqual(out["supported_formats"], ["mp3", "wav"])
+        self.assertEqual(out["default_format"], "mp3")
 
     def test_non_voice_model_voices_is_none(self):
         # image/text models have no voices -> null, like capabilities/constraints.

--- a/tests/test_tts.py
+++ b/tests/test_tts.py
@@ -36,7 +36,7 @@ def _build_args(**ov):
 
 
 def _tts_models_payload():
-    """Mimics /models?type=tts response with two entries."""
+    """Mimics /models?type=tts with model-specific format contracts."""
     return json.dumps({
         "object": "list",
         "data": [
@@ -47,6 +47,8 @@ def _tts_models_payload():
                     "name": "Kokoro",
                     "pricing": {"input": {"usd": 3.5}},
                     "voices": ["af_sky", "am_michael"],
+                    "supported_formats": ["mp3", "wav"],
+                    "default_format": "mp3",
                 },
             },
             {
@@ -55,6 +57,26 @@ def _tts_models_payload():
                 "model_spec": {
                     "pricing": {"input": {"usd": 18.75}},
                     "voices": ["voice_a"],
+                    "supported_formats": ["mp3", "wav"],
+                    "default_format": "mp3",
+                },
+            },
+            {
+                "id": "tts-inworld-1-5-max",
+                "type": "tts",
+                "model_spec": {
+                    "pricing": {"input": {"usd": 12.5}},
+                    "supported_formats": ["wav"],
+                    "default_format": "wav",
+                },
+            },
+            {
+                "id": "tts-gradium-v1",
+                "type": "tts",
+                "model_spec": {
+                    "pricing": {"input": {"usd": 20.0}},
+                    "supported_formats": ["wav", "pcm", "opus"],
+                    "default_format": "wav",
                 },
             },
         ],
@@ -82,18 +104,104 @@ class TestTtsFlow(unittest.TestCase):
     def test_generate_writes_mp3(self):
         from venice.commands import tts
 
+        captured = {}
         responses = iter([
             FakeResp(200, _tts_models_payload(), "application/json"),
             FakeResp(200, b"FAKEMP3", "audio/mpeg"),
         ])
 
+        def fake_urlopen(req, timeout=None):
+            if req.full_url.endswith("/audio/speech"):
+                captured["body"] = json.loads(req.data.decode("utf-8"))
+            return next(responses)
+
         with mock.patch.dict(os.environ, {"VENICE_API_KEY": "fake"}), \
-             mock.patch("venice.client.urllib.request.urlopen", lambda *a, **kw: next(responses)):
+             mock.patch("venice.client.urllib.request.urlopen", fake_urlopen):
             rc = tts._run(_build_args(text="Hello, voice."))
         self.assertEqual(rc, 0)
         written = sorted(Path(".").glob("venice-tts-*.mp3"))
         self.assertEqual(len(written), 1, f"expected 1 mp3, got {written}")
         self.assertEqual(written[0].read_bytes(), b"FAKEMP3")
+        self.assertNotIn("response_format", captured["body"])
+
+    def test_wav_only_model_uses_catalog_default(self):
+        from venice.commands import tts
+
+        captured = {}
+        responses = iter([
+            FakeResp(200, _tts_models_payload(), "application/json"),
+            FakeResp(200, b"WAV", "audio/wav; charset=binary"),
+        ])
+
+        def fake_urlopen(req, timeout=None):
+            if req.full_url.endswith("/audio/speech"):
+                captured["body"] = json.loads(req.data.decode("utf-8"))
+            return next(responses)
+
+        with mock.patch.dict(os.environ, {"VENICE_API_KEY": "fake"}), \
+             mock.patch("venice.client.urllib.request.urlopen", fake_urlopen):
+            rc = tts._run(_build_args(model="tts-inworld-1-5-max"))
+        self.assertEqual(rc, 0)
+        self.assertNotIn("response_format", captured["body"])
+        self.assertEqual(len(list(Path(".").glob("venice-tts-*.wav"))), 1)
+
+    def test_response_content_type_wins_for_generated_extension(self):
+        from venice.commands import tts
+
+        responses = iter([
+            FakeResp(200, _tts_models_payload(), "application/json"),
+            FakeResp(200, b"WAV", "audio/wav"),
+        ])
+        with mock.patch.dict(os.environ, {"VENICE_API_KEY": "fake"}), \
+             mock.patch("venice.client.urllib.request.urlopen",
+                        lambda *a, **kw: next(responses)):
+            rc = tts._run(_build_args(format="mp3"))
+        self.assertEqual(rc, 0)
+        self.assertEqual(len(list(Path(".").glob("venice-tts-*.wav"))), 1)
+
+    def test_explicit_output_filename_is_preserved(self):
+        from venice.commands import tts
+
+        output = Path("custom.audio")
+        responses = iter([
+            FakeResp(200, _tts_models_payload(), "application/json"),
+            FakeResp(200, b"WAV", "audio/wav"),
+        ])
+        with mock.patch.dict(os.environ, {"VENICE_API_KEY": "fake"}), \
+             mock.patch("venice.client.urllib.request.urlopen",
+                        lambda *a, **kw: next(responses)):
+            rc = tts._run(_build_args(output=output))
+        self.assertEqual(rc, 0)
+        self.assertEqual(output.read_bytes(), b"WAV")
+
+    def test_unsupported_format_fails_before_speech_request(self):
+        from venice.commands import tts
+
+        calls = []
+
+        def fake_urlopen(req, timeout=None):
+            calls.append(req.full_url)
+            return FakeResp(200, _tts_models_payload(), "application/json")
+
+        with mock.patch.dict(os.environ, {"VENICE_API_KEY": "fake"}), \
+             mock.patch("venice.client.urllib.request.urlopen", fake_urlopen):
+            rc = tts._run(_build_args(
+                model="tts-inworld-1-5-max", format="mp3"
+            ))
+        self.assertEqual(rc, 2)
+        self.assertEqual(len(calls), 1)
+        self.assertTrue(calls[0].endswith("/models?type=tts"))
+
+    def test_unknown_model_fails_before_speech_request(self):
+        from venice.commands import tts
+
+        with mock.patch.dict(os.environ, {"VENICE_API_KEY": "fake"}), \
+             mock.patch("venice.client.urllib.request.urlopen",
+                        lambda *a, **kw: FakeResp(
+                            200, _tts_models_payload(), "application/json"
+                        )):
+            rc = tts._run(_build_args(model="tts-nope"))
+        self.assertEqual(rc, 2)
 
     def test_dry_run_does_not_call_speech(self):
         from venice.commands import tts
@@ -207,6 +315,15 @@ class TestTtsFlow(unittest.TestCase):
 
 
 class TestTtsPricingValidation(unittest.TestCase):
+    def test_catalog_api_failure_is_rejected(self):
+        from venice.client import VeniceAPIError
+        from venice.commands import tts
+
+        client = mock.Mock()
+        client.get_json.side_effect = VeniceAPIError(0, "/models", "offline")
+        with self.assertRaisesRegex(ValueError, "could not fetch live TTS catalog"):
+            tts._resolve_tts(client, "m", None)
+
     def test_non_finite_catalog_price_is_rejected(self):
         from venice.commands import tts
 
@@ -215,11 +332,46 @@ class TestTtsPricingValidation(unittest.TestCase):
             def get_json(*args, **kwargs):
                 return {"data": [{
                     "id": "m",
-                    "model_spec": {"pricing": {"input": {"usd": float("nan")}}},
+                    "model_spec": {
+                        "pricing": {"input": {"usd": float("nan")}},
+                        "supported_formats": ["wav"],
+                        "default_format": "wav",
+                    },
                 }]}
 
         with self.assertRaisesRegex(ValueError, "invalid TTS price"):
-            tts._fetch_tts_price_per_million(Client(), "m")
+            tts._resolve_tts(Client(), "m", None)
+
+    def test_catalog_contract_failures_are_rejected(self):
+        from venice.commands import tts
+
+        cases = (
+            ({}, "no data list"),
+            ({"data": []}, "not in the live TTS catalog"),
+            ({"data": [{"id": "m"}]}, "has no model_spec"),
+            ({"data": [{"id": "m", "model_spec": {}}]},
+             "invalid supported_formats"),
+            ({"data": [{"id": "m", "model_spec": {
+                "supported_formats": ["wav"]}}]}, "has no default_format"),
+            ({"data": [{"id": "m", "model_spec": {
+                "supported_formats": ["wav"], "default_format": "mp3"}}]},
+             "is not in supported_formats"),
+        )
+        for doc, message in cases:
+            with self.subTest(message=message):
+                client = mock.Mock()
+                client.get_json.return_value = doc
+                with self.assertRaisesRegex(ValueError, message):
+                    tts._resolve_tts(client, "m", None)
+
+    def test_parser_accepts_live_catalog_values(self):
+        from venice import cli
+
+        args = cli.build_parser().parse_args([
+            "tts", "hello", "--model", "tts-gradium-v1", "--format", "opus"
+        ])
+        self.assertEqual(args.model, "tts-gradium-v1")
+        self.assertEqual(args.format, "opus")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

- resolve TTS models, supported formats, defaults, and pricing from one live catalog lookup
- omit `response_format` when the user did not select one and derive generated filenames from the response content type with catalog fallback
- keep CLI, config, MCP, agent schemas, model details, help, and docs aligned

Fixes #145

## Validation

- `make lint`
- `make scan`
- `VENICE_API_KEY=test-fake-key make test`
- `VENICE_API_KEY=test-fake-key make drive`
- focused TTS/MCP/config/agent/MCP-server suite: 490 tests passed