### PR TITLE
fix(installer): resolve source scripts portably

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -4,8 +4,31 @@
 
 set -eu
 
-SCRIPT="$(readlink -f "$0")"
-REPO="$(cd "$(dirname "$SCRIPT")" && pwd)"
+# This bootstrap is intentionally kept in sync with uninstall.sh.  It cannot
+# live in a sourced helper: finding that helper safely already requires
+# resolving this script through any symlinks used to invoke it.
+resolve_script() {
+    self="$1"
+    hops=0
+    while [ -L "$self" ]; do
+        hops=$((hops + 1))
+        if [ "$hops" -gt 40 ]; then
+            echo "unable to resolve script path: too many symlinks" >&2
+            return 1
+        fi
+        self_dir="$(CDPATH= cd -P "$(dirname "$self")" && pwd)" || return 1
+        target="$(readlink "$self")" || return 1
+        case "$target" in
+            /*) self="$target" ;;
+            *) self="$self_dir/$target" ;;
+        esac
+    done
+    self_dir="$(CDPATH= cd -P "$(dirname "$self")" && pwd)" || return 1
+    printf '%s/%s\n' "$self_dir" "$(basename "$self")"
+}
+
+SCRIPT="$(resolve_script "$0")"
+REPO="$(CDPATH= cd -P "$(dirname "$SCRIPT")" && pwd)"
 
 BIN_SRC="$REPO/bin/venice"
 PKG_SRC="$REPO/src/venice"

--- a/tests/test_install_scripts.py
+++ b/tests/test_install_scripts.py
@@ -1,0 +1,128 @@
+import os
+import shutil
+import stat
+import subprocess
+import tempfile
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).parents[1]
+
+
+class InstallScriptTests(unittest.TestCase):
+    def setUp(self):
+        self.temp_dir = tempfile.TemporaryDirectory(prefix="venice install ")
+        self.addCleanup(self.temp_dir.cleanup)
+        self.temp = Path(self.temp_dir.name)
+        self.home = self.temp / "home with spaces"
+        self.data_home = self.temp / "data with spaces"
+        self.home.mkdir()
+        self.data_home.mkdir()
+
+        system_readlink = shutil.which("readlink")
+        if system_readlink is None:
+            self.skipTest("readlink is unavailable")
+        shim_dir = self.temp / "bsd bin"
+        shim_dir.mkdir()
+        readlink_shim = shim_dir / "readlink"
+        readlink_shim.write_text(
+            "#!/bin/sh\n"
+            "if [ \"${1-}\" = -f ]; then\n"
+            "    echo 'readlink: illegal option -- f' >&2\n"
+            "    exit 1\n"
+            "fi\n"
+            f"exec {self._shell_quote(system_readlink)} \"$@\"\n",
+            encoding="utf-8",
+        )
+        readlink_shim.chmod(0o755)
+
+        self.env = os.environ.copy()
+        self.env.update(
+            {
+                "HOME": str(self.home),
+                "XDG_DATA_HOME": str(self.data_home),
+                "PATH": f"{shim_dir}{os.pathsep}{self.env.get('PATH', '')}",
+                "PYTHONDONTWRITEBYTECODE": "1",
+                "VENICE_API_KEY": "test-fake-key",
+            }
+        )
+
+    @staticmethod
+    def _shell_quote(value):
+        return "'" + value.replace("'", "'\\''") + "'"
+
+    def run_script(self, name, *, through_symlink=False):
+        script = ROOT / name
+        if through_symlink:
+            launcher_dir = self.temp / "launchers with spaces"
+            launcher_dir.mkdir(exist_ok=True)
+            absolute_link = launcher_dir / f"absolute-{name}"
+            absolute_link.symlink_to(script)
+            launcher = launcher_dir / name
+            launcher.symlink_to(os.path.relpath(absolute_link, launcher_dir))
+            script = launcher
+        return subprocess.run(
+            [str(script)],
+            cwd=self.temp,
+            env=self.env,
+            text=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            timeout=30,
+            check=False,
+        )
+
+    def test_bsd_readlink_supports_symlinked_install_and_uninstall(self):
+        installed = self.run_script("install.sh", through_symlink=True)
+        self.assertEqual(installed.returncode, 0, installed.stderr)
+
+        bin_link = self.home / ".local/bin/venice"
+        lib_link = self.home / ".local/lib/venice"
+        self.assertTrue(bin_link.is_symlink())
+        self.assertTrue(lib_link.is_symlink())
+        self.assertEqual(os.readlink(bin_link), str(ROOT / "bin/venice"))
+        self.assertEqual(os.readlink(lib_link), str(ROOT / "src/venice"))
+        config_dir = self.home / ".config/venice"
+        self.assertEqual(stat.S_IMODE(config_dir.stat().st_mode), 0o700)
+
+        credentials = config_dir / "credentials"
+        credentials.write_text("test-fake-key\n", encoding="utf-8")
+        credentials.chmod(0o600)
+
+        uninstalled = self.run_script("uninstall.sh", through_symlink=True)
+        self.assertEqual(uninstalled.returncode, 0, uninstalled.stderr)
+        self.assertFalse(bin_link.exists())
+        self.assertFalse(lib_link.exists())
+        self.assertTrue(credentials.exists())
+        self.assertNotIn("shred", uninstalled.stdout)
+        self.assertIn("rm -f ~/.config/venice/credentials", uninstalled.stdout)
+        self.assertIn("rmdir ~/.config/venice", uninstalled.stdout)
+
+    def test_install_refuses_to_replace_a_regular_file(self):
+        bin_dst = self.home / ".local/bin/venice"
+        bin_dst.parent.mkdir(parents=True)
+        bin_dst.write_text("user managed\n", encoding="utf-8")
+
+        installed = self.run_script("install.sh")
+        self.assertNotEqual(installed.returncode, 0)
+        self.assertEqual(bin_dst.read_text(encoding="utf-8"), "user managed\n")
+        self.assertIn("exists and is not a symlink", installed.stderr)
+
+    def test_uninstall_preserves_links_that_point_elsewhere(self):
+        bin_dst = self.home / ".local/bin/venice"
+        lib_dst = self.home / ".local/lib/venice"
+        bin_dst.parent.mkdir(parents=True)
+        lib_dst.parent.mkdir(parents=True)
+        bin_dst.symlink_to(self.temp / "foreign bin")
+        lib_dst.symlink_to(self.temp / "foreign lib")
+
+        uninstalled = self.run_script("uninstall.sh")
+        self.assertEqual(uninstalled.returncode, 0, uninstalled.stderr)
+        self.assertTrue(bin_dst.is_symlink())
+        self.assertTrue(lib_dst.is_symlink())
+        self.assertEqual(uninstalled.stdout.count("points elsewhere"), 2)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/uninstall.sh
+++ b/uninstall.sh
@@ -4,8 +4,31 @@
 
 set -eu
 
-SCRIPT="$(readlink -f "$0")"
-REPO="$(cd "$(dirname "$SCRIPT")" && pwd)"
+# This bootstrap is intentionally kept in sync with install.sh.  It cannot
+# live in a sourced helper: finding that helper safely already requires
+# resolving this script through any symlinks used to invoke it.
+resolve_script() {
+    self="$1"
+    hops=0
+    while [ -L "$self" ]; do
+        hops=$((hops + 1))
+        if [ "$hops" -gt 40 ]; then
+            echo "unable to resolve script path: too many symlinks" >&2
+            return 1
+        fi
+        self_dir="$(CDPATH= cd -P "$(dirname "$self")" && pwd)" || return 1
+        target="$(readlink "$self")" || return 1
+        case "$target" in
+            /*) self="$target" ;;
+            *) self="$self_dir/$target" ;;
+        esac
+    done
+    self_dir="$(CDPATH= cd -P "$(dirname "$self")" && pwd)" || return 1
+    printf '%s/%s\n' "$self_dir" "$(basename "$self")"
+}
+
+SCRIPT="$(resolve_script "$0")"
+REPO="$(CDPATH= cd -P "$(dirname "$SCRIPT")" && pwd)"
 
 unlink_if_ours() {
     dst="$1"; expected="$2"
@@ -37,4 +60,7 @@ fi
 
 echo
 echo "Credentials at $HOME/.config/venice/credentials were NOT removed."
-echo "To wipe: shred -u ~/.config/venice/credentials && rmdir ~/.config/venice"
+echo "To remove the file (secure overwrite is not portable):"
+echo "  rm -f ~/.config/venice/credentials"
+echo "Then remove the directory if it is empty:"
+echo "  rmdir ~/.config/venice"


### PR DESCRIPTION
Closes #151

## Summary
- replace GNU-only `readlink -f` in source install/uninstall with bounded POSIX symlink resolution
- keep exact-repository ownership and refusal behavior intact
- replace GNU `shred` guidance with portable removal wording
- add isolated BSD-readlink lifecycle tests with direct and symlinked invocation

## Validation
- `VENICE_API_KEY=test-fake-key PYTHONPATH=src python3 -m unittest -v tests.test_install_scripts`
- `VENICE_API_KEY=test-fake-key make test` (1786 tests)
- `VENICE_API_KEY=test-fake-key make drive` (37 tests)
- `VENICE_API_KEY=test-fake-key make lint`
- `VENICE_API_KEY=test-fake-key make scan`
- `git diff --check`