### PR TITLE
[codex] preserve Gemini thought signatures

### DIFF
--- a/src/venice/commands/_agent.py
+++ b/src/venice/commands/_agent.py
@@ -2782,6 +2782,7 @@ def supports_function_calling(models, model_id) -> Optional[bool]:
 # The loop
 # --------------------------------------------------------------------------- #
 _REASONING_FIELDS = ("reasoning_content", "reasoning_details", "reasoning")
+_THOUGHT_SIGNATURE_FIELD = "thought_signature"
 
 
 def _message_field(msg, name):
@@ -2816,8 +2817,10 @@ def _assistant_dict(msg) -> dict:
     Keep content and exact tool-call ids plus one deliberately allowlisted reasoning
     extension.  Compatible providers use three aliases; when a response unexpectedly
     carries more than one, preserve the first in ``_REASONING_FIELDS`` order rather
-    than sending conflicting thinking payloads back on the next request.  Do not use a
-    whole-message ``model_dump()``: response-only metadata can be rejected on replay.
+    than sending conflicting thinking payloads back on the next request.  A Gemini
+    ``thought_signature`` is independent of those aliases and must be passed back
+    exactly when present.  Do not use a whole-message ``model_dump()``: response-only
+    metadata can be rejected on replay.
     """
     d = {"role": "assistant", "content": (_message_field(msg, "content") or "")}
     for field in _REASONING_FIELDS:
@@ -2825,6 +2828,9 @@ def _assistant_dict(msg) -> dict:
         if value is not None:
             d[field] = _request_value(value)
             break
+    signature = _message_field(msg, _THOUGHT_SIGNATURE_FIELD)
+    if signature is not None:
+        d[_THOUGHT_SIGNATURE_FIELD] = _request_value(signature)
     tcs = _message_field(msg, "tool_calls")
     if tcs:
         d["tool_calls"] = [

--- a/src/venice/commands/chat.py
+++ b/src/venice/commands/chat.py
@@ -723,6 +723,7 @@ def _consume_stream_message_full(stream):
     usage = None
     parts: list = []
     reasoning_parts = {field: [] for field in _agent._REASONING_FIELDS}
+    thought_signature_parts: list = []
     for chunk in stream:
         vp = getattr(chunk, "venice_parameters", None)
         if vp is not None and citations is None:
@@ -740,6 +741,9 @@ def _consume_stream_message_full(stream):
                 value = getattr(delta, field, None)
                 if value is not None:
                     reasoning_parts[field].append(_agent._request_value(value))
+            signature = getattr(delta, _agent._THOUGHT_SIGNATURE_FIELD, None)
+            if signature is not None:
+                thought_signature_parts.append(_agent._request_value(signature))
     if parts:
         sys.stdout.write("\n")
     _print_citations(citations)
@@ -756,6 +760,17 @@ def _consume_stream_message_full(stream):
         else:
             message[field] = values[0] if len(values) == 1 else values
         break
+    if thought_signature_parts:
+        if all(isinstance(value, str) for value in thought_signature_parts):
+            message[_agent._THOUGHT_SIGNATURE_FIELD] = "".join(
+                thought_signature_parts
+            )
+        else:
+            message[_agent._THOUGHT_SIGNATURE_FIELD] = (
+                thought_signature_parts[0]
+                if len(thought_signature_parts) == 1
+                else thought_signature_parts
+            )
     return message, usage
 
 

--- a/tests/test_agent.py
+++ b/tests/test_agent.py
@@ -48,7 +48,7 @@ def _free_tool():
 
 
 class TestAssistantReplay(unittest.TestCase):
-    """#129: compatible reasoning fields survive every buffered history seam."""
+    """#129/#146: reasoning and thought signatures survive buffered history."""
 
     def test_synthetic_sdk_message_replays_reasoning_and_exact_tool_call(self):
         from openai.types.chat import ChatCompletion
@@ -65,6 +65,7 @@ class TestAssistantReplay(unittest.TestCase):
                     "role": "assistant",
                     "content": "I will inspect it.",
                     "reasoning_content": "reasoning bytes: \u2603",
+                    "thought_signature": "sig-exact",
                     "tool_calls": [{
                         "id": "call-123",
                         "type": "function",
@@ -78,6 +79,7 @@ class TestAssistantReplay(unittest.TestCase):
             "role": "assistant",
             "content": "I will inspect it.",
             "reasoning_content": "reasoning bytes: \u2603",
+            "thought_signature": "sig-exact",
             "tool_calls": [{
                 "id": "call-123",
                 "type": "function",
@@ -92,12 +94,14 @@ class TestAssistantReplay(unittest.TestCase):
             reasoning_content="preferred",
             reasoning_details=[{"type": "summary", "text": "other"}],
             reasoning="last",
+            thought_signature="sig-independent",
             refusal="response-only",
         )
         self.assertEqual(_agent._assistant_dict(msg), {
             "role": "assistant",
             "content": "visible",
             "reasoning_content": "preferred",
+            "thought_signature": "sig-independent",
         })
 
     def test_non_reasoning_message_shape_is_unchanged(self):
@@ -110,6 +114,7 @@ class TestAssistantReplay(unittest.TestCase):
         first = FakeToolCompletion(
             tool_calls=[_FnCall("c1", "t", "{}")],
             reasoning_content="keep this exactly \u2603",
+            thought_signature="sig-exact",
         )
         fake, calls = _fake_oai([first, FakeToolCompletion("done")])
         messages = [{"role": "user", "content": "go"}]
@@ -123,11 +128,19 @@ class TestAssistantReplay(unittest.TestCase):
             calls[1]["messages"][1]["reasoning_content"],
             "keep this exactly \u2603",
         )
+        self.assertEqual(
+            calls[1]["messages"][1]["thought_signature"],
+            "sig-exact",
+        )
 
     def test_forced_final_response_keeps_reasoning_in_history(self):
         seq = [
             FakeToolCompletion(tool_calls=[_FnCall("c1", "t", "{}")]),
-            FakeToolCompletion("wrapped", reasoning_content="final thought"),
+            FakeToolCompletion(
+                "wrapped",
+                reasoning_content="final thought",
+                thought_signature="final-sig",
+            ),
         ]
         fake, _calls = _fake_oai(seq)
         messages = [{"role": "user", "content": "go"}]
@@ -138,6 +151,7 @@ class TestAssistantReplay(unittest.TestCase):
                 max_tool_calls=1, yes=True, json_out=False,
             )
         self.assertEqual(messages[-1]["reasoning_content"], "final thought")
+        self.assertEqual(messages[-1]["thought_signature"], "final-sig")
 
 
 def _tty(value=True):

--- a/tests/test_repl.py
+++ b/tests/test_repl.py
@@ -371,12 +371,19 @@ class TestRepl(unittest.TestCase):
             env2 = json.loads((Path(d) / (sid + ".json")).read_text())
             self.assertEqual(len(env2["messages"]), 4)
 
-    def test_streamed_reasoning_replays_and_is_saved(self):
+    def test_streamed_reasoning_and_signature_replay_save_and_resume(self):
         with tempfile.TemporaryDirectory() as d:
             results = [
                 [
-                    FakeChunk(reasoning_content="think "),
-                    FakeChunk("answer", reasoning_content="carefully"),
+                    FakeChunk(
+                        reasoning_content="think ",
+                        thought_signature="sig-",
+                    ),
+                    FakeChunk(
+                        "answer",
+                        reasoning_content="carefully",
+                        thought_signature="exact",
+                    ),
                 ],
                 [FakeChunk("follow-up")],
             ]
@@ -390,11 +397,29 @@ class TestRepl(unittest.TestCase):
             replayed = calls[1]["messages"][1]
             self.assertEqual(replayed["content"], "answer")
             self.assertEqual(replayed["reasoning_content"], "think carefully")
+            self.assertEqual(replayed["thought_signature"], "sig-exact")
 
-            saved = json.loads(list(Path(d).glob("*.json"))[0].read_text())
+            session_path = list(Path(d).glob("*.json"))[0]
+            saved = json.loads(session_path.read_text())
             self.assertEqual(
                 saved["messages"][1]["reasoning_content"],
                 "think carefully",
+            )
+            self.assertEqual(
+                saved["messages"][1]["thought_signature"],
+                "sig-exact",
+            )
+
+            rc2, _fake2, calls2 = _run_repl(
+                _args(interactive=True, resume=saved["id"]),
+                [[FakeChunk("resumed")]],
+                ["third", "/exit"],
+                sessions_dir=d,
+            )
+            self.assertEqual(rc2, 0)
+            self.assertEqual(
+                calls2[0]["messages"][1]["thought_signature"],
+                "sig-exact",
             )
 
     def test_ephemeral_writes_no_file(self):


### PR DESCRIPTION
## Summary

- preserve Gemini `thought_signature` independently of compatible reasoning aliases
- reconstruct streamed signature deltas for REPL history
- round-trip signatures through tool calls, autosave, and resumed sessions

## Root cause and impact

Assistant history was deliberately rebuilt from an allowlist, but that allowlist only covered reasoning aliases and tool calls. Venice's current assistant-message contract also returns `thought_signature` for Gemini native/GCP reasoning, so later turns silently dropped the provider continuity token. Streamed REPL turns had a separate reasoning-only accumulator with the same gap.

The replay allowlist now copies the signature without broadening into response-only metadata, and the streaming path reconstructs signature fragments in arrival order.

## Validation

- `VENICE_API_KEY=test-fake-key PYTHONPATH=src python3 -m unittest -v tests.test_agent.TestAssistantReplay tests.test_repl.TestRepl.test_streamed_reasoning_and_signature_replay_save_and_resume tests.test_code_command.TestCodeCommand.test_plan_reasoning_replays_and_survives_the_session_round_trip tests.test_code_command.TestCodeCommand.test_acceptance_retry_replays_the_complete_assistant_message`
- `VENICE_API_KEY=test-fake-key make lint`
- `VENICE_API_KEY=test-fake-key make scan`
- `VENICE_API_KEY=test-fake-key make test` (1,730 tests)

Closes #146.
