### PR TITLE
[codex] support current model catalog types

### DIFF
--- a/src/venice/commands/_agent.py
+++ b/src/venice/commands/_agent.py
@@ -2087,7 +2087,8 @@ _MODELS_SCHEMA = _obj(
             "type": "string",
             "enum": ["all", *MODEL_TYPES],
             "description": "Which catalog type to list model ids for "
-            "(text, code, image, video, music, tts, embedding, upscale), "
+            "(text, code, image, video, music, tts, embedding, upscale, asr, "
+            "inpaint), "
             "or 'all' for a {type: [ids]} map.",
         },
     },
@@ -2284,7 +2285,8 @@ _BUILTINS = [
         "venice_models",
         "models_tool",
         "List available Venice model ids for a catalog type (text/code/image/video/"
-        "music/tts/embedding/upscale, or 'all') via the free /models catalog. Use it "
+        "music/tts/embedding/upscale/asr/inpaint, or 'all') via the free /models "
+        "catalog. Use it "
         "to choose a valid `model` for the other venice_* tools instead of guessing. "
         "Read-only; not spend-gated.",
         _MODELS_SCHEMA,

--- a/src/venice/commands/_mcp.py
+++ b/src/venice/commands/_mcp.py
@@ -1426,20 +1426,26 @@ def models_tool(client, *, type: str) -> dict:
             f"models: unknown type {type!r}; choose from "
             + ", ".join(("all", *valid))
         )
-    types = valid if type == "all" else (type,)
-    by_type = {}
-    for t in types:
-        cat = _models.catalog(client, t)
-        if cat is None:
-            return _err(f"models: /models catalog unavailable for type {t!r}")
-        by_type[t] = [m["id"] for m in cat
-                      if isinstance(m, dict) and m.get("id")]
     if type == "all":
+        try:
+            catalog = _models_cmd._fetch_all(client)
+        except VeniceAPIError:
+            return _err("models: /models catalog unavailable for type 'all'")
+        by_type = {
+            t: [m["id"] for m in cat
+                if isinstance(m, dict) and m.get("id")]
+            for t, cat in catalog.items()
+        }
         return {"status": "ok", "type": "all",
                 "count": sum(len(v) for v in by_type.values()),
                 "models": by_type}
+    cat = _models.catalog(client, type)
+    if cat is None:
+        return _err(f"models: /models catalog unavailable for type {type!r}")
+    models = [m["id"] for m in cat
+              if isinstance(m, dict) and m.get("id")]
     return {"status": "ok", "type": type,
-            "count": len(by_type[type]), "models": by_type[type]}
+            "count": len(models), "models": models}
 
 
 def model_details_tool(client, *, model: str) -> dict:

--- a/src/venice/commands/models.py
+++ b/src/venice/commands/models.py
@@ -17,6 +17,8 @@ MODEL_TYPES = (
     "tts",
     "embedding",
     "upscale",
+    "asr",
+    "inpaint",
 )
 
 
@@ -61,11 +63,30 @@ def _fetch_type(client, mtype: str) -> List[dict]:
 
 
 def _fetch_all(client) -> dict:
-    return {t: _fetch_type(client, t) for t in MODEL_TYPES}
+    # The API's `all` filter is the forward-compatible catalog surface: every
+    # native model carries its own `type`, including types added after this CLI
+    # release. `code` is different -- it is a convenience filter over text
+    # models, not a ModelResponse type -- so preserve that existing bucket with
+    # one separate request.
+    models = _fetch_type(client, "all")
+    by_type = {t: [] for t in MODEL_TYPES}
+    for model in models:
+        if not isinstance(model, dict):
+            continue
+        model_type = model.get("type")
+        if isinstance(model_type, str) and model_type:
+            by_type.setdefault(model_type, []).append(model)
+    by_type["code"] = _fetch_type(client, "code")
+    return {t: by_type[t] for t in _ordered_types(by_type)}
+
+
+def _ordered_types(by_type: dict) -> List[str]:
+    """Known display order followed by future catalog types, deterministically."""
+    return list(MODEL_TYPES) + sorted(t for t in by_type if t not in MODEL_TYPES)
 
 
 def _print_counts(by_type: dict) -> None:
-    rows = [(t, len(by_type.get(t, []))) for t in MODEL_TYPES]
+    rows = [(t, len(by_type.get(t, []))) for t in _ordered_types(by_type)]
     total = sum(c for _, c in rows)
     width = max(len(t) for t, _ in rows)
     print(f"{'TYPE':<{width}}  COUNT")
@@ -113,10 +134,9 @@ def _print_listing(models: Iterable[dict], detail: bool) -> None:
 
 
 def _find_model(client, slug: str) -> Optional[dict]:
-    for t in MODEL_TYPES:
-        for m in _fetch_type(client, t):
-            if m.get("id") == slug:
-                return m
+    for m in _fetch_type(client, "all"):
+        if isinstance(m, dict) and m.get("id") == slug:
+            return m
     return None
 
 
@@ -153,7 +173,7 @@ def _run(args) -> int:
             return 0
 
         if args.type == "all":
-            for t in MODEL_TYPES:
+            for t in _ordered_types(by_type):
                 print(f"### {t} ({len(by_type[t])})")
                 _print_listing(by_type[t], detail=args.detail)
                 print()

--- a/tests/test_agent.py
+++ b/tests/test_agent.py
@@ -2996,6 +2996,12 @@ class TestToolRegistry(unittest.TestCase):
         desc = spec.parameters["properties"]["format"]["description"]
         self.assertIn("catalog default", desc)
 
+    def test_models_schema_exposes_current_catalog_types(self):
+        spec = _agent.get("venice_models")
+        model_types = spec.parameters["properties"]["type"]["enum"]
+        self.assertIn("asr", model_types)
+        self.assertIn("inpaint", model_types)
+
     def test_every_registry_tool_has_a_category(self):
         # drift guard: a new tool with no/empty category fails here.
         for spec in _agent._REGISTRY:

--- a/tests/test_mcp_tools.py
+++ b/tests/test_mcp_tools.py
@@ -1269,13 +1269,37 @@ class TestModelsTool(_ToolTest):
 
     def test_all_returns_map_keyed_by_type(self):
         from venice.commands.models import MODEL_TYPES
-        resps = _seq(*[FakeResp(200, self._catalog(f"{t}-1")) for t in MODEL_TYPES])
+
+        native = [
+            {"id": f"{t}-1", "type": t}
+            for t in MODEL_TYPES if t != "code"
+        ]
+        native.append({"id": "future-1", "type": "future-media"})
+        all_catalog = json.dumps({"data": native}).encode()
+        resps = _seq(
+            FakeResp(200, all_catalog),
+            FakeResp(200, self._catalog("code-1")),
+        )
         with mock.patch("venice.client.urllib.request.urlopen", resps), \
                 self.stdout_guard():
             out = _mcp.models_tool(_client(), type="all")
         self.assertEqual(out["status"], "ok")
-        self.assertEqual(set(out["models"]), set(MODEL_TYPES))
-        self.assertEqual(out["count"], len(MODEL_TYPES))
+        self.assertEqual(set(out["models"]), set(MODEL_TYPES) | {"future-media"})
+        self.assertEqual(out["models"]["asr"], ["asr-1"])
+        self.assertEqual(out["models"]["inpaint"], ["inpaint-1"])
+        self.assertEqual(out["models"]["code"], ["code-1"])
+        self.assertEqual(out["models"]["future-media"], ["future-1"])
+        self.assertEqual(out["count"], len(MODEL_TYPES) + 1)
+
+    def test_lists_current_asr_and_inpaint_types(self):
+        for model_type in ("asr", "inpaint"):
+            with self.subTest(model_type=model_type), \
+                    mock.patch("venice.client.urllib.request.urlopen", _seq(
+                        FakeResp(200, self._catalog(f"{model_type}-1")))), \
+                    self.stdout_guard():
+                out = _mcp.models_tool(_client(), type=model_type)
+            self.assertEqual(out["status"], "ok")
+            self.assertEqual(out["models"], [f"{model_type}-1"])
 
     def test_unknown_type_errors_without_http(self):
         def boom(*a, **kw):
@@ -1349,9 +1373,8 @@ class TestModelDetailsTool(_ToolTest):
         self.assertIsNone(out["voices"])
 
     def test_unknown_model_errors(self):
-        from venice.commands.models import MODEL_TYPES
         empty = json.dumps({"data": []}).encode()
-        resps = _seq(*[FakeResp(200, empty) for _ in MODEL_TYPES])
+        resps = _seq(FakeResp(200, empty))
         with mock.patch("venice.client.urllib.request.urlopen", resps), \
                 self.stdout_guard():
             out = _mcp.model_details_tool(_client(), model="nope")

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -17,30 +17,44 @@ def _args(**ov):
 
 
 def _models_payload(type_):
-    if type_ == "music":
-        ids = ["elevenlabs-sound-effects-v2", "mmaudio-v2-text-to-audio"]
-    elif type_ == "text":
-        ids = ["zai-org-glm-5-1", "claude-opus-4-7"]
+    ids_by_type = {
+        "text": ["zai-org-glm-5-1", "claude-opus-4-7"],
+        "music": ["elevenlabs-sound-effects-v2", "mmaudio-v2-text-to-audio"],
+        "asr": ["nvidia-parakeet-tdt-0.6b-v3"],
+        "inpaint": ["flux-dev-inpainting"],
+        "future-media": ["tomorrows-model"],
+        "alpha-future": ["next-weeks-model"],
+    }
+    if type_ == "all":
+        typed_ids = [
+            (model_type, mid)
+            for model_type, ids in ids_by_type.items()
+            for mid in ids
+        ]
+    elif type_ == "code":
+        # `code` is a special filter over models whose native response type is
+        # still `text`.
+        typed_ids = [("text", "zai-org-glm-5-1")]
     else:
-        ids = []
+        typed_ids = [(type_, mid) for mid in ids_by_type.get(type_, [])]
     return json.dumps({
         "object": "list",
         "data": [
             {
                 "id": mid,
-                "type": type_,
+                "type": model_type,
                 "model_spec": {
                     "name": mid.upper(),
                     "pricing": {"input": {"usd": 1.5}, "output": {"usd": 4.0}},
                     "capabilities": {"supportsWebSearch": True, "supportsVision": False},
                 },
             }
-            for mid in ids
+            for model_type, mid in typed_ids
         ],
     }).encode()
 
 
-def _fake_urlopen_factory():
+def _fake_urlopen_factory(calls=None):
     """Return a urlopen mock that routes /models?type=X to the right payload."""
     def _urlopen(req, timeout=None):
         url = req.full_url
@@ -48,11 +62,24 @@ def _fake_urlopen_factory():
         type_ = ""
         if "type=" in url:
             type_ = url.split("type=", 1)[1].split("&", 1)[0]
+        if calls is not None:
+            calls.append(type_)
         return FakeResp(200, _models_payload(type_), "application/json")
     return _urlopen
 
 
 class TestModels(unittest.TestCase):
+
+    def test_parser_accepts_current_asr_and_inpaint_types(self):
+        from venice.commands import models
+
+        parser = argparse.ArgumentParser()
+        subparsers = parser.add_subparsers(dest="command")
+        models.register(subparsers)
+        for model_type in ("asr", "inpaint"):
+            with self.subTest(model_type=model_type):
+                args = parser.parse_args(["models", "--type", model_type])
+                self.assertEqual(args.type, model_type)
 
     def test_default_prints_counts_by_type(self):
         from venice.commands import models
@@ -68,7 +95,11 @@ class TestModels(unittest.TestCase):
         self.assertIn("COUNT", out)
         self.assertIn("text", out)
         self.assertIn("music", out)
-        # text and music have 2 each (per payload factory); others 0
+        self.assertIn("asr", out)
+        self.assertIn("inpaint", out)
+        self.assertIn("future-media", out)
+        self.assertRegex(out, r"(?m)^asr\s+1$")
+        self.assertRegex(out, r"(?m)^inpaint\s+1$")
         self.assertIn("TOTAL", out)
 
     def test_type_filter_lists_ids(self):
@@ -83,6 +114,43 @@ class TestModels(unittest.TestCase):
         lines = [l for l in buf.getvalue().splitlines() if l.strip()]
         self.assertIn("elevenlabs-sound-effects-v2", lines)
         self.assertIn("mmaudio-v2-text-to-audio", lines)
+
+    def test_current_types_filter_and_emit_json(self):
+        from venice.commands import models
+
+        expected = {
+            "asr": "nvidia-parakeet-tdt-0.6b-v3",
+            "inpaint": "flux-dev-inpainting",
+        }
+        for model_type, model_id in expected.items():
+            with self.subTest(model_type=model_type):
+                buf = io.StringIO()
+                with mock.patch.dict(os.environ, {"VENICE_API_KEY": "fake"}), \
+                     mock.patch("venice.client.urllib.request.urlopen",
+                                _fake_urlopen_factory()), \
+                     mock.patch.object(sys, "stdout", buf):
+                    rc = models._run(_args(type=model_type, json=True))
+                self.assertEqual(rc, 0)
+                self.assertEqual(json.loads(buf.getvalue())[0]["id"], model_id)
+
+    def test_all_uses_aggregate_catalog_and_preserves_future_types(self):
+        from venice.commands import models
+
+        calls = []
+        buf = io.StringIO()
+        with mock.patch.dict(os.environ, {"VENICE_API_KEY": "fake"}), \
+             mock.patch("venice.client.urllib.request.urlopen",
+                        _fake_urlopen_factory(calls)), \
+             mock.patch.object(sys, "stdout", buf):
+            rc = models._run(_args(type="all", json=True))
+        self.assertEqual(rc, 0)
+        self.assertEqual(calls, ["all", "code"])
+        by_type = json.loads(buf.getvalue())
+        self.assertEqual(by_type["asr"][0]["id"], "nvidia-parakeet-tdt-0.6b-v3")
+        self.assertEqual(by_type["inpaint"][0]["id"], "flux-dev-inpainting")
+        self.assertEqual(by_type["future-media"][0]["id"], "tomorrows-model")
+        self.assertEqual(by_type["code"][0]["id"], "zai-org-glm-5-1")
+        self.assertEqual(list(by_type)[-2:], ["alpha-future", "future-media"])
 
     def test_detail_includes_pricing_and_caps(self):
         from venice.commands import models
@@ -102,15 +170,37 @@ class TestModels(unittest.TestCase):
     def test_slug_lookup_prints_json_for_one(self):
         from venice.commands import models
 
+        calls = []
         buf = io.StringIO()
         with mock.patch.dict(os.environ, {"VENICE_API_KEY": "fake"}), \
-             mock.patch("venice.client.urllib.request.urlopen", _fake_urlopen_factory()), \
+             mock.patch("venice.client.urllib.request.urlopen",
+                        _fake_urlopen_factory(calls)), \
              mock.patch.object(sys, "stdout", buf):
             rc = models._run(_args(slug="mmaudio-v2-text-to-audio"))
         self.assertEqual(rc, 0)
+        self.assertEqual(calls, ["all"])
         doc = json.loads(buf.getvalue())
         self.assertEqual(doc["id"], "mmaudio-v2-text-to-audio")
         self.assertEqual(doc["type"], "music")
+
+    def test_current_type_slugs_are_found_in_the_all_catalog(self):
+        from venice.commands import models
+
+        for slug, model_type in (
+            ("nvidia-parakeet-tdt-0.6b-v3", "asr"),
+            ("flux-dev-inpainting", "inpaint"),
+        ):
+            with self.subTest(model_type=model_type):
+                calls = []
+                buf = io.StringIO()
+                with mock.patch.dict(os.environ, {"VENICE_API_KEY": "fake"}), \
+                     mock.patch("venice.client.urllib.request.urlopen",
+                                _fake_urlopen_factory(calls)), \
+                     mock.patch.object(sys, "stdout", buf):
+                    rc = models._run(_args(slug=slug))
+                self.assertEqual(rc, 0)
+                self.assertEqual(calls, ["all"])
+                self.assertEqual(json.loads(buf.getvalue())["type"], model_type)
 
     def test_slug_not_found_returns_exit_6(self):
         from venice.commands import models


### PR DESCRIPTION
## Summary

- expose current ASR and inpaint model types across CLI, MCP, and agent schemas
- build aggregate catalog views from the API's `type=all` response so future native types remain visible
- preserve the special `code` filter as its own bucket and reduce slug lookup to one aggregate request

## Validation

- `VENICE_API_KEY=test-fake-key PYTHONPATH=src python3 -m unittest -v tests.test_models tests.test_mcp_tools.TestModelsTool tests.test_mcp_tools.TestModelDetailsTool tests.test_agent.TestToolRegistry` (32 tests)
- `VENICE_API_KEY=test-fake-key make lint`
- `VENICE_API_KEY=test-fake-key make scan`
- `VENICE_API_KEY=test-fake-key make test`
- `git diff --check`

Closes #148.
