### PR TITLE
v0.83: validate video catalog constraints

### DIFF
--- a/README.md
+++ b/README.md
@@ -448,8 +448,9 @@ Text-to-video (and image-to-video, see below) on the same async queue as
 minutes, not seconds, so it polls less often and waits longer by default
 (`--poll-interval` 5s, `--max-wait` 900s -- both config-backable via
 `defaults.video.*`). `--model` defaults to the catalog's
-`default`-trait video model; available durations, resolutions, aspect ratios,
-and the media-input modes below all vary by model.
+`default`-trait video model. Duration, resolution, and aspect ratio are checked
+against that selected model's live catalog constraints before the quote;
+media-input support also varies by model.
 
 ```sh
 # Quote only -- no spend.
@@ -480,11 +481,11 @@ local files are read, size-checked, and encoded to a `data:` URL for you.
 venice video "slow zoom out from the figure" --image hero.png --yes
 venice video "morph A into B" --image a.png --end-image b.png --yes
 
-# Reference images for character/style consistency (repeatable, up to 9).
+# Reference images for character/style consistency (repeatable, up to 30).
 venice video "the same knight, new scene" \
   --reference-image knight1.png --reference-image knight2.png --yes
 
-# Video-to-video / upscale, and reference videos (repeatable, up to 3). The
+# Video-to-video / upscale, and reference videos (repeatable, up to 10). The
 # aggregate reference-video duration feeds the *quote* so R2V pricing is right.
 venice video "restyle this clip" --video source.mp4 \
   --reference-video ref.mp4 --reference-video-duration 5 --yes
@@ -498,8 +499,8 @@ venice video "@Element1 greets @Element2 at @Image1" \
 ```
 
 Full media flags: `--image`, `--end-image`, `--video`, `--audio` (background
-music, distinct from `--no-audio`), `--reference-image` (≤9),
-`--reference-video` (≤3), `--reference-audio` (≤3), `--scene-image` (≤4),
+music, distinct from `--no-audio`), `--reference-image` (≤30),
+`--reference-video` (≤10), `--reference-audio` (≤10), `--scene-image` (≤4),
 `--reference-video-duration`, and `--element` (JSON, ≤4). Image/reference
 inputs condition generation and are sent only on `/video/queue`; `--video` and
 `--reference-video-duration` also reach `/video/quote` because they change the
@@ -1935,14 +1936,17 @@ their sections apply only on the command line.
 
 **Any** config value whose flag has a fixed set of choices is validated against
 that set — `defaults.image.format`,
-`defaults.sfx.model`, `defaults.video.{duration,resolution,aspect_ratio}`,
+`defaults.sfx.model`,
 `defaults.image_edit.{aspect_ratio,output_format}`, `defaults.chat.web_search`,
 `defaults.bit_depth` and `defaults.contact_sheet.engine`.
 An unrecognized value is reported on stderr, naming the legal values exactly as
 `--flag` would, and skipped — so the command falls back to its built-in default
 rather than sending something the API will reject. This applies on the CLI and on
 the agent-tool path alike; config must never be able to set a value the command
-line would refuse.
+line would refuse. Video duration, resolution, and aspect ratio are different:
+their legal values vary by model, so
+`defaults.video.{duration,resolution,aspect_ratio}` are validated against the
+selected model's live catalog entry before any quote or paid request.
 
 The **API key is never stored here** — it stays in
 `~/.config/venice/credentials`. Unknown keys are preserved on write, so the

--- a/src/venice/commands/_agent.py
+++ b/src/venice/commands/_agent.py
@@ -50,6 +50,7 @@ from . import _compact
 from . import _openai
 from . import _shared
 from . import upscale as _upscale
+from . import video as _video
 from .models import MODEL_TYPES
 
 
@@ -2149,8 +2150,37 @@ _VIDEO_SCHEMA = _obj(
         "resolution": _p("string", "Output resolution tier, e.g. 720p/1080p."),
         "aspect_ratio": _p("string", "Output aspect ratio, e.g. 16:9."),
         "no_audio": _p("boolean", "Generate silent video (no soundtrack)."),
-        "image_url": _p("string", "URL of a start/reference image (image-to-video)."),
-        "end_image_url": _p("string", "URL of an end frame to interpolate toward."),
+        "image_url": _p("string", "Authorized local path or URL of a start image."),
+        "end_image_url": _p("string", "Authorized local path or URL of an end frame."),
+        "video_url": _p("string", "Authorized local path or URL of an input video."),
+        "audio_url": _p("string", "Authorized local path or URL of input audio."),
+        "reference_image_urls": {
+            "type": "array",
+            "items": {"type": "string"},
+            "maxItems": _video.REF_IMAGE_MAX,
+            "description": "Authorized local paths or URLs of reference images.",
+        },
+        "reference_video_urls": {
+            "type": "array",
+            "items": {"type": "string"},
+            "maxItems": _video.REF_VIDEO_MAX,
+            "description": "Authorized local paths or URLs of reference videos.",
+        },
+        "reference_audio_urls": {
+            "type": "array",
+            "items": {"type": "string"},
+            "maxItems": _video.REF_AUDIO_MAX,
+            "description": "Authorized local paths or URLs of reference audio clips.",
+        },
+        "scene_image_urls": {
+            "type": "array",
+            "items": {"type": "string"},
+            "maxItems": _video.SCENE_MAX,
+            "description": "Authorized local paths or URLs of scene images.",
+        },
+        "reference_video_duration": _p(
+            "number", "Aggregate reference-video duration used for the quote."
+        ),
         "background": _BACKGROUND_PARAM,
     },
     required=["prompt"],

--- a/src/venice/commands/_mcp.py
+++ b/src/venice/commands/_mcp.py
@@ -860,6 +860,7 @@ def video_tool(
         return _err(f"video: invalid max_wait: {e}")
 
     ns = SimpleNamespace(
+        duration=duration,
         image=image_url, end_image=end_image_url, video=video_url,
         audio_input=audio_url, reference_image=reference_image_urls,
         reference_video=reference_video_urls, reference_audio=reference_audio_urls,
@@ -874,6 +875,11 @@ def video_tool(
         return _err(f"video: invalid media input (exit {rc})")
 
     models = _models.catalog(client, "video")
+    if models is None:
+        return _err(
+            "video: could not fetch the live video catalog; cannot validate "
+            "model-specific options"
+        )
     model, rc = _models.resolve_model(
         model, models, label="video", noun="video model",
         config_key="defaults.video.model",
@@ -881,8 +887,19 @@ def video_tool(
     if rc is not None:
         return _err(f"video: could not resolve model (exit {rc})")
 
+    try:
+        _video.validate_model_options(
+            models,
+            model,
+            duration=duration,
+            resolution=resolution,
+            aspect_ratio=aspect_ratio,
+        )
+    except ValueError as e:
+        return _err(f"video: {e}")
+
     extra = _video._shared_params(ns)
-    quote_body = {"model": model, "duration": duration}
+    quote_body = {"model": model}
     quote_body.update(extra)
     quote_body.update(quote_media)
     try:
@@ -898,7 +915,7 @@ def video_tool(
     if gate is not None:
         return gate
 
-    queue_body = {"model": model, "prompt": prompt.strip(), "duration": duration}
+    queue_body = {"model": model, "prompt": prompt.strip()}
     queue_body.update(extra)
     if negative_prompt:
         queue_body["negative_prompt"] = negative_prompt

--- a/src/venice/commands/video.py
+++ b/src/venice/commands/video.py
@@ -7,8 +7,9 @@ models return a `download_url` at queue time -- for those, `/video/retrieve`
 reports JSON status only and the mp4 is fetched from that presigned URL once
 COMPLETED. Non-VPS models stream `video/mp4` straight from `/video/retrieve`.
 
-A free `/models?type=video` catalog GET (via the lean client) validates
-`--model` and resolves a default before the paid quote -- mirrors `venice chat`.
+A free `/models?type=video` catalog GET (via the lean client) resolves the model
+and validates its advertised duration/resolution/aspect-ratio constraints before
+the paid quote.
 """
 from __future__ import annotations
 
@@ -47,23 +48,14 @@ MEDIA_LIMITS = {
     "audio": 15 * 1024 * 1024,  # audio inputs <= 15 MB
 }
 DEFAULT_MIME = {"image": "image/png", "video": "video/mp4", "audio": "audio/mpeg"}
-REF_IMAGE_MAX = 9
-REF_VIDEO_MAX = 3
-REF_AUDIO_MAX = 3
+REF_IMAGE_MAX = 30
+REF_VIDEO_MAX = 10
+REF_AUDIO_MAX = 10
 SCENE_MAX = 4
 ELEMENTS_MAX = 4
 ELEMENT_REF_IMAGE_MAX = 3
 
 DEFAULT_VIDEO_DURATION = "5s"
-DURATION_CHOICES = (
-    "2s", "3s", "4s", "5s", "6s", "7s", "8s", "9s", "10s", "11s", "12s", "13s",
-    "14s", "15s", "16s", "18s", "20s", "25s", "30s", "1 gen", "Auto",
-)
-RESOLUTION_CHOICES = (
-    "256p", "360p", "480p", "540p", "580p", "720p", "1080p", "1440p", "2160p",
-    "4k", "2x", "4x", "true_1080p",
-)
-ASPECT_CHOICES = ("1:1", "2:3", "3:2", "3:4", "4:3", "9:16", "16:9", "21:9")
 
 
 def register(subparsers) -> None:
@@ -84,13 +76,18 @@ def register(subparsers) -> None:
         help="Video model id (default: the catalog's 'default'-trait model).",
     )
     p.add_argument(
-        "--duration", choices=DURATION_CHOICES, default=None,
-        help=f"Clip length (default {DEFAULT_VIDEO_DURATION}). Config-backable "
-        "via defaults.video.duration; an explicit --duration still wins.",
+        "--duration", default=None,
+        help=f"Clip length (default {DEFAULT_VIDEO_DURATION}); validated against "
+        "the selected model's live catalog constraints. Config-backable via "
+        "defaults.video.duration; an explicit --duration still wins.",
     )
-    p.add_argument("--resolution", choices=RESOLUTION_CHOICES, default=None)
     p.add_argument(
-        "--aspect-ratio", choices=ASPECT_CHOICES, default=None, dest="aspect_ratio"
+        "--resolution", default=None,
+        help="Output resolution; validated against the selected model's live catalog.",
+    )
+    p.add_argument(
+        "--aspect-ratio", default=None, dest="aspect_ratio",
+        help="Output aspect ratio; validated against the selected model's live catalog.",
     )
     p.add_argument("--negative-prompt", default=None, dest="negative_prompt")
     # Tri-stated so `defaults.video.no_audio` can reach the dest (#57 Class B).
@@ -215,8 +212,8 @@ def register_status(subparsers) -> None:
 
 
 def _shared_params(args) -> dict:
-    """Optional params accepted by both /video/quote and /video/queue."""
-    extra: dict = {}
+    """Params accepted by both /video/quote and /video/queue."""
+    extra: dict = {"duration": args.duration}
     if args.resolution:
         extra["resolution"] = args.resolution
     if args.aspect_ratio:
@@ -224,6 +221,82 @@ def _shared_params(args) -> dict:
     if args.no_audio:
         extra["audio"] = False
     return extra
+
+
+def _constraint_values(constraints: dict, field: str, model: str) -> Tuple[str, ...]:
+    values = constraints.get(field)
+    if (
+        not isinstance(values, list)
+        or any(not isinstance(value, str) or not value.strip() for value in values)
+    ):
+        raise ValueError(
+            f"live video catalog entry for {model!r} has invalid "
+            f"constraints.{field}"
+        )
+    return tuple(values)
+
+
+def validate_model_options(
+    models,
+    model: str,
+    *,
+    duration: str,
+    resolution: Optional[str] = None,
+    aspect_ratio: Optional[str] = None,
+) -> None:
+    """Validate request choices against one selected live video catalog entry.
+
+    Unlike the generic model resolver, generation cannot proceed with an explicit
+    model when the catalog is unavailable: the catalog is the authority for these
+    model-specific values, and guessing could reach a paid request with stale
+    options.
+    """
+    if models is None:
+        raise ValueError("could not fetch the live video catalog")
+
+    entry = next(
+        (
+            item
+            for item in models
+            if isinstance(item, dict) and item.get("id") == model
+        ),
+        None,
+    )
+    if entry is None:
+        raise ValueError(f"model {model!r} is not in the live video catalog")
+    spec = entry.get("model_spec")
+    constraints = spec.get("constraints") if isinstance(spec, dict) else None
+    if not isinstance(constraints, dict):
+        raise ValueError(
+            f"live video catalog entry for {model!r} has no constraints object"
+        )
+
+    available = {
+        "duration": _constraint_values(constraints, "durations", model),
+        "resolution": _constraint_values(constraints, "resolutions", model),
+        "aspect ratio": _constraint_values(constraints, "aspect_ratios", model),
+    }
+    requested = {
+        "duration": duration,
+        "resolution": resolution,
+        "aspect ratio": aspect_ratio,
+    }
+    for label, value in requested.items():
+        if value is None:
+            if label == "duration":
+                raise ValueError("duration must be a non-empty string")
+            continue
+        if not isinstance(value, str) or not value.strip():
+            raise ValueError(f"{label} must be a non-empty string")
+        choices = available[label]
+        if value not in choices:
+            if choices:
+                suffix = "choose from " + ", ".join(choices)
+            else:
+                suffix = f"{model!r} advertises no {label} values"
+            raise ValueError(
+                f"{label} {value!r} is not supported by {model!r}; {suffix}"
+            )
 
 
 def _is_url(value: str) -> bool:
@@ -409,6 +482,13 @@ def _run_generate(args) -> int:
         return rc
 
     models = _models.catalog(client, "video")
+    if models is None:
+        print(
+            "video: could not fetch the live video catalog; cannot validate "
+            "model-specific options",
+            file=sys.stderr,
+        )
+        return 2
     model, rc = _models.resolve_model(
         args.model, models, label="video", noun="video model",
         config_key="defaults.video.model",
@@ -416,12 +496,24 @@ def _run_generate(args) -> int:
     if rc is not None:
         return rc
 
+    try:
+        validate_model_options(
+            models,
+            model,
+            duration=args.duration,
+            resolution=args.resolution,
+            aspect_ratio=args.aspect_ratio,
+        )
+    except ValueError as e:
+        print(f"video: {e}", file=sys.stderr)
+        return 2
+
     quote_media, queue_media, rc = _collect_media(args)
     if rc is not None:
         return rc
 
     extra = _shared_params(args)
-    quote_body = {"model": model, "duration": args.duration}
+    quote_body = {"model": model}
     quote_body.update(extra)
     quote_body.update(quote_media)
     try:
@@ -457,7 +549,7 @@ def _run_generate(args) -> int:
         if rc is not None:
             return rc
 
-    queue_body = {"model": model, "prompt": args.prompt, "duration": args.duration}
+    queue_body = {"model": model, "prompt": args.prompt}
     queue_body.update(extra)
     if args.negative_prompt:
         queue_body["negative_prompt"] = args.negative_prompt

--- a/src/venice/mcp_server.py
+++ b/src/venice/mcp_server.py
@@ -271,7 +271,9 @@ def build_server(client, doc=None, root=None) -> FastMCP:
         takes an http(s)/data URL or a local path. LONG-RUNNING -- blocks while polling
         up to max_wait seconds (a host may time out). Paid: a quote is fetched first;
         over-cap or dynamic quotes need confirm=true. Omitted args fall back to
-        defaults.video.* in the user's config, then to the built-in duration=5s."""
+        defaults.video.* in the user's config, then to the built-in duration=5s.
+        Duration/resolution/aspect ratio are validated against the selected model's
+        live catalog constraints before quote or spend."""
         return _mcp.video_tool(
             client, prompt,
             **_merged(_defaults["video"], dict(

--- a/src/venice/userconfig.py
+++ b/src/venice/userconfig.py
@@ -599,10 +599,12 @@ _COMMAND_MAP = {
         # #57 Class C: literal now lives in `video._run_generate`. `_run_status`
         # already snapshots/restores args.model around apply_defaults, since
         # there the model is job identity rather than a preference.
-        "duration": ("duration", _one_of("venice.commands.video", "DURATION_CHOICES")),
+        # These three are model-specific and validated against the selected
+        # model's live catalog constraints before quote/spend.
+        "duration": ("duration", str),
         "model": ("model", str),
-        "resolution": ("resolution", _one_of("venice.commands.video", "RESOLUTION_CHOICES")),
-        "aspect_ratio": ("aspect_ratio", _one_of("venice.commands.video", "ASPECT_CHOICES")),
+        "resolution": ("resolution", str),
+        "aspect_ratio": ("aspect_ratio", str),
         "negative_prompt": ("negative_prompt", str),
         # #57 Class B: tri-stated --no-audio/--with-audio and --no-cleanup.
         "no_audio": ("no_audio", _as_bool),

--- a/tests/test_agent.py
+++ b/tests/test_agent.py
@@ -2687,6 +2687,20 @@ class TestAsyncJobSchemas(unittest.TestCase):
             self.assertIn("background", props)
             self.assertEqual(props["background"]["type"], "boolean")
 
+    def test_video_schema_exposes_bounded_reference_inputs(self):
+        props = _agent._VIDEO_SCHEMA["properties"]
+        expected = {
+            "reference_image_urls": _agent._video.REF_IMAGE_MAX,
+            "reference_video_urls": _agent._video.REF_VIDEO_MAX,
+            "reference_audio_urls": _agent._video.REF_AUDIO_MAX,
+            "scene_image_urls": _agent._video.SCENE_MAX,
+        }
+        for name, maximum in expected.items():
+            self.assertEqual(props[name]["type"], "array")
+            self.assertEqual(props[name]["maxItems"], maximum)
+        for name in ("video_url", "audio_url", "reference_video_duration"):
+            self.assertIn(name, props)
+
     def test_job_schemas_require_handle_fields_and_hide_controls(self):
         for schema in (_agent._JOB_STATUS_SCHEMA, _agent._JOB_RESULT_SCHEMA):
             self.assertEqual(schema.get("required"), ["queue_id", "type", "model"])

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1007,7 +1007,6 @@ class TestClassCParity(unittest.TestCase):
         cases = [
             ("image", image, ["image", "p"], "format", "gif"),
             ("sfx", sfx, ["sfx", "p"], "model", "bogus"),
-            ("video", video, ["video", "p"], "duration", "99s"),
             # #57 C2/D: the first int choice set, and the first choices row
             # reached through _GLOBAL_MAP rather than a section.
             ("master", master, ["master", "in.wav"], "bit_depth", 8),

--- a/tests/test_mcp_tools.py
+++ b/tests/test_mcp_tools.py
@@ -39,10 +39,17 @@ def _price_doc(model, usd):
     ).encode()
 
 
-def _video_catalog(model="seedance-2-0-text-to-video"):
+def _video_catalog(model="seedance-2-0-text-to-video", constraints=None):
     """A /models?type=video catalog whose first id carries the 'default' trait."""
+    constraints = constraints or {
+        "durations": ["5s", "10s"],
+        "resolutions": ["720p", "1080p"],
+        "aspect_ratios": ["16:9", "9:16"],
+    }
     return json.dumps(
-        {"data": [{"id": model, "model_spec": {"traits": ["default"]}}]}
+        {"data": [{"id": model, "model_spec": {
+            "traits": ["default"], "constraints": constraints,
+        }}]}
     ).encode()
 
 
@@ -744,6 +751,84 @@ class TestVisionTool(_ToolTest):
 
 
 class TestVideoTool(_ToolTest):
+    def test_catalog_values_reach_matching_quote_and_queue_bodies(self):
+        constraints = {
+            "durations": ["17s", "auto"],
+            "resolutions": ["2K", "768P"],
+            "aspect_ratios": ["adaptive", "9:21"],
+        }
+        seen = {}
+
+        def fake(req, timeout=None):
+            if "type=video" in req.full_url:
+                return FakeResp(200, _video_catalog(constraints=constraints))
+            if req.full_url.endswith("/video/quote"):
+                seen["quote"] = json.loads(req.data.decode())
+                return FakeResp(200, b'{"quote": 0.5}')
+            if req.full_url.endswith("/video/queue"):
+                seen["queue"] = json.loads(req.data.decode())
+                return FakeResp(200, b'{"queue_id":"catalog123"}')
+            raise AssertionError(f"background must not poll: {req.full_url}")
+
+        with mock.patch("venice.client.urllib.request.urlopen", fake), self.stdout_guard():
+            res = _mcp.video_tool(
+                _client(), "animate", duration="17s", resolution="2K",
+                aspect_ratio="adaptive", confirm=True, background=True,
+            )
+        self.assertEqual(res["status"], "queued")
+        for field in ("duration", "resolution", "aspect_ratio"):
+            self.assertEqual(seen["quote"][field], seen["queue"][field])
+
+    def test_unsupported_catalog_value_stops_before_quote(self):
+        seen = []
+
+        def fake(req, timeout=None):
+            seen.append(req.full_url)
+            return FakeResp(200, _video_catalog())
+
+        with mock.patch("venice.client.urllib.request.urlopen", fake), self.stdout_guard():
+            res = _mcp.video_tool(_client(), "animate", duration="17s", confirm=True)
+        self.assertEqual(res["status"], "error")
+        self.assertIn("not supported", res["message"])
+        self.assertEqual(len(seen), 1)
+
+    def test_null_duration_is_rejected_before_quote(self):
+        seen = []
+
+        def fake(req, timeout=None):
+            seen.append(req.full_url)
+            return FakeResp(200, _video_catalog())
+
+        with mock.patch("venice.client.urllib.request.urlopen", fake), self.stdout_guard():
+            res = _mcp.video_tool(_client(), "animate", duration=None, confirm=True)
+        self.assertEqual(res["status"], "error")
+        self.assertIn("duration must be a non-empty string", res["message"])
+        self.assertEqual(len(seen), 1)
+
+    def test_catalog_outage_is_error_even_with_explicit_model(self):
+        with mock.patch.object(_mcp._models, "catalog", return_value=None), \
+             self.stdout_guard():
+            res = _mcp.video_tool(
+                _client(), "animate", model="seedance-2-0-text-to-video",
+                confirm=True,
+            )
+        self.assertEqual(res["status"], "error")
+        self.assertIn("cannot validate model-specific options", res["message"])
+
+    def test_reference_over_schema_max_stops_before_network(self):
+        def boom(*a, **kw):
+            raise AssertionError("invalid reference count must not reach the network")
+
+        refs = [
+            f"https://x.test/{i}.png"
+            for i in range(_mcp._video.REF_IMAGE_MAX + 1)
+        ]
+        with mock.patch("venice.client.urllib.request.urlopen", boom), self.stdout_guard():
+            res = _mcp.video_tool(
+                _client(), "animate", reference_image_urls=refs, confirm=True
+            )
+        self.assertEqual(res["status"], "error")
+
     def test_authorized_local_media_uses_signature_mime_before_catalog(self):
         frame = Path(self.td) / "frame.txt"
         frame.write_bytes(b"\x00\x00\x00\x18ftypisombody")

--- a/tests/test_video.py
+++ b/tests/test_video.py
@@ -18,14 +18,25 @@ from venice import config
 from tests.test_client import FakeResp
 
 DEFAULT_MODEL = "seedance-2-0-text-to-video"
+DEFAULT_CONSTRAINTS = {
+    "durations": ["5s", "10s"],
+    "resolutions": ["720p", "1080p"],
+    "aspect_ratios": ["16:9", "9:16"],
+}
 
 
-def _catalog(*ids_with_default):
+def _catalog(*ids_with_default, constraints=None):
     """Build a /models?type=video response; first id carries the 'default' trait."""
     data = []
     for i, mid in enumerate(ids_with_default):
         traits = ["default"] if i == 0 else []
-        data.append({"id": mid, "model_spec": {"traits": traits}})
+        data.append({
+            "id": mid,
+            "model_spec": {
+                "traits": traits,
+                "constraints": constraints or DEFAULT_CONSTRAINTS,
+            },
+        })
     return FakeResp(200, json.dumps({"data": data}).encode(), "application/json")
 
 
@@ -285,6 +296,180 @@ class TestVideoFlow(unittest.TestCase):
         self.assertEqual(rc, 6)
         self.assertEqual(list(Path(".").glob("venice-video-*")), [])
 
+    def test_current_catalog_values_reach_matching_quote_and_queue_bodies(self):
+        from venice.commands import video
+
+        constraints = {
+            "durations": ["1s", "17s", "auto"],
+            "resolutions": ["2K", "768P"],
+            "aspect_ratios": ["adaptive", "9:21"],
+        }
+        seen = {}
+
+        def fake_urlopen(req, timeout=None):
+            if "type=video" in req.full_url:
+                return _catalog(DEFAULT_MODEL, constraints=constraints)
+            if req.full_url.endswith("/video/quote"):
+                seen["quote"] = json.loads(req.data.decode())
+                return FakeResp(200, b'{"quote": 0.5}', "application/json")
+            if req.full_url.endswith("/video/queue"):
+                seen["queue"] = json.loads(req.data.decode())
+                return FakeResp(200, b'{"queue_id":"newvalues123"}', "application/json")
+            raise AssertionError(f"unexpected call: {req.full_url}")
+
+        with mock.patch.dict(os.environ, {"VENICE_API_KEY": "fake"}), \
+             mock.patch("venice.client.urllib.request.urlopen", fake_urlopen), \
+             mock.patch("sys.stdout"):
+            rc = video._run_generate(_build_args(
+                duration="17s", resolution="2K", aspect_ratio="adaptive",
+                background=True,
+            ))
+
+        self.assertEqual(rc, 0)
+        for field in ("duration", "resolution", "aspect_ratio"):
+            self.assertEqual(seen["quote"][field], seen["queue"][field])
+
+    def test_model_specific_rejection_stops_before_quote(self):
+        from venice.commands import video
+
+        calls = []
+
+        def fake_urlopen(req, timeout=None):
+            calls.append(req.full_url)
+            return _catalog(DEFAULT_MODEL)
+
+        err = io.StringIO()
+        with mock.patch.dict(os.environ, {"VENICE_API_KEY": "fake"}), \
+             mock.patch("venice.client.urllib.request.urlopen", fake_urlopen), \
+             contextlib.redirect_stderr(err):
+            rc = video._run_generate(_build_args(duration="17s"))
+
+        self.assertEqual(rc, 2)
+        self.assertEqual(len(calls), 1)
+        self.assertIn("duration '17s' is not supported", err.getvalue())
+        self.assertIn("5s, 10s", err.getvalue())
+
+    def test_validator_uses_selected_model_and_accepts_current_values(self):
+        from venice.commands import video
+
+        first = {
+            "durations": ["1s", "17s", "auto"],
+            "resolutions": ["2K", "768P"],
+            "aspect_ratios": ["adaptive", "9:21"],
+        }
+        second = {
+            "durations": ["5s"],
+            "resolutions": ["720p"],
+            "aspect_ratios": ["16:9"],
+        }
+        models = [
+            {"id": "current", "model_spec": {"constraints": first}},
+            {"id": "other", "model_spec": {"constraints": second}},
+        ]
+        requests = (
+            {"duration": "1s", "resolution": "2K", "aspect_ratio": "adaptive"},
+            {"duration": "17s", "resolution": "768P", "aspect_ratio": "9:21"},
+            {"duration": "auto"},
+        )
+        for request in requests:
+            with self.subTest(request=request):
+                video.validate_model_options(models, "current", **request)
+        with self.assertRaisesRegex(ValueError, "not supported"):
+            video.validate_model_options(models, "other", **requests[0])
+
+    def test_catalog_outage_stops_before_quote_with_or_without_explicit_model(self):
+        from venice.commands import video
+
+        for model in (None, DEFAULT_MODEL):
+            with self.subTest(model=model):
+                err = io.StringIO()
+                with mock.patch.dict(os.environ, {"VENICE_API_KEY": "fake"}), \
+                     mock.patch.object(video._models, "catalog", return_value=None), \
+                     contextlib.redirect_stderr(err):
+                    rc = video._run_generate(_build_args(model=model))
+
+                self.assertEqual(rc, 2)
+                self.assertIn("could not fetch the live video catalog", err.getvalue())
+                self.assertNotIn("pass --model", err.getvalue())
+
+    def test_missing_constraints_and_unsupported_default_fail_loud(self):
+        from venice.commands import video
+
+        cases = [
+            ({"data": [{"id": DEFAULT_MODEL, "model_spec": {"traits": ["default"]}}]},
+             "has no constraints object"),
+            ({"data": [{
+                "id": DEFAULT_MODEL,
+                "model_spec": {
+                    "traits": ["default"],
+                    "constraints": {
+                        "durations": "5s",
+                        "resolutions": [],
+                        "aspect_ratios": [],
+                    },
+                },
+            }]}, "invalid constraints.durations"),
+            ({"data": [{
+                "id": DEFAULT_MODEL,
+                "model_spec": {
+                    "traits": ["default"],
+                    "constraints": {
+                        "durations": ["10s"],
+                        "resolutions": [],
+                        "aspect_ratios": [],
+                    },
+                },
+            }]}, "duration '5s' is not supported"),
+        ]
+        for doc, message in cases:
+            with self.subTest(message=message):
+                calls = []
+
+                def fake_urlopen(req, timeout=None):
+                    calls.append(req.full_url)
+                    return FakeResp(200, json.dumps(doc).encode(), "application/json")
+
+                err = io.StringIO()
+                with mock.patch.dict(os.environ, {"VENICE_API_KEY": "fake"}), \
+                     mock.patch("venice.client.urllib.request.urlopen", fake_urlopen), \
+                     contextlib.redirect_stderr(err):
+                    rc = video._run_generate(_build_args())
+                self.assertEqual(rc, 2)
+                self.assertEqual(len(calls), 1)
+                self.assertIn(message, err.getvalue())
+
+    def test_parser_accepts_catalog_driven_values(self):
+        from venice.commands import video
+
+        parser = argparse.ArgumentParser()
+        subparsers = parser.add_subparsers(dest="command")
+        video.register(subparsers)
+        args = parser.parse_args([
+            "video", "p", "--duration", "1s", "--resolution", "768P",
+            "--aspect-ratio", "9:21",
+        ])
+        self.assertEqual((args.duration, args.resolution, args.aspect_ratio),
+                         ("1s", "768P", "9:21"))
+
+    def test_config_value_is_validated_against_selected_model(self):
+        from venice.commands import video
+
+        doc = {"version": 1, "mcpServers": {},
+               "defaults": {"video": {"duration": "99s"}}}
+        calls = []
+
+        def fake_urlopen(req, timeout=None):
+            calls.append(req.full_url)
+            return _catalog(DEFAULT_MODEL)
+
+        with mock.patch("venice.userconfig.load_config", lambda *a, **k: doc), \
+             mock.patch.dict(os.environ, {"VENICE_API_KEY": "fake"}), \
+             mock.patch("venice.client.urllib.request.urlopen", fake_urlopen), \
+             contextlib.redirect_stderr(io.StringIO()):
+            rc = video._run_generate(_build_args(duration=None))
+        self.assertEqual(rc, 2)
+        self.assertEqual(len(calls), 1)
+
     def test_missing_api_key_returns_exit_2(self):
         from venice.commands import video
 
@@ -447,6 +632,30 @@ class TestVideoMediaInputs(unittest.TestCase):
         self.assertTrue(refs[0].startswith("data:image/png;base64,"))
         self.assertEqual(base64.b64decode(refs[0].split(",", 1)[1]), b"AAA")
         self.assertEqual(refs[1], "https://x.test/b.png")
+
+    def test_reference_arrays_accept_schema_maxima_and_reject_one_more(self):
+        from venice.commands import video
+
+        cases = (
+            ("reference_image", video.REF_IMAGE_MAX),
+            ("reference_video", video.REF_VIDEO_MAX),
+            ("reference_audio", video.REF_AUDIO_MAX),
+        )
+        for attr, cap in cases:
+            with self.subTest(attr=attr, count=cap):
+                args = _build_args(**{
+                    attr: [f"https://x.test/{i}" for i in range(cap)]
+                })
+                _quote, queue, rc = video._collect_media(args)
+                self.assertIsNone(rc)
+                self.assertEqual(len(queue[f"{attr}_urls"]), cap)
+            with self.subTest(attr=attr, count=cap + 1):
+                args = _build_args(**{
+                    attr: [f"https://x.test/{i}" for i in range(cap + 1)]
+                })
+                with contextlib.redirect_stderr(io.StringIO()):
+                    _quote, _queue_body, rc = video._collect_media(args)
+                self.assertEqual(rc, 2)
 
     def test_reference_video_duration_is_quote_only(self):
         rc, cap = self._run_full(_build_args(


### PR DESCRIPTION
## Summary

- validate duration, resolution, and aspect ratio against the selected video model's live catalog constraints before quote/spend
- raise reference-array limits to the current 30/10/10 contract and expose the existing media inputs across agent/MCP schemas
- keep shared quote/queue fields unified and make config/help/tests catalog-driven

The generic advanced queue-JSON escape hatch discussed in #147 is deliberately deferred.

## Validation

- `VENICE_API_KEY=test-fake-key make lint`
- `VENICE_API_KEY=test-fake-key make scan`
- `VENICE_API_KEY=test-fake-key make test`
- `git diff --check`

Closes #147.