### PR TITLE
v0.83: expose native image controls

### DIFF
--- a/README.md
+++ b/README.md
@@ -254,6 +254,12 @@ venice image "frost wyrm, splash art" --variants 4 --yes
 venice image "portrait card frame" --width 768 --height 1024 \
     --negative-prompt "text, watermark" --seed 42 --cfg-scale 7.5 --yes
 
+# Model-native controls. Style references accept local files, HTTP(S) URLs,
+# data URLs, or raw base64; repeat the JSON flag for each reference.
+venice image "portrait in the same painted style" --resolution 1K --quality high \
+    --style-reference '{"image":"style.png","strength":0.7}' \
+    --embed-exif-metadata --enhance-prompt --yes
+
 # Omit the Venice watermark (best for finished card art).
 venice image "frost wyrm, splash art" --hide-watermark --yes
 
@@ -315,6 +321,17 @@ Choose a model with `--model` (default `venice-sd35`); see
 `venice models --type image --detail` for ids and per-image pricing.
 Formats: `png` (default), `webp`, `jpeg`. Aspect-ratio/resolution-tier
 models take `--aspect-ratio`/`--resolution` instead of `--width`/`--height`.
+Native controls include repeatable `--style-reference JSON`, `--quality`,
+`--lora-strength`, `--embed-exif-metadata`, `--web-search`,
+`--disable-prompt-optimization-thinking`, and `--enhance-prompt` (with explicit
+inverse forms for boolean options). Style-reference image data is bounded below
+8 MiB; local files are checked as recognized images and encoded as data URLs.
+Raw base64 is accepted and preserved. Reference count,
+reference-strength support, and quality are validated against the selected
+model's live catalog entry. Quality/resolution pricing is selected from the
+matching catalog matrix. Because web search and prompt enhancement can add an
+unlisted charge, their total is treated as unknown: `--max-spend` fails closed
+and MCP/agent callers must explicitly confirm.
 `--hide-watermark` drops the Venice watermark (Venice may keep it for some
 content); `--no-safe-mode` stops adult-classified art from being blurred. To
 drop the watermark **by default**, set `defaults.image.hide_watermark` in config
@@ -371,9 +388,10 @@ confirm before the charge.
 ## Edit images
 
 Iterate on already-generated art without regenerating it — recolor, restyle, or
-inpaint a card — via `/image/edit`. Add one or two `--layer` images (masks or
-overlays) to composite instead, which routes to `/image/multi-edit` (up to 3
-images total, base first):
+inpaint a card — via `/image/edit`. Add repeatable `--layer` images (masks or
+overlays) to composite instead, which routes to `/image/multi-edit` (base
+first). The selected model's live `maxInputImages` constraint supplies the
+limit:
 
 ```sh
 # Prompt-only edit -> ./card-edit.png.
@@ -387,14 +405,21 @@ venice image-edit --image-url https://example.com/card.png \
 # Mask/overlay composite -> /image/multi-edit (base first, then layers).
 venice image-edit base.png -p "apply this mask" --layer mask.png --yes
 
+# Multi-edit-only quality plus prompt controls shared by both edit routes.
+venice image-edit base.png -p "combine these references" --layer style.png \
+    --quality high --enhance-prompt \
+    --disable-prompt-optimization-thinking --yes
+
 # Dry-run: show the planned output + balance, spend nothing.
 venice image-edit card.png -p "brighter" --dry-run
 ```
 
 Provide exactly one base source: a positional file (base64-encoded under 25 MB)
 or `--image-url`. `--prompt/-p` is required. Optional `--model`, `--aspect-ratio`,
-`--resolution`, `--output-format`, and `--safe-mode`/`--no-safe-mode` (config-backable
-via `defaults.image_edit.safe_mode`) map straight to the API;
+`--resolution`, `--output-format`, prompt optimization controls, and
+`--safe-mode`/`--no-safe-mode` map straight to the API. `--quality` applies only
+to multi-edit and is checked against that model's advertised qualities. These
+preferences are config-backable via `defaults.image_edit.*`;
 omit them to take the model defaults (`firered-image-edit`, PNG for 1K). Pricing
 is dynamic like `upscale`; balance is shown and you confirm before the charge.
 
@@ -1871,12 +1896,15 @@ safety), it should be settable in config." Currently config-backable:
 
 - `defaults.image.*` — `model`, `format`, `variants`, `width`, `height`,
   `aspect_ratio`, `resolution`, `style_prefix`, `preset`, `preset_file`,
-  `negative_prompt`, `cfg_scale`, `steps`, `style_preset`, `hide_watermark`,
+  `negative_prompt`, `cfg_scale`, `steps`, `style_preset`, `style_references`,
+  `embed_exif_metadata`, `lora_strength`, `quality`, `enable_web_search`,
+  `disable_prompt_optimization_thinking`, `enhance_prompt`, `hide_watermark`,
   `safe_mode` (tri-state `--safe-mode`/`--no-safe-mode`; set `false` to skip
   Venice's safety blur). Note `variants` is a **cost multiplier** — it is
   reflected in the confirmation prompt before anything is charged
 - `defaults.image_edit.*` — `model`, `aspect_ratio`, `resolution`, `output_format`,
-  `safe_mode` (tri-state `--safe-mode`/`--no-safe-mode`)
+  `quality`, `disable_prompt_optimization_thinking`, `enhance_prompt`, `safe_mode`
+  (tri-state `--safe-mode`/`--no-safe-mode`)
 - `defaults.tts.*` — `model`, `format`, `voice`, `speed`, `play`
 - `defaults.sfx.*` — `model`, `duration`, `play`, `master`, `loop`,
   `no_cleanup`, `poll_interval`, `max_wait` (`loop` only takes effect when
@@ -1920,7 +1948,7 @@ positionals) stay CLI-only by design.
 These per-command defaults also apply when a generator runs as an **agent tool**
 inside `venice chat --tools` and `venice code` — e.g. `defaults.image.safe_mode`
 is honored when the model calls `venice_image`, not just on the `venice image`
-CLI. `defaults.image_edit.safe_mode`, `defaults.music.instrumental`,
+CLI. `defaults.image_edit.*`, `defaults.music.instrumental`,
 `defaults.video.no_audio` and `defaults.upscale.enhance` reach the tools the same
 way, as do the generation knobs `defaults.image.{model,format,variants}`,
 `defaults.tts.{model,format}`, `defaults.sfx.{model,duration}`,
@@ -1935,9 +1963,10 @@ CLI-only because the tool implementations fix their own polling cadence, and
 their sections apply only on the command line.
 
 **Any** config value whose flag has a fixed set of choices is validated against
-that set — `defaults.image.format`,
+that set — `defaults.image.{format,quality}`,
 `defaults.sfx.model`,
-`defaults.image_edit.{aspect_ratio,output_format}`, `defaults.chat.web_search`,
+`defaults.image_edit.{aspect_ratio,output_format,quality}`,
+`defaults.chat.web_search`,
 `defaults.bit_depth` and `defaults.contact_sheet.engine`.
 An unrecognized value is reported on stderr, naming the legal values exactly as
 `--flag` would, and skipped — so the command falls back to its built-in default

--- a/src/venice/commands/_agent.py
+++ b/src/venice/commands/_agent.py
@@ -49,6 +49,7 @@ from . import _models
 from . import _compact
 from . import _openai
 from . import _shared
+from . import image as _image
 from . import upscale as _upscale
 from . import video as _video
 from .models import MODEL_TYPES
@@ -1892,6 +1893,50 @@ _IMAGE_SCHEMA = _obj(
         "cfg_scale": _p("number"),
         "steps": _p("integer"),
         "style_preset": _p("string"),
+        "style_references": {
+            "type": "array",
+            "items": {
+                "type": "object",
+                "properties": {
+                    "image": _p(
+                        "string",
+                        "Authorized local path, HTTP(S) URL, data URL, or raw base64.",
+                    ),
+                    "strength": {
+                        "type": "number",
+                        "minimum": 0.1,
+                        "maximum": 1.0,
+                        "description": "Optional model-supported strength.",
+                    },
+                },
+                "required": ["image"],
+                "additionalProperties": False,
+            },
+            "description": (
+                "Style references, bounded by the selected live model catalog."
+            ),
+        },
+        "aspect_ratio": _p("string"),
+        "resolution": _p("string"),
+        "embed_exif_metadata": _p("boolean"),
+        "lora_strength": {
+            "type": "integer",
+            "minimum": 0,
+            "maximum": 100,
+            "description": "LoRA strength.",
+        },
+        "quality": {
+            "type": "string",
+            "enum": list(_image.QUALITY_CHOICES),
+            "description": "Model-supported quality.",
+        },
+        "enable_web_search": _p(
+            "boolean", "Allow supported models to use paid web search."
+        ),
+        "disable_prompt_optimization_thinking": _p("boolean"),
+        "enhance_prompt": _p(
+            "boolean", "Rewrite the prompt before generation; may add cost."
+        ),
         "safe_mode": _p("boolean", "Blur adult/NSFW content. Defaults to on; set false to disable."),
         "hide_watermark": _p("boolean", "Omit the Venice watermark. Defaults to off; set true to hide it."),
     },
@@ -2130,12 +2175,22 @@ _IMAGE_EDIT_SCHEMA = _obj(
         "layer_paths": {
             "type": "array",
             "items": {"type": "string"},
-            "description": "One or two local mask/overlay images (routes to /image/multi-edit).",
+            "description": (
+                "Local mask/overlay images (routes to /image/multi-edit); "
+                "the live model catalog supplies the count limit."
+            ),
         },
         "model": _p("string", "Edit model id (default: the server picks one)."),
         "aspect_ratio": _p("string", "Output aspect ratio ('auto' infers from the input)."),
         "resolution": _p("string", "Output resolution tier, e.g. 1K/2K/4K."),
         "output_format": _p("string", "Output image format: png, jpeg, or webp."),
+        "quality": {
+            "type": "string",
+            "enum": list(_image.QUALITY_CHOICES),
+            "description": "Multi-edit quality.",
+        },
+        "disable_prompt_optimization_thinking": _p("boolean"),
+        "enhance_prompt": _p("boolean", "Rewrite the edit prompt before generation."),
         "safe_mode": _p("boolean", "Blur adult/NSFW content. Defaults to on; set false to disable."),
     },
     required=["prompt"],
@@ -2710,7 +2765,8 @@ def builtin_tools(
                 "output_dir": output_dir,
             }
             if impl_name in {
-                "upscale_tool", "bg_remove_tool", "video_tool", "image_edit_tool"
+                "image_tool", "upscale_tool", "bg_remove_tool", "video_tool",
+                "image_edit_tool",
             }:
                 controlled["path_authority"] = media_path_authority
             return impl(client, **controlled, **{**defaults, **_clean(arguments)})

--- a/src/venice/commands/_mcp.py
+++ b/src/venice/commands/_mcp.py
@@ -200,13 +200,21 @@ def image_tool(
     cfg_scale: Optional[float] = None,
     steps: Optional[int] = None,
     style_preset: Optional[str] = None,
+    style_references: Optional[List[dict]] = None,
     aspect_ratio: Optional[str] = None,
     resolution: Optional[str] = None,
+    embed_exif_metadata: Optional[bool] = None,
+    lora_strength: Optional[int] = None,
+    quality: Optional[str] = None,
+    enable_web_search: Optional[bool] = None,
+    disable_prompt_optimization_thinking: Optional[bool] = None,
+    enhance_prompt: Optional[bool] = None,
     safe_mode: bool = True,
     hide_watermark: bool = False,
     output_dir: Optional[str] = None,
     confirm: bool = False,
     max_spend: Optional[float] = None,
+    path_authority=None,
 ) -> dict:
     """Generate 1-4 image variants via /image/generate; write files, return paths."""
     if not prompt or not prompt.strip():
@@ -220,10 +228,27 @@ def image_tool(
         return _err(
             f"image: unknown format {format!r}; choose from {', '.join(_image.FORMATS)}"
         )
+    try:
+        _image.validate_lora_strength(lora_strength)
+    except ValueError as e:
+        return _err(f"image: {e}")
 
     prompt = prompt.strip()
+    ns = SimpleNamespace(
+        model=model, prompt=prompt, format=format, safe_mode=safe_mode,
+        hide_watermark=hide_watermark, variants=variants, width=width, height=height,
+        aspect_ratio=aspect_ratio, resolution=resolution, negative_prompt=negative_prompt,
+        seed=seed, cfg_scale=cfg_scale, steps=steps, style_preset=style_preset,
+        style_references=style_references, embed_exif_metadata=embed_exif_metadata,
+        lora_strength=lora_strength, quality=quality,
+        enable_web_search=enable_web_search,
+        disable_prompt_optimization_thinking=disable_prompt_optimization_thinking,
+        enhance_prompt=enhance_prompt, style_prefix=None,
+    )
     try:
-        price = _image._fetch_image_price(client, model)
+        price = _image.prepare_request(
+            client, ns, path_authority=media_path_authority(path_authority)
+        )
         cost = _image._estimate_cost(price, variants)
     except ValueError as e:
         return _err(f"image: {e}")
@@ -231,13 +256,6 @@ def image_tool(
     if gate is not None:
         return gate
 
-    ns = SimpleNamespace(
-        model=model, prompt=prompt, format=format, safe_mode=safe_mode,
-        hide_watermark=hide_watermark, variants=variants, width=width, height=height,
-        aspect_ratio=aspect_ratio, resolution=resolution, negative_prompt=negative_prompt,
-        seed=seed, cfg_scale=cfg_scale, steps=steps, style_preset=style_preset,
-        style_prefix=None,
-    )
     body = _image._build_body(prompt, ns)
     try:
         doc = client.post_json("/image/generate", body)
@@ -1202,6 +1220,9 @@ def image_edit_tool(
     aspect_ratio: Optional[str] = None,
     resolution: Optional[str] = None,
     output_format: Optional[str] = None,
+    quality: Optional[str] = None,
+    disable_prompt_optimization_thinking: Optional[bool] = None,
+    enhance_prompt: Optional[bool] = None,
     safe_mode: Optional[bool] = None,
     output_dir: Optional[str] = None,
     confirm: bool = False,
@@ -1210,7 +1231,7 @@ def image_edit_tool(
 ) -> dict:
     """Edit/inpaint an image via /image/edit (dynamic price -> needs confirm).
 
-    Base image is a local `input_path` or an `image_url`; one or two
+    Base image is a local `input_path` or an `image_url`; repeatable
     `layer_paths` (masks/overlays) route to /image/multi-edit. Writes the
     result and returns its path.
     """
@@ -1220,10 +1241,8 @@ def image_edit_tool(
         return _err("image-edit: prompt is required")
     if len(prompt) > _image_edit.MAX_PROMPT:
         return _err(f"image-edit: prompt exceeds {_image_edit.MAX_PROMPT} chars")
-    if len(layer_paths or []) > _image_edit.MAX_LAYERS:
-        return _err(
-            f"image-edit: at most {_image_edit.MAX_LAYERS} layer paths are allowed"
-        )
+    if quality is not None and not layer_paths:
+        return _err("image-edit: quality is supported only with layer_paths")
     inp = None
     if input_path:
         resolved = _model_media_path(
@@ -1243,10 +1262,19 @@ def image_edit_tool(
             return resolved
         layer, _mime = resolved
         layers.append(layer)
+    if layers:
+        try:
+            model = _image_edit.resolve_multi_edit_model(
+                client, model, 1 + len(layers), quality
+            )
+        except ValueError as e:
+            return _err(f"image-edit: {e}")
     ns = SimpleNamespace(
         input=inp, image_url=image_url, prompt=prompt, layer=layers or None,
         model=model, aspect_ratio=aspect_ratio, resolution=resolution,
-        output_format=output_format, safe_mode=safe_mode,
+        output_format=output_format, quality=quality, safe_mode=safe_mode,
+        disable_prompt_optimization_thinking=disable_prompt_optimization_thinking,
+        enhance_prompt=enhance_prompt,
     )
     rc = _image_edit._validate(ns)  # stderr warnings only
     if rc is not None:
@@ -1257,7 +1285,11 @@ def image_edit_tool(
     endpoint, body = _image_edit._build_body(ns, base_image, layers_b64)
 
     ext = _image_edit.EXT_BY_FORMAT.get(output_format or "png", ".png")
-    name = f"{inp.stem}-edit{ext}" if inp is not None else f"{_image_edit.URL_DEFAULT_STEM}{ext}"
+    name = (
+        f"{inp.stem}-edit{ext}"
+        if inp is not None
+        else f"{_image_edit.URL_DEFAULT_STEM}{ext}"
+    )
     out_path = resolve_output_dir(output_dir) / name
     return _binary_op_tool(
         client, endpoint=endpoint, body=body, out_path=out_path,

--- a/src/venice/commands/image.py
+++ b/src/venice/commands/image.py
@@ -24,13 +24,16 @@ import base64
 import binascii
 import hashlib
 import json
+import os
 import re
+import stat
 import sys
 from pathlib import Path
 from typing import List, Optional, Tuple
 
 from .. import _numeric, auth, billing, config, userconfig
 from ..client import VeniceAPIError, build_client_from_auth
+from . import _models, _shared
 from ._shared import (
     add_balance_flag as _add_balance_flag,
     confirm_or_exit as _confirm_or_exit,
@@ -55,6 +58,8 @@ EXT_BY_FORMAT = {
 MIN_VARIANTS = 1
 MAX_VARIANTS = 4
 DEFAULT_VARIANTS = 1
+QUALITY_CHOICES = ("low", "medium", "high")
+STYLE_REFERENCE_MAX_BYTES = 8 * 1024 * 1024
 
 
 def register(subparsers) -> None:
@@ -150,6 +155,53 @@ def register(subparsers) -> None:
     p.add_argument("--style-preset", default=None,
                    help="Predefined style preset (model-dependent).")
     p.add_argument(
+        "--style-reference",
+        action="append",
+        dest="style_references",
+        default=None,
+        metavar="JSON",
+        help="Style reference as JSON with image=PATH|URL|data: and optional "
+        "strength=0.1-1. Repeatable; count is validated from the live model catalog.",
+    )
+    p.add_argument(
+        "--embed-exif-metadata",
+        action=argparse.BooleanOptionalAction,
+        default=None,
+        help="Embed generation metadata in the output image when supported.",
+    )
+    p.add_argument("--lora-strength", type=int, default=None, metavar="N",
+                   help="LoRA strength 0-100 for models using additional LoRAs.")
+    p.add_argument("--quality", choices=QUALITY_CHOICES, default=None,
+                   help="Model-supported output quality; may change the price.")
+    p.add_argument(
+        "--web-search",
+        action=argparse.BooleanOptionalAction,
+        dest="enable_web_search",
+        default=None,
+        help="Allow supported image models to use web search (additional cost).",
+    )
+    thinking = p.add_mutually_exclusive_group()
+    thinking.add_argument(
+        "--disable-prompt-optimization-thinking",
+        action="store_true",
+        dest="disable_prompt_optimization_thinking",
+        default=None,
+        help="Skip supported models' prompt-optimization thinking step.",
+    )
+    thinking.add_argument(
+        "--enable-prompt-optimization-thinking",
+        action="store_false",
+        dest="disable_prompt_optimization_thinking",
+        default=None,
+        help="Force supported models' prompt-optimization thinking step on.",
+    )
+    p.add_argument(
+        "--enhance-prompt",
+        action=argparse.BooleanOptionalAction,
+        default=None,
+        help="Rewrite the prompt before generation (additional cost when applied).",
+    )
+    p.add_argument(
         "--variants",
         type=int,
         default=None,
@@ -230,6 +282,15 @@ def _build_body(prompt: str, args) -> dict:
         "cfg_scale": args.cfg_scale,
         "steps": args.steps,
         "style_preset": args.style_preset,
+        "style_references": getattr(args, "style_references", None),
+        "embed_exif_metadata": getattr(args, "embed_exif_metadata", None),
+        "lora_strength": getattr(args, "lora_strength", None),
+        "quality": getattr(args, "quality", None),
+        "enable_web_search": getattr(args, "enable_web_search", None),
+        "disable_prompt_optimization_thinking": getattr(
+            args, "disable_prompt_optimization_thinking", None
+        ),
+        "enhance_prompt": getattr(args, "enhance_prompt", None),
     }
     for k, v in optional.items():
         if v is not None:
@@ -272,7 +333,12 @@ def _sidecar_params(doc: dict, body: dict) -> dict:
         data = req.get("data")
         if isinstance(data, dict) and data:
             resolved = data
-    params = dict(resolved if resolved is not None else body)
+    # Keep every provider-shaped request field even when the response echoes only
+    # a subset, then let resolved values (especially the server-selected seed)
+    # override what was sent.
+    params = dict(body)
+    if resolved is not None:
+        params.update(resolved)
     params.pop("variants", None)
     params.setdefault("model", body.get("model"))
     params.setdefault("prompt", body.get("prompt"))
@@ -280,48 +346,293 @@ def _sidecar_params(doc: dict, body: dict) -> dict:
     return params
 
 
+# ---- native controls, catalog validation, and pricing -----------------------
+
+def validate_lora_strength(value) -> None:
+    if value is None:
+        return
+    if (
+        isinstance(value, bool)
+        or not isinstance(value, int)
+        or not 0 <= value <= 100
+    ):
+        raise ValueError("lora_strength must be an integer between 0 and 100")
+
+
+def _decode_data_image(value: str) -> None:
+    """Validate a style-reference data URL without rewriting it."""
+    if "," not in value:
+        raise ValueError("style reference data URL is missing its payload")
+    header, payload = value.split(",", 1)
+    if not header.lower().startswith("data:image/") or ";base64" not in header.lower():
+        raise ValueError("style reference data URL must be a base64 image")
+    max_encoded = 4 * ((STYLE_REFERENCE_MAX_BYTES + 2) // 3)
+    if len(payload) > max_encoded:
+        raise ValueError(
+            "style reference data URL exceeds the encoded 8 MiB image limit"
+        )
+    try:
+        data = base64.b64decode(payload, validate=True)
+    except (binascii.Error, ValueError):
+        raise ValueError("style reference data URL has invalid base64") from None
+    if not data:
+        raise ValueError("style reference data URL is empty")
+    if _shared._sniff_media_mime(data[:64], "image") is None:
+        raise ValueError("style reference data URL is not a recognized image container")
+    if len(data) >= STYLE_REFERENCE_MAX_BYTES:
+        raise ValueError(
+            f"style reference data is {len(data)} bytes; limit is less than "
+            f"{STYLE_REFERENCE_MAX_BYTES} bytes"
+        )
+
+
+def _is_raw_base64_image(value: str) -> bool:
+    """Recognize a bounded raw-base64 image without mistaking paths for data."""
+    max_encoded = 4 * ((STYLE_REFERENCE_MAX_BYTES + 2) // 3)
+    if len(value) > max_encoded:
+        return False
+    try:
+        data = base64.b64decode(value, validate=True)
+    except (binascii.Error, ValueError):
+        return False
+    return bool(data) and len(data) < STYLE_REFERENCE_MAX_BYTES and (
+        _shared._sniff_media_mime(data[:64], "image") is not None
+    )
+
+
+def _resolve_style_image(value, *, path_authority=None) -> str:
+    if not isinstance(value, str) or not value.strip():
+        raise ValueError("style reference image must be a non-empty string")
+    value = value.strip()
+    if value.startswith(("http://", "https://")):
+        return value
+    if value.startswith("data:"):
+        _decode_data_image(value)
+        return value
+    if len(value) > 4 * ((STYLE_REFERENCE_MAX_BYTES + 2) // 3):
+        raise ValueError("style reference exceeds the encoded 8 MiB image limit")
+    if _is_raw_base64_image(value):
+        return value
+
+    if path_authority is not None:
+        try:
+            path, mime = path_authority.resolve(
+                value, kind="image", max_bytes=STYLE_REFERENCE_MAX_BYTES - 1
+            )
+        except _shared.MediaPathError as e:
+            raise ValueError(str(e)) from None
+    else:
+        path = Path(value).expanduser()
+        try:
+            info = path.stat()
+        except OSError:
+            raise ValueError(f"style reference file does not exist: {value}") from None
+        if not stat.S_ISREG(info.st_mode):
+            raise ValueError("style reference path must name a regular file")
+        if info.st_size == 0:
+            raise ValueError("style reference file is empty")
+        if info.st_size >= STYLE_REFERENCE_MAX_BYTES:
+            raise ValueError(
+                f"style reference file is {info.st_size} bytes; limit is less than "
+                f"{STYLE_REFERENCE_MAX_BYTES} bytes"
+            )
+        try:
+            with path.open("rb") as fh:
+                prefix = fh.read(64)
+        except OSError:
+            raise ValueError("style reference file could not be read") from None
+        mime = _shared._sniff_media_mime(prefix, "image")
+        if mime is None:
+            raise ValueError("style reference is not a recognized image container")
+    return _shared.encode_data_url(path, detected_mime=mime)
+
+
+def resolve_style_references(raw_values, *, path_authority=None) -> Optional[List[dict]]:
+    """Parse CLI/config/tool style references and normalize their image values."""
+    if raw_values is None:
+        return None
+    if not isinstance(raw_values, list):
+        raise ValueError("style_references must be a list")
+    out: List[dict] = []
+    for raw in raw_values:
+        if isinstance(raw, str):
+            try:
+                item = json.loads(raw)
+            except ValueError as e:
+                raise ValueError(f"--style-reference is not valid JSON: {e}") from None
+        else:
+            item = raw
+        if not isinstance(item, dict):
+            raise ValueError("each style reference must be a JSON object")
+        unknown = set(item) - {"image", "strength"}
+        if unknown:
+            raise ValueError(
+                "style reference has unknown field(s): " + ", ".join(sorted(unknown))
+            )
+        resolved = {"image": _resolve_style_image(
+            item.get("image"), path_authority=path_authority
+        )}
+        if item.get("strength") is not None:
+            try:
+                strength = _numeric.finite_float(item["strength"])
+            except ValueError as e:
+                raise ValueError(f"invalid style reference strength: {e}") from None
+            if not 0.1 <= strength <= 1.0:
+                raise ValueError("style reference strength must be between 0.1 and 1")
+            resolved["strength"] = strength
+        out.append(resolved)
+    return out
+
+
+def _model_entry(models, model: str) -> Optional[dict]:
+    if not isinstance(models, list):
+        return None
+    return next(
+        (m for m in models if isinstance(m, dict) and m.get("id") == model), None
+    )
+
+
+def _validated_usd(node) -> Optional[float]:
+    if not isinstance(node, dict) or "usd" not in node:
+        return None
+    try:
+        return _numeric.non_negative_float(node["usd"])
+    except ValueError:
+        raise ValueError("model catalog contains an invalid image price") from None
+
+
+def _price_from_entry(entry, *, resolution=None, quality=None) -> Optional[float]:
+    spec = entry.get("model_spec") if isinstance(entry, dict) else None
+    pricing = spec.get("pricing") if isinstance(spec, dict) else None
+    constraints = spec.get("constraints") if isinstance(spec, dict) else None
+    if not isinstance(pricing, dict):
+        return None
+    constraints = constraints if isinstance(constraints, dict) else {}
+
+    quality_matrix = pricing.get("quality")
+    if quality is not None or isinstance(quality_matrix, dict):
+        selected_quality = quality or constraints.get("defaultQuality")
+        selected_resolution = resolution or constraints.get("defaultResolution")
+        if selected_quality and selected_resolution and isinstance(quality_matrix, dict):
+            by_resolution = quality_matrix.get(selected_resolution)
+            if isinstance(by_resolution, dict):
+                return _validated_usd(by_resolution.get(selected_quality))
+        if quality is not None:
+            return None
+
+    resolution_prices = pricing.get("resolutions")
+    selected_resolution = resolution or constraints.get("defaultResolution")
+    if selected_resolution and isinstance(resolution_prices, dict):
+        return _validated_usd(resolution_prices.get(selected_resolution))
+
+    for key in ("generation", "image", "output"):
+        price = _validated_usd(pricing.get(key))
+        if price is not None:
+            return price
+    return _validated_usd(pricing)
+
+
+def _validate_model_controls(entry, args) -> None:
+    spec = entry.get("model_spec") if isinstance(entry, dict) else None
+    constraints = spec.get("constraints") if isinstance(spec, dict) else None
+    constraints = constraints if isinstance(constraints, dict) else {}
+    refs = getattr(args, "style_references", None) or []
+    if refs:
+        if not isinstance(spec, dict) or spec.get("supportsStyleReferences") is not True:
+            raise ValueError(f"model {args.model!r} does not support style references")
+        cap = constraints.get("maxStyleReferences")
+        if (
+            isinstance(cap, bool)
+            or not isinstance(cap, (int, float))
+            or int(cap) != cap
+            or cap < 1
+        ):
+            raise ValueError(
+                f"live image catalog entry for {args.model!r} has no valid "
+                "maxStyleReferences"
+            )
+        if len(refs) > int(cap):
+            raise ValueError(
+                f"model {args.model!r} accepts at most {int(cap)} style references"
+            )
+        if any("strength" in ref for ref in refs):
+            if constraints.get("supportsStyleReferenceStrength") is not True:
+                raise ValueError(
+                    f"model {args.model!r} does not support style reference strength"
+                )
+
+    quality = getattr(args, "quality", None)
+    if quality is not None:
+        choices = constraints.get("qualities")
+        if not isinstance(choices, list) or any(not isinstance(v, str) for v in choices):
+            raise ValueError(
+                f"live image catalog entry for {args.model!r} has no valid qualities"
+            )
+        if quality not in choices:
+            raise ValueError(
+                f"quality {quality!r} is not supported by {args.model!r}; "
+                "choose from " + ", ".join(choices)
+            )
+
+
+def prepare_request(client, args, *, path_authority=None) -> Optional[float]:
+    """Normalize native inputs, validate the live model contract, and return price."""
+    args.style_references = resolve_style_references(
+        getattr(args, "style_references", None), path_authority=path_authority
+    )
+    models = _models.catalog(client, "image")
+    entry = _model_entry(models, args.model)
+    quality = getattr(args, "quality", None)
+    if (args.style_references or quality is not None) and entry is None:
+        if models is None:
+            raise ValueError("could not fetch the live image catalog")
+        raise ValueError(f"model {args.model!r} is not in the live image catalog")
+    if entry is not None:
+        _validate_model_controls(entry, args)
+    price = _price_from_entry(
+        entry, resolution=getattr(args, "resolution", None), quality=quality
+    )
+    # These switches explicitly carry additional, unlisted charges. Never let the
+    # base image price masquerade as a complete max-spend estimate.
+    if (
+        getattr(args, "enable_web_search", None) is True
+        or getattr(args, "enhance_prompt", None) is True
+    ):
+        return None
+    return price
+
+
+def _price_description(args, prefix: str) -> str:
+    parts = [prefix, f"model={args.model}"]
+    if getattr(args, "resolution", None):
+        parts.append(f"resolution={args.resolution}")
+    if getattr(args, "quality", None):
+        parts.append(f"quality={args.quality}")
+    if getattr(args, "style_references", None):
+        parts.append(f"style_refs={len(args.style_references)}")
+    if getattr(args, "enable_web_search", None):
+        parts.append("web_search=on")
+    if getattr(args, "enhance_prompt", None):
+        parts.append("enhance_prompt=on")
+    return ", ".join(parts)
+
+
 # ---- pricing + cost estimation ----------------------------------------------
 
 def _fetch_image_price(client, model: str) -> Optional[float]:
-    """Per-image USD price for the model from /models?type=image. Best-effort.
-
-    Schema-tolerant: returns the first USD value found in model_spec.pricing
-    (values may be nested one level, as with tts's {"input": {"usd": ...}}).
-    """
-    try:
-        doc = client.get_json("/models", params={"type": "image"})
-    except VeniceAPIError:
-        return None
-    data = doc.get("data") if isinstance(doc, dict) else None
-    if not isinstance(data, list):
-        return None
-    for m in data:
-        if isinstance(m, dict) and m.get("id") == model:
-            spec = m.get("model_spec")
-            pricing = spec.get("pricing") if isinstance(spec, dict) else None
-            return _usd_from_pricing(pricing)
-    return None
+    """Compatibility wrapper for callers/tests that need only the base price."""
+    return _price_from_entry(_model_entry(_models.catalog(client, "image"), model))
 
 
 def _usd_from_pricing(pricing) -> Optional[float]:
+    """Compatibility parser for a base-price block, without matrix guessing."""
     if not isinstance(pricing, dict):
         return None
-    for v in pricing.values():
-        if isinstance(v, (int, float)):
-            # e.g. {"usd": 0.01} handled below; a bare number is unlabeled.
-            continue
-        if isinstance(v, dict) and "usd" in v:
-            try:
-                return _numeric.non_negative_float(v["usd"])
-            except ValueError:
-                raise ValueError("model catalog contains an invalid image price") from None
-    # Fall back to a top-level "usd" key.
-    if "usd" in pricing:
-        try:
-            return _numeric.non_negative_float(pricing["usd"])
-        except ValueError:
-            raise ValueError("model catalog contains an invalid image price") from None
-    return None
+    for key in ("generation", "image", "output"):
+        price = _validated_usd(pricing.get(key))
+        if price is not None:
+            return price
+    return _validated_usd(pricing)
 
 
 def _estimate_cost(
@@ -416,9 +727,12 @@ def _write_sidecar(json_path: Path, params: dict) -> None:
     """Best-effort: write a params sidecar. Warns but never fails the run --
     the image is already on disk; the sidecar is reproducibility metadata."""
     try:
-        with json_path.open("w", encoding="utf-8") as fh:
+        fd = os.open(json_path, os.O_WRONLY | os.O_CREAT | os.O_TRUNC, 0o600)
+        with os.fdopen(fd, "w", encoding="utf-8") as fh:
+            os.fchmod(fh.fileno(), 0o600)
             json.dump(params, fh, indent=2, sort_keys=True, allow_nan=False)
             fh.write("\n")
+        os.chmod(json_path, 0o600)
     except OSError as e:
         print(f"warning: could not write sidecar {json_path}: {e}", file=sys.stderr)
         return
@@ -457,7 +771,9 @@ def _generate_one(client, prompt: str, args, paths: List[Path]) -> int:
 _REPLAY_FIELDS = (
     "model", "prompt", "format", "width", "height", "aspect_ratio",
     "resolution", "negative_prompt", "seed", "cfg_scale", "steps",
-    "style_preset", "variants", "safe_mode", "hide_watermark",
+    "style_preset", "style_references", "variants", "safe_mode",
+    "hide_watermark", "embed_exif_metadata", "lora_strength", "quality",
+    "enable_web_search", "disable_prompt_optimization_thinking", "enhance_prompt",
 )
 
 
@@ -503,7 +819,7 @@ def _apply_replay(args):
 
     merged = argparse.Namespace(**vars(args))
     for f in _REPLAY_FIELDS:
-        cur = getattr(args, f)
+        cur = getattr(args, f, None)
         if f == "prompt":
             explicit = bool(cur and cur.strip())
         else:
@@ -597,6 +913,15 @@ def _run(args) -> int:
         )
         return 2
 
+    try:
+        validate_lora_strength(getattr(args, "lora_strength", None))
+    except ValueError:
+        print(
+            "image: --lora-strength must be an integer between 0 and 100",
+            file=sys.stderr,
+        )
+        return 2
+
     if args.from_file is None and not (args.prompt and args.prompt.strip()):
         print(
             "image: prompt required (positional prompt or --from-file PATH)",
@@ -618,13 +943,13 @@ def _run(args) -> int:
 def _run_single(client, args) -> int:
     prompt = args.prompt.strip()
     try:
-        price = _fetch_image_price(client, args.model)
+        price = prepare_request(client, args)
     except ValueError as e:
         print(f"image: {e}", file=sys.stderr)
         return 2
     cost = _estimate_cost(price, args.variants)
     desc = f"{args.variants} image" + ("s" if args.variants != 1 else "")
-    _print_estimate(cost, f"{desc}, model={args.model}")
+    _print_estimate(cost, _price_description(args, desc))
     _print_balance_and_remaining(client, cost, show=not args.no_balance)
 
     if _over_budget(cost, args.max_spend):
@@ -656,13 +981,13 @@ def _run_batch(client, args) -> int:
 
     n = len(items)
     try:
-        price = _fetch_image_price(client, args.model)
+        price = prepare_request(client, args)
     except ValueError as e:
         print(f"image: {e}", file=sys.stderr)
         return 2
     cost = _estimate_cost(price, args.variants, n)
     desc = f"{n} prompt" + ("s" if n != 1 else "") + f" x {args.variants}"
-    _print_estimate(cost, f"{desc}, model={args.model}")
+    _print_estimate(cost, _price_description(args, desc))
     _print_balance_and_remaining(client, cost, show=not args.no_balance)
 
     if _over_budget(cost, args.max_spend):

--- a/src/venice/commands/image_edit.py
+++ b/src/venice/commands/image_edit.py
@@ -2,12 +2,13 @@
 
 Iterate on already-generated art without regenerating: tweak a color, change
 the sky, or composite a mask onto a base image. With no `--layer`, the base
-image + prompt go to `/image/edit`. With one or two `--layer` images, the base
-plus those layers/masks go to `/image/multi-edit` (max 3 images total, base
-first). The base image is a local file (sent as a base64 string in a JSON body)
-or an image URL; layers are local files. The endpoint returns raw image bytes
-(png/jpeg/webp), so we use the client's bytes-or-json path. Pricing is dynamic
-($0.001-$10.00/call); the balance is shown and you confirm before the charge.
+image + prompt go to `/image/edit`. One or more `--layer` images route the base
+plus those layers/masks to `/image/multi-edit`; the live model catalog supplies
+the input-image limit. The base image is a local file (sent as a base64 string
+in a JSON body) or an image URL; layers are local files. The endpoint returns
+raw image bytes (png/jpeg/webp), so we use the client's bytes-or-json path.
+Pricing is dynamic ($0.001-$10.00/call); the balance is shown and you confirm
+before the charge.
 """
 from __future__ import annotations
 
@@ -18,6 +19,8 @@ from typing import List, Optional
 
 from .. import _numeric, auth, userconfig
 from ..client import build_client_from_auth
+from . import _models
+from .image import QUALITY_CHOICES
 from ._shared import (
     add_balance_flag,
     check_image_file,
@@ -32,7 +35,8 @@ from ._shared import (
 
 EDIT_ENDPOINT = "/image/edit"
 MULTI_EDIT_ENDPOINT = "/image/multi-edit"
-MAX_LAYERS = 2  # /image/multi-edit takes up to 3 images (base + 2 layers)
+DEFAULT_EDIT_MODEL = "firered-image-edit"
+CONTRACT_DEFAULT_MAX_INPUT_IMAGES = 3
 MAX_PROMPT = 32768
 URL_DEFAULT_STEM = "venice-edit"
 
@@ -56,8 +60,9 @@ def register(subparsers) -> None:
         description=(
             "Edit an already-generated image from a text prompt without "
             "regenerating it, e.g. `venice image-edit card.png -p 'change the "
-            "sky to a sunrise'`. Pass one or two `--layer` images (masks/"
-            "overlays) to composite via /image/multi-edit. The base is a local "
+            "sky to a sunrise'`. Pass repeatable `--layer` images (masks/"
+            "overlays) to composite via /image/multi-edit; the selected model's "
+            "live maxInputImages limit is enforced. The base is a local "
             "file (positional) or --image-url. Pricing is dynamic; the balance "
             "is shown and you confirm before the charge."
         ),
@@ -72,7 +77,8 @@ def register(subparsers) -> None:
     p.add_argument("--layer", type=Path, action="append", default=None,
                    metavar="PATH",
                    help="Extra image (mask/overlay) layered onto the base; "
-                   "routes to /image/multi-edit. Repeatable, up to 2.")
+                   "routes to /image/multi-edit. Repeatable; the limit is "
+                   "model-specific.")
     p.add_argument("--model", default=None, metavar="ID",
                    help="Edit model id (default: server picks firered-image-edit).")
     p.add_argument("--aspect-ratio", default=None, choices=ASPECT_RATIOS,
@@ -82,6 +88,33 @@ def register(subparsers) -> None:
     p.add_argument("--output-format", default=None,
                    choices=OUTPUT_FORMATS,
                    help="Output image format (default inferred; PNG for 1K).")
+    p.add_argument(
+        "--quality",
+        choices=QUALITY_CHOICES,
+        default=None,
+        help="Output quality for supported multi-edit models; requires --layer.",
+    )
+    thinking = p.add_mutually_exclusive_group()
+    thinking.add_argument(
+        "--disable-prompt-optimization-thinking",
+        action="store_true",
+        dest="disable_prompt_optimization_thinking",
+        default=None,
+        help="Skip supported models' prompt-optimization thinking step.",
+    )
+    thinking.add_argument(
+        "--enable-prompt-optimization-thinking",
+        action="store_false",
+        dest="disable_prompt_optimization_thinking",
+        default=None,
+        help="Force supported models' prompt-optimization thinking step on.",
+    )
+    p.add_argument(
+        "--enhance-prompt",
+        action=argparse.BooleanOptionalAction,
+        default=None,
+        help="Rewrite the edit prompt before generation (additional cost when applied).",
+    )
     p.add_argument(
         "--safe-mode",
         action=argparse.BooleanOptionalAction,
@@ -124,9 +157,8 @@ def _validate(args) -> Optional[int]:
         if rc is not None:
             return rc
     layers = args.layer or []
-    if len(layers) > MAX_LAYERS:
-        print(f"image-edit: at most {MAX_LAYERS} --layer images "
-              "(base + 2 = 3 total)", file=sys.stderr)
+    if getattr(args, "quality", None) is not None and not layers:
+        print("image-edit: --quality is supported only with --layer", file=sys.stderr)
         return 2
     for layer in layers:
         rc = check_image_file(layer, label="image-edit")
@@ -148,6 +180,12 @@ def _add_common(body: dict, args) -> None:
     # carries safe_mode=true rather than omitting the key, which the API
     # schema declares as the default anyway. (#57 Class B)
     body["safe_mode"] = args.safe_mode if args.safe_mode is not None else True
+    if getattr(args, "disable_prompt_optimization_thinking", None) is not None:
+        body["disable_prompt_optimization_thinking"] = (
+            args.disable_prompt_optimization_thinking
+        )
+    if getattr(args, "enhance_prompt", None) is not None:
+        body["enhance_prompt"] = args.enhance_prompt
 
 
 def _build_body(args, base_image: str, layers_b64: List[str]) -> tuple:
@@ -157,6 +195,8 @@ def _build_body(args, base_image: str, layers_b64: List[str]) -> tuple:
         body: dict = {"images": [base_image, *layers_b64], "prompt": args.prompt}
         if args.model is not None:
             body["modelId"] = args.model  # multi-edit uses modelId, not model
+        if getattr(args, "quality", None) is not None:
+            body["quality"] = args.quality
         _add_common(body, args)
         return MULTI_EDIT_ENDPOINT, body
     body = {"image": base_image, "prompt": args.prompt}
@@ -164,6 +204,61 @@ def _build_body(args, base_image: str, layers_b64: List[str]) -> tuple:
         body["model"] = args.model
     _add_common(body, args)
     return EDIT_ENDPOINT, body
+
+
+def resolve_multi_edit_model(
+    client, requested: Optional[str], image_count: int, quality: Optional[str] = None
+) -> str:
+    """Resolve and validate an inpaint model before a paid multi-edit request."""
+    models = _models.catalog(client, "inpaint")
+    if models is None:
+        raise ValueError("could not fetch the live inpaint model catalog")
+    model = requested or _models.default_model(models)
+    ids = [m.get("id") for m in models if isinstance(m, dict) and m.get("id")]
+    if model is None and DEFAULT_EDIT_MODEL in ids:
+        model = DEFAULT_EDIT_MODEL
+    if model is None:
+        raise ValueError(
+            "no default inpaint model is advertised; pass --model. available: "
+            + ", ".join(ids)
+        )
+    entry = next(
+        (m for m in models if isinstance(m, dict) and m.get("id") == model), None
+    )
+    if entry is None:
+        raise ValueError(
+            f"unknown inpaint model {model!r}; available: " + ", ".join(ids)
+        )
+    spec = entry.get("model_spec")
+    constraints = spec.get("constraints") if isinstance(spec, dict) else None
+    if not isinstance(constraints, dict):
+        raise ValueError(f"live inpaint catalog entry for {model!r} has no constraints")
+    combine = constraints.get("combineImages")
+    if combine is not True:
+        raise ValueError(f"model {model!r} does not support multi-image editing")
+    cap = constraints.get(
+        "maxInputImages", CONTRACT_DEFAULT_MAX_INPUT_IMAGES
+    )
+    if isinstance(cap, bool) or not isinstance(cap, int) or cap < 1:
+        raise ValueError(
+            f"live inpaint catalog entry for {model!r} has invalid maxInputImages"
+        )
+    if image_count > cap:
+        raise ValueError(f"model {model!r} accepts at most {cap} input images")
+    if quality is not None:
+        qualities = constraints.get("qualities")
+        if not isinstance(qualities, list) or any(
+            not isinstance(value, str) for value in qualities
+        ):
+            raise ValueError(
+                f"live inpaint catalog entry for {model!r} has no valid qualities"
+            )
+        if quality not in qualities:
+            raise ValueError(
+                f"quality {quality!r} is not supported by {model!r}; choose from "
+                + ", ".join(qualities)
+            )
+    return model
 
 
 def _run(args) -> int:
@@ -177,6 +272,15 @@ def _run(args) -> int:
     except auth.AuthError as e:
         print(str(e), file=sys.stderr)
         return 2
+
+    if args.layer:
+        try:
+            args.model = resolve_multi_edit_model(
+                client, args.model, 1 + len(args.layer), getattr(args, "quality", None)
+            )
+        except ValueError as e:
+            print(f"image-edit: {e}", file=sys.stderr)
+            return 2
 
     cost = None  # dynamic pricing -- no reliable upfront quote
     print_estimate(cost, "image edit; dynamic $0.001-$10.00/call")

--- a/src/venice/mcp_server.py
+++ b/src/venice/mcp_server.py
@@ -69,6 +69,15 @@ def build_server(client, doc=None, root=None) -> FastMCP:
         cfg_scale: Optional[float] = None,
         steps: Optional[int] = None,
         style_preset: Optional[str] = None,
+        style_references: Optional[List[dict]] = None,
+        aspect_ratio: Optional[str] = None,
+        resolution: Optional[str] = None,
+        embed_exif_metadata: Optional[bool] = None,
+        lora_strength: Optional[int] = None,
+        quality: Optional[str] = None,
+        enable_web_search: Optional[bool] = None,
+        disable_prompt_optimization_thinking: Optional[bool] = None,
+        enhance_prompt: Optional[bool] = None,
         safe_mode: Optional[bool] = None,
         hide_watermark: Optional[bool] = None,
         output_dir: Optional[str] = None,
@@ -89,9 +98,18 @@ def build_server(client, doc=None, root=None) -> FastMCP:
                 model=model, variants=variants, format=format,
                 width=width, height=height, negative_prompt=negative_prompt,
                 seed=seed, cfg_scale=cfg_scale, steps=steps,
-                style_preset=style_preset, safe_mode=safe_mode,
+                style_preset=style_preset, style_references=style_references,
+                aspect_ratio=aspect_ratio, resolution=resolution,
+                embed_exif_metadata=embed_exif_metadata,
+                lora_strength=lora_strength, quality=quality,
+                enable_web_search=enable_web_search,
+                disable_prompt_optimization_thinking=(
+                    disable_prompt_optimization_thinking
+                ),
+                enhance_prompt=enhance_prompt, safe_mode=safe_mode,
                 hide_watermark=hide_watermark, output_dir=output_dir,
                 confirm=confirm, max_spend=max_spend,
+                path_authority=path_authority,
             )),
         )
 
@@ -301,14 +319,18 @@ def build_server(client, doc=None, root=None) -> FastMCP:
         aspect_ratio: Optional[str] = None,
         resolution: Optional[str] = None,
         output_format: Optional[str] = None,
+        quality: Optional[str] = None,
+        disable_prompt_optimization_thinking: Optional[bool] = None,
+        enhance_prompt: Optional[bool] = None,
         safe_mode: Optional[bool] = None,
         output_dir: Optional[str] = None,
         confirm: bool = False,
         max_spend: Optional[float] = None,
     ) -> dict:
         """Edit/inpaint an image via Venice /image/edit and return the file path. Base
-        image is a local input_path OR an image_url; one or two layer_paths (masks/
-        overlays) route to /image/multi-edit. Pricing is dynamic (no up-front estimate),
+        image is a local input_path OR an image_url; repeatable layer_paths (masks/
+        overlays) route to /image/multi-edit and use the model's live input limit.
+        Pricing is dynamic (no up-front estimate),
         so this ALWAYS requires confirm=true."""
         return _mcp.image_edit_tool(
             client, prompt,
@@ -316,7 +338,12 @@ def build_server(client, doc=None, root=None) -> FastMCP:
                 input_path=input_path, image_url=image_url,
                 layer_paths=layer_paths, model=model, aspect_ratio=aspect_ratio,
                 resolution=resolution, output_format=output_format,
-                safe_mode=safe_mode, output_dir=output_dir, confirm=confirm,
+                quality=quality,
+                disable_prompt_optimization_thinking=(
+                    disable_prompt_optimization_thinking
+                ),
+                enhance_prompt=enhance_prompt, safe_mode=safe_mode,
+                output_dir=output_dir, confirm=confirm,
                 max_spend=max_spend, path_authority=path_authority,
             )),
         )

--- a/src/venice/userconfig.py
+++ b/src/venice/userconfig.py
@@ -261,6 +261,14 @@ def _as_list(v):
     return [str(v)]
 
 
+def _as_object_list(v):
+    """Preserve a JSON object array for structured repeatable API inputs."""
+    values = v if isinstance(v, list) else [v]
+    if any(not isinstance(item, dict) for item in values):
+        raise ValueError("expected a JSON object or array of objects")
+    return [dict(item) for item in values]
+
+
 def _exact_int(v):
     """int(), but refusing a value that would lose information.
 
@@ -506,6 +514,17 @@ _COMMAND_MAP = {
         "cfg_scale": ("cfg_scale", _numeric.finite_float),
         "steps": ("steps", int),
         "style_preset": ("style_preset", str),
+        "style_references": ("style_references", _as_object_list),
+        "embed_exif_metadata": ("embed_exif_metadata", _as_bool),
+        "lora_strength": ("lora_strength", _exact_int),
+        "quality": (
+            "quality", _one_of("venice.commands.image", "QUALITY_CHOICES")
+        ),
+        "enable_web_search": ("enable_web_search", _as_bool),
+        "disable_prompt_optimization_thinking": (
+            "disable_prompt_optimization_thinking", _as_bool
+        ),
+        "enhance_prompt": ("enhance_prompt", _as_bool),
         # #57 Class C: the valued generation knobs. Their argparse defaults moved
         # to None and the literals now live in `image._run`'s `apply_literals`
         # call, which runs AFTER the --from-json replay merge.
@@ -519,9 +538,20 @@ _COMMAND_MAP = {
         # the two image commands read alike here and on the tool surfaces).
         "safe_mode": ("safe_mode", _as_bool),
         "model": ("model", str),
-        "aspect_ratio": ("aspect_ratio", _one_of("venice.commands.image_edit", "ASPECT_RATIOS")),
+        "aspect_ratio": (
+            "aspect_ratio", _one_of("venice.commands.image_edit", "ASPECT_RATIOS")
+        ),
         "resolution": ("resolution", str),  # free-form tier, no argparse choices
-        "output_format": ("output_format", _one_of("venice.commands.image_edit", "OUTPUT_FORMATS")),
+        "output_format": (
+            "output_format", _one_of("venice.commands.image_edit", "OUTPUT_FORMATS")
+        ),
+        "quality": (
+            "quality", _one_of("venice.commands.image", "QUALITY_CHOICES")
+        ),
+        "disable_prompt_optimization_thinking": (
+            "disable_prompt_optimization_thinking", _as_bool
+        ),
+        "enhance_prompt": ("enhance_prompt", _as_bool),
     },
     "tts": {
         # Model and format are validated against the live TTS catalog before spend.

--- a/tests/test_agent.py
+++ b/tests/test_agent.py
@@ -2701,6 +2701,30 @@ class TestAsyncJobSchemas(unittest.TestCase):
         for name in ("video_url", "audio_url", "reference_video_duration"):
             self.assertIn(name, props)
 
+    def test_image_schemas_expose_native_controls(self):
+        image_props = _agent._IMAGE_SCHEMA["properties"]
+        for name in (
+            "style_references", "embed_exif_metadata", "lora_strength", "quality",
+            "enable_web_search", "disable_prompt_optimization_thinking",
+            "enhance_prompt", "aspect_ratio", "resolution",
+        ):
+            self.assertIn(name, image_props)
+        refs = image_props["style_references"]
+        self.assertEqual(refs["type"], "array")
+        self.assertEqual(
+            set(refs["items"]["properties"]), {"image", "strength"}
+        )
+        self.assertEqual(refs["items"]["properties"]["strength"]["minimum"], 0.1)
+        self.assertEqual(refs["items"]["properties"]["strength"]["maximum"], 1.0)
+        self.assertEqual(image_props["lora_strength"]["minimum"], 0)
+        self.assertEqual(image_props["lora_strength"]["maximum"], 100)
+        self.assertEqual(image_props["quality"]["enum"], ["low", "medium", "high"])
+        edit_props = _agent._IMAGE_EDIT_SCHEMA["properties"]
+        for name in (
+            "quality", "disable_prompt_optimization_thinking", "enhance_prompt"
+        ):
+            self.assertIn(name, edit_props)
+
     def test_job_schemas_require_handle_fields_and_hide_controls(self):
         for schema in (_agent._JOB_STATUS_SCHEMA, _agent._JOB_RESULT_SCHEMA):
             self.assertEqual(schema.get("required"), ["queue_id", "type", "model"])
@@ -2732,9 +2756,11 @@ class TestMediaPathAuthorityWiring(unittest.TestCase):
             _agent._mcp, "vision_tool", return_value={"status": "ok"}
         ) as vision, mock.patch.object(
             _agent._mcp, "upscale_tool", return_value={"status": "ok"}
-        ) as upscale:
+        ) as upscale, mock.patch.object(
+            _agent._mcp, "image_tool", return_value={"status": "ok"}
+        ) as image:
             tools = {tool.name: tool for tool in _agent.builtin_tools(
-                object(), only={"venice_vision", "venice_upscale"},
+                object(), only={"venice_vision", "venice_upscale", "venice_image"},
                 media_path_authority=authority,
             )}
             tools["venice_vision"].invoke({
@@ -2744,8 +2770,13 @@ class TestMediaPathAuthorityWiring(unittest.TestCase):
                 {"input_path": "frame.png", "path_authority": "model-controlled"},
                 confirm=True,
             )
+            tools["venice_image"].invoke(
+                {"prompt": "p", "path_authority": "model-controlled"},
+                confirm=True,
+            )
         self.assertIs(vision.call_args.kwargs["path_authority"], authority)
         self.assertIs(upscale.call_args.kwargs["path_authority"], authority)
+        self.assertIs(image.call_args.kwargs["path_authority"], authority)
 
     def test_upscale_schema_matches_current_contract(self):
         tool = next(t for t in _agent.builtin_tools(
@@ -2885,10 +2916,22 @@ class TestConfigDefaults(unittest.TestCase):
         captured = {}
 
         def image_tool(client, prompt=None, *, hide_watermark=None, steps=None,
-                       safe_mode=None, confirm=False, max_spend=None,
+                       safe_mode=None, style_references=None,
+                       embed_exif_metadata=None, quality=None,
+                       enable_web_search=None,
+                       disable_prompt_optimization_thinking=None,
+                       enhance_prompt=None, confirm=False, max_spend=None,
                        output_dir=None, **kw):
             captured.update(hide_watermark=hide_watermark, steps=steps,
-                            safe_mode=safe_mode)
+                            safe_mode=safe_mode,
+                            style_references=style_references,
+                            embed_exif_metadata=embed_exif_metadata,
+                            quality=quality,
+                            enable_web_search=enable_web_search,
+                            disable_prompt_optimization_thinking=(
+                                disable_prompt_optimization_thinking
+                            ),
+                            enhance_prompt=enhance_prompt)
             captured.update(kw)
             return {"status": "ok"}
 
@@ -2936,6 +2979,29 @@ class TestConfigDefaults(unittest.TestCase):
         tool.invoke({"prompt": "p"})
         self.assertIs(captured["hide_watermark"], True)  # _as_bool
         self.assertEqual(captured["steps"], 12)          # int
+
+    def test_native_image_config_is_coerced_and_injected(self):
+        captured, spy = self._spy()
+        doc = {"defaults": {"image": {
+            "style_references": {
+                "image": "https://x.test/style.png", "strength": 0.5
+            },
+            "embed_exif_metadata": "false",
+            "quality": "high",
+            "enable_web_search": "true",
+            "disable_prompt_optimization_thinking": "false",
+            "enhance_prompt": "true",
+        }}}
+        tool = self._tool(spy, doc)
+        tool.invoke({"prompt": "p"})
+        self.assertEqual(captured["style_references"], [{
+            "image": "https://x.test/style.png", "strength": 0.5
+        }])
+        self.assertIs(captured["embed_exif_metadata"], False)
+        self.assertEqual(captured["quality"], "high")
+        self.assertIs(captured["enable_web_search"], True)
+        self.assertIs(captured["disable_prompt_optimization_thinking"], False)
+        self.assertIs(captured["enhance_prompt"], True)
 
     def test_safety_flags_flow_through_and_model_wins(self):
         # #61: safe_mode/hide_watermark are now on _IMAGE_SCHEMA, so a model-supplied

--- a/tests/test_image.py
+++ b/tests/test_image.py
@@ -36,6 +36,13 @@ def _build_args(**ov):
         cfg_scale=None,
         steps=None,
         style_preset=None,
+        style_references=None,
+        embed_exif_metadata=None,
+        lora_strength=None,
+        quality=None,
+        enable_web_search=None,
+        disable_prompt_optimization_thinking=None,
+        enhance_prompt=None,
         variants=None,
         safe_mode=True,
         hide_watermark=False,
@@ -103,6 +110,33 @@ def _unpriced_image_models_payload():
             "model_spec": {"name": "Venice SD3.5", "pricing": {}},
         }],
     }).encode()
+
+
+def _native_image_entry(*, max_refs=2, strength=True):
+    return {
+        "id": "venice-sd35",
+        "type": "image",
+        "model_spec": {
+            "name": "Venice SD3.5",
+            "supportsStyleReferences": True,
+            "constraints": {
+                "maxStyleReferences": max_refs,
+                "supportsStyleReferenceStrength": strength,
+                "qualities": ["low", "medium", "high"],
+                "defaultQuality": "medium",
+                "defaultResolution": "1K",
+            },
+            "pricing": {
+                "quality": {
+                    "1K": {
+                        "low": {"usd": 0.01},
+                        "medium": {"usd": 0.02},
+                        "high": {"usd": 0.03},
+                    }
+                }
+            },
+        },
+    }
 
 
 def _gen_payload(n=1):
@@ -326,6 +360,27 @@ class TestImageFlow(unittest.TestCase):
         self.assertEqual(b["format"], "png")
         self.assertNotIn("variants", b)  # omitted when 1
 
+    def test_body_includes_native_generation_controls(self):
+        from venice.commands import image
+
+        refs = [{"image": "https://x.test/style.png", "strength": 0.75}]
+        body = image._build_body("p", _resolved_args(
+            style_references=refs,
+            embed_exif_metadata=False,
+            lora_strength=65,
+            quality="high",
+            enable_web_search=True,
+            disable_prompt_optimization_thinking=False,
+            enhance_prompt=True,
+        ))
+        self.assertEqual(body["style_references"], refs)
+        self.assertIs(body["embed_exif_metadata"], False)
+        self.assertEqual(body["lora_strength"], 65)
+        self.assertEqual(body["quality"], "high")
+        self.assertIs(body["enable_web_search"], True)
+        self.assertIs(body["disable_prompt_optimization_thinking"], False)
+        self.assertIs(body["enhance_prompt"], True)
+
     def test_style_prefix_prepended(self):
         from venice.commands import image
 
@@ -527,6 +582,7 @@ class TestImageFlow(unittest.TestCase):
         spec = json.loads(sidecars[0].read_text())
         self.assertEqual(spec["seed"], 998319)  # resolved seed captured
         self.assertNotIn("variants", spec)  # normalized to a single image
+        self.assertEqual(sidecars[0].stat().st_mode & 0o777, 0o600)
 
     def test_save_json_multivariant_writes_one_sidecar(self):
         from venice.commands import image
@@ -844,6 +900,136 @@ class TestImagePricingValidation(unittest.TestCase):
                 ValueError, "invalid image price"
             ):
                 image._usd_from_pricing({"image": {"usd": bad}})
+
+    def test_quality_matrix_uses_exact_resolution_and_quality(self):
+        from venice.commands import image
+
+        entry = _native_image_entry()
+        self.assertEqual(
+            image._price_from_entry(entry, resolution="1K", quality="high"),
+            0.03,
+        )
+        self.assertIsNone(
+            image._price_from_entry(entry, resolution="2K", quality="high")
+        )
+
+
+class TestNativeImageControls(unittest.TestCase):
+    def test_local_style_reference_becomes_bounded_data_url(self):
+        from venice.commands import image
+
+        with tempfile.TemporaryDirectory() as td:
+            path = Path(td) / "style.png"
+            raw = b"\x89PNG\r\n\x1a\nSTYLE"
+            path.write_bytes(raw)
+            refs = image.resolve_style_references([
+                json.dumps({"image": str(path), "strength": 0.5})
+            ])
+        self.assertEqual(refs[0]["strength"], 0.5)
+        self.assertTrue(refs[0]["image"].startswith("data:image/png;base64,"))
+        self.assertEqual(
+            base64.b64decode(refs[0]["image"].split(",", 1)[1]), raw
+        )
+
+    def test_raw_base64_style_reference_is_preserved(self):
+        from venice.commands import image
+
+        raw = base64.b64encode(b"\x89PNG\r\n\x1a\nSTYLE").decode()
+        refs = image.resolve_style_references([{"image": raw}])
+        self.assertEqual(refs, [{"image": raw}])
+
+    def test_style_reference_rejects_unknown_fields_and_strength_range(self):
+        from venice.commands import image
+
+        with self.assertRaisesRegex(ValueError, "unknown field"):
+            image.resolve_style_references([
+                {"image": "https://x.test/a.png", "weight": 1}
+            ])
+        with self.assertRaisesRegex(ValueError, "between 0.1 and 1"):
+            image.resolve_style_references([
+                {"image": "https://x.test/a.png", "strength": 1.1}
+            ])
+        fake_data = (
+            "data:image/png;base64,"
+            + base64.b64encode(b"not an image").decode()
+        )
+        with self.assertRaisesRegex(ValueError, "recognized image"):
+            image.resolve_style_references([{"image": fake_data}])
+
+    def test_catalog_enforces_reference_count_and_strength_support(self):
+        from venice.commands import image
+
+        args = _resolved_args(style_references=[
+            {"image": "https://x.test/a.png"},
+            {"image": "https://x.test/b.png"},
+        ])
+        with self.assertRaisesRegex(ValueError, "at most 1"):
+            image._validate_model_controls(_native_image_entry(max_refs=1), args)
+
+        args.style_references = [
+            {"image": "https://x.test/a.png", "strength": 0.5}
+        ]
+        with self.assertRaisesRegex(ValueError, "does not support.*strength"):
+            image._validate_model_controls(
+                _native_image_entry(strength=False), args
+            )
+
+    def test_quality_and_unknown_addons_are_fail_closed_for_cost(self):
+        from venice.commands import image
+
+        args = _resolved_args(quality="high")
+        with mock.patch.object(image._models, "catalog", return_value=[
+            _native_image_entry()
+        ]):
+            self.assertEqual(image.prepare_request(object(), args), 0.03)
+            args.enable_web_search = True
+            self.assertIsNone(image.prepare_request(object(), args))
+            args.enable_web_search = False
+            args.enhance_prompt = True
+            self.assertIsNone(image.prepare_request(object(), args))
+
+    def test_native_controls_round_trip_through_replay(self):
+        from venice.commands import image
+
+        with tempfile.TemporaryDirectory() as td:
+            sidecar = Path(td) / "native.json"
+            refs = [{"image": "https://x.test/style.png", "strength": 0.6}]
+            sidecar.write_text(json.dumps({
+                "prompt": "saved prompt",
+                "style_references": refs,
+                "embed_exif_metadata": False,
+                "lora_strength": 40,
+                "quality": "high",
+                "enable_web_search": True,
+                "disable_prompt_optimization_thinking": False,
+                "enhance_prompt": True,
+            }), encoding="utf-8")
+            merged = image._apply_replay(_build_args(
+                prompt=None, from_json=sidecar
+            ))
+        self.assertEqual(merged.style_references, refs)
+        self.assertIs(merged.embed_exif_metadata, False)
+        self.assertEqual(merged.lora_strength, 40)
+        self.assertEqual(merged.quality, "high")
+        self.assertIs(merged.enable_web_search, True)
+        self.assertIs(merged.disable_prompt_optimization_thinking, False)
+        self.assertIs(merged.enhance_prompt, True)
+
+    def test_sidecar_keeps_native_fields_the_response_does_not_echo(self):
+        from venice.commands import image
+
+        body = image._build_body("p", _resolved_args(
+            quality="high",
+            embed_exif_metadata=False,
+            enhance_prompt=True,
+        ))
+        params = image._sidecar_params({
+            "request": {"data": {"seed": 1234}}
+        }, body)
+        self.assertEqual(params["seed"], 1234)
+        self.assertEqual(params["quality"], "high")
+        self.assertIs(params["embed_exif_metadata"], False)
+        self.assertIs(params["enhance_prompt"], True)
 
 
 if __name__ == "__main__":

--- a/tests/test_image_edit.py
+++ b/tests/test_image_edit.py
@@ -28,6 +28,9 @@ def _args(**ov):
         aspect_ratio=None,
         resolution=None,
         output_format=None,
+        quality=None,
+        disable_prompt_optimization_thinking=None,
+        enhance_prompt=None,
         safe_mode=None,
         output=None,
         yes=True,
@@ -71,17 +74,46 @@ class TestImageEditFlow(unittest.TestCase):
         Path("in.png").write_bytes(SOURCE_PNG)
         Path("mask.png").write_bytes(MASK_PNG)
         Path("layer2.png").write_bytes(LAYER2_PNG)
+        Path("layer3.png").write_bytes(b"LAYER3PNG")
 
     def tearDown(self):
         os.chdir(self.cwd)
         self.tmp.cleanup()
 
-    def _run(self, args, resp=None):
+    def _run(self, args, resp=None, *, max_inputs=3, qualities=None):
         from venice.commands import image_edit
 
         captured = {}
 
         def fake_urlopen(req, timeout=None):
+            if req.data is None:
+                catalog = {
+                    "data": [
+                        {
+                            "id": "firered-image-edit",
+                            "model_spec": {
+                                "traits": ["default"],
+                                "constraints": {
+                                    "combineImages": True,
+                                    "maxInputImages": max_inputs,
+                                    "qualities": qualities
+                                    or ["low", "medium", "high"],
+                                },
+                            },
+                        },
+                        {
+                            "id": "qwen-edit",
+                            "model_spec": {
+                                "constraints": {
+                                    "combineImages": True,
+                                    "maxInputImages": 3,
+                                    "qualities": ["low", "medium", "high"],
+                                }
+                            },
+                        },
+                    ]
+                }
+                return FakeResp(200, json.dumps(catalog).encode(), "application/json")
             captured["url"] = req.full_url
             captured["body"] = json.loads(req.data.decode("utf-8"))
             return resp if resp is not None else FakeResp(200, EDITED_PNG, "image/png")
@@ -151,6 +183,40 @@ class TestImageEditFlow(unittest.TestCase):
         self.assertEqual(cap["body"]["modelId"], "qwen-edit")
         self.assertNotIn("model", cap["body"])
 
+    def test_native_prompt_controls_apply_to_both_edit_routes(self):
+        for layers in (None, [Path("mask.png")]):
+            with self.subTest(multi=bool(layers)):
+                rc, cap = self._run(_args(
+                    layer=layers,
+                    disable_prompt_optimization_thinking=False,
+                    enhance_prompt=True,
+                ))
+                self.assertEqual(rc, 0)
+                self.assertIs(
+                    cap["body"]["disable_prompt_optimization_thinking"], False
+                )
+                self.assertIs(cap["body"]["enhance_prompt"], True)
+
+    def test_multi_edit_quality_is_validated_and_sent(self):
+        rc, cap = self._run(_args(
+            layer=[Path("mask.png")], quality="high"
+        ))
+        self.assertEqual(rc, 0)
+        self.assertEqual(cap["body"]["quality"], "high")
+
+        rc, cap = self._run(
+            _args(layer=[Path("mask.png")], quality="high"),
+            qualities=["low"],
+        )
+        self.assertEqual(rc, 2)
+        self.assertNotIn("body", cap)
+
+    def test_live_model_cap_can_allow_more_than_legacy_three_inputs(self):
+        layers = [Path("mask.png"), Path("layer2.png"), Path("layer3.png")]
+        rc, cap = self._run(_args(layer=layers), max_inputs=4)
+        self.assertEqual(rc, 0)
+        self.assertEqual(len(cap["body"]["images"]), 4)
+
     def test_safe_mode_tristate_body(self):
         """#57 Class B: safe_mode is sent unconditionally now. Unset -> true
         (previously the key was omitted; the API schema defaults it to true, so
@@ -217,16 +283,21 @@ class TestImageEditFlow(unittest.TestCase):
             rc = image_edit._run(_args(prompt=None))
         self.assertEqual(rc, 2)
 
-    def test_too_many_layers_returns_2(self):
+    def test_model_specific_input_limit_returns_2_before_paid_request(self):
+        rc, captured = self._run(_args(
+            layer=[Path("mask.png"), Path("layer2.png"), Path("in.png")]))
+        self.assertEqual(rc, 2)
+        self.assertNotIn("body", captured)
+
+    def test_quality_without_layers_returns_2_before_network(self):
         from venice.commands import image_edit
 
         def explode(*a, **kw):
-            raise AssertionError("must not call the API on bad input")
+            raise AssertionError("single-edit quality must fail before network")
 
         with mock.patch.dict(os.environ, {"VENICE_API_KEY": "fake"}), \
              mock.patch("venice.client.urllib.request.urlopen", explode):
-            rc = image_edit._run(_args(
-                layer=[Path("mask.png"), Path("layer2.png"), Path("in.png")]))
+            rc = image_edit._run(_args(quality="high"))
         self.assertEqual(rc, 2)
 
     def test_missing_input_file_returns_2(self):

--- a/tests/test_mcp_serve.py
+++ b/tests/test_mcp_serve.py
@@ -99,6 +99,32 @@ class TestServerWiring(unittest.TestCase):
         self.assertEqual(creativity["minimum"], 0.0)
         self.assertEqual(creativity["maximum"], 0.02)
 
+    def test_image_wrappers_expose_native_controls(self):
+        from venice.mcp_server import build_server
+
+        class FakeClient:
+            api_key = "fake"
+            base_url = "https://api.venice.ai/api/v1"
+
+        server = build_server(FakeClient(), doc={})
+        image_props = server._tool_manager.get_tool(
+            "venice_image"
+        ).parameters["properties"]
+        for name in (
+            "style_references", "aspect_ratio", "resolution",
+            "embed_exif_metadata", "lora_strength", "quality",
+            "enable_web_search", "disable_prompt_optimization_thinking",
+            "enhance_prompt",
+        ):
+            self.assertIn(name, image_props)
+        edit_props = server._tool_manager.get_tool(
+            "venice_image_edit"
+        ).parameters["properties"]
+        for name in (
+            "quality", "disable_prompt_optimization_thinking", "enhance_prompt"
+        ):
+            self.assertIn(name, edit_props)
+
     def test_retired_upscale_config_returns_error_without_delegating(self):
         from venice.mcp_server import build_server
         from venice.commands import _mcp

--- a/tests/test_mcp_tools.py
+++ b/tests/test_mcp_tools.py
@@ -53,6 +53,41 @@ def _video_catalog(model="seedance-2-0-text-to-video", constraints=None):
     ).encode()
 
 
+def _inpaint_catalog(model="firered-image-edit", *, max_inputs=3, qualities=None):
+    return json.dumps({
+        "data": [{
+            "id": model,
+            "model_spec": {
+                "traits": ["default"],
+                "constraints": {
+                    "combineImages": True,
+                    "maxInputImages": max_inputs,
+                    "qualities": qualities or ["low", "medium", "high"],
+                },
+            },
+        }]
+    }).encode()
+
+
+def _native_image_catalog(*, price=0.01, max_refs=2):
+    return json.dumps({
+        "data": [{
+            "id": "venice-sd35",
+            "model_spec": {
+                "supportsStyleReferences": True,
+                "constraints": {
+                    "maxStyleReferences": max_refs,
+                    "supportsStyleReferenceStrength": True,
+                    "qualities": ["low", "medium", "high"],
+                    "defaultQuality": "medium",
+                    "defaultResolution": "1K",
+                },
+                "pricing": {"image": {"usd": price}},
+            },
+        }]
+    }).encode()
+
+
 class _ToolTest(unittest.TestCase):
     """Base with a persistent temp output dir (survives until tearDown) and a
     stdout-empty guard usable around any tool call."""
@@ -156,6 +191,17 @@ class TestImageTool(_ToolTest):
         self.assertEqual(res["status"], "error")
         self.assertIn("variants", res["message"])
 
+    def test_boolean_lora_strength_is_rejected_without_http(self):
+        def boom(*a, **kw):
+            raise AssertionError("invalid lora strength must not hit the network")
+
+        with mock.patch("venice.client.urllib.request.urlopen", boom):
+            res = _mcp.image_tool(
+                _client(), "x", lora_strength=True, confirm=True
+            )
+        self.assertEqual(res["status"], "error")
+        self.assertIn("integer between 0 and 100", res["message"])
+
     def test_api_error_becomes_error_dict(self):
         from urllib.error import HTTPError
 
@@ -169,6 +215,64 @@ class TestImageTool(_ToolTest):
             res = _mcp.image_tool(_client(), "x", confirm=True)
         self.assertEqual(res["status"], "error")
         self.assertIn("image failed", res["message"])
+
+    def test_style_reference_path_fails_closed_without_host_authority(self):
+        outside_dir = tempfile.mkdtemp()
+        self.addCleanup(shutil.rmtree, outside_dir, ignore_errors=True)
+        outside = Path(outside_dir) / "style.png"
+        outside.write_bytes(b"\x89PNG\r\n\x1a\nSTYLE")
+
+        def boom(*a, **kw):
+            raise AssertionError("denied style path must not reach the API")
+
+        with mock.patch("venice.client.urllib.request.urlopen", boom):
+            res = _mcp.image_tool(
+                _client(), "x", confirm=True,
+                style_references=[{"image": str(outside)}],
+            )
+        self.assertEqual(res["status"], "error")
+        self.assertIn("escapes", res["message"])
+
+    def test_allowed_style_reference_is_normalized_before_generate(self):
+        style = Path(self.td) / "style.png"
+        style.write_bytes(b"\x89PNG\r\n\x1a\nSTYLE")
+        gen = json.dumps({
+            "images": [base64.b64encode(b"IMG").decode()]
+        }).encode()
+        captured = {}
+
+        def fake(req, timeout=None):
+            if req.data is None:
+                return FakeResp(200, _native_image_catalog(), "application/json")
+            captured["body"] = json.loads(req.data.decode())
+            return FakeResp(200, gen)
+
+        with mock.patch("venice.client.urllib.request.urlopen", fake):
+            res = _mcp.image_tool(
+                _client(), "x", confirm=True, output_dir=self.td,
+                style_references=[{"image": str(style), "strength": 0.4}],
+                path_authority=self.media_authority(),
+            )
+        self.assertEqual(res["status"], "ok")
+        ref = captured["body"]["style_references"][0]
+        self.assertTrue(ref["image"].startswith("data:image/png;base64,"))
+        self.assertEqual(ref["strength"], 0.4)
+
+    def test_cost_addons_require_confirmation_even_with_high_cap(self):
+        calls = {"n": 0}
+
+        def fake(req, timeout=None):
+            calls["n"] += 1
+            return FakeResp(200, _native_image_catalog(), "application/json")
+
+        with mock.patch("venice.client.urllib.request.urlopen", fake):
+            res = _mcp.image_tool(
+                _client(), "x", enable_web_search=True,
+                confirm=False, max_spend=100.0,
+            )
+        self.assertEqual(res["status"], "confirmation_required")
+        self.assertIsNone(res["estimated_cost_usd"])
+        self.assertEqual(calls["n"], 1)
 
 
 class TestTtsTool(_ToolTest):
@@ -1153,6 +1257,8 @@ class TestImageEditTool(_ToolTest):
         captured = {}
 
         def fake(req, timeout=None):
+            if req.data is None:
+                return FakeResp(200, _inpaint_catalog(), "application/json")
             captured["url"] = req.full_url
             captured["body"] = json.loads(req.data.decode())
             return FakeResp(200, b"EDITED", "image/png")
@@ -1198,6 +1304,8 @@ class TestImageEditTool(_ToolTest):
         captured = {}
 
         def fake(req, timeout=None):
+            if req.data is None:
+                return FakeResp(200, _inpaint_catalog(), "application/json")
             captured["url"] = req.full_url
             captured["body"] = json.loads(req.data.decode())
             return FakeResp(200, b"MULTI", "image/png")
@@ -1211,6 +1319,33 @@ class TestImageEditTool(_ToolTest):
         self.assertEqual(res["status"], "ok")
         self.assertTrue(captured["url"].endswith("/image/multi-edit"))
         self.assertEqual(len(captured["body"]["images"]), 2)  # base + 1 layer
+
+    def test_multi_edit_native_controls_reach_request(self):
+        ip = self._png()
+        layer = Path(self.td) / "mask.png"
+        layer.write_bytes(b"\x89PNG\r\n\x1a\nMASK")
+        captured = {}
+
+        def fake(req, timeout=None):
+            if req.data is None:
+                return FakeResp(200, _inpaint_catalog(), "application/json")
+            captured["body"] = json.loads(req.data.decode())
+            return FakeResp(200, b"MULTI", "image/png")
+
+        with mock.patch("venice.client.urllib.request.urlopen", fake):
+            res = _mcp.image_edit_tool(
+                _client(), "composite", input_path=str(ip),
+                layer_paths=[str(layer)], quality="high",
+                disable_prompt_optimization_thinking=False,
+                enhance_prompt=True, output_dir=self.td, confirm=True,
+                path_authority=self.media_authority(),
+            )
+        self.assertEqual(res["status"], "ok")
+        self.assertEqual(captured["body"]["quality"], "high")
+        self.assertIs(
+            captured["body"]["disable_prompt_optimization_thinking"], False
+        )
+        self.assertIs(captured["body"]["enhance_prompt"], True)
 
     def test_denied_layer_stops_before_confirmation_and_api(self):
         ip = self._png()


### PR DESCRIPTION
## Summary

- expose the current native image generation and edit controls across CLI, config, MCP, agent schemas, help, and sidecar replay
- normalize bounded local/data/raw-base64 style references, enforce model-facing path authority, and validate style/quality limits from the live catalog
- make quality/resolution pricing deterministic, treat unlisted paid add-ons as unknown, and resolve multi-edit input limits from the selected inpaint model
- keep sidecars provider-shaped and private (`0600`)

## Validation

- `VENICE_API_KEY=test-fake-key make test` (1,771 tests)
- `VENICE_API_KEY=test-fake-key make drive` (37 tests)
- `make lint`
- `make scan`
- `git diff --check`

No live Venice API calls were made.

Closes #149
