### PR TITLE
fix(uninstall): preserve foreign Bash completions

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -78,8 +78,10 @@ link "$PKG_SRC" "$LIB_DST"
 # `source <(venice completion bash)`. Never fatal: a missing dir or unwritable
 # path just skips it (a partial write on failure is cleaned up).
 COMPL_DST="${XDG_DATA_HOME:-$HOME/.local/share}/bash-completion/completions/venice"
+COMPL_OWNER="# venice source completion owner: $REPO"
 if mkdir -p "$(dirname "$COMPL_DST")" 2>/dev/null \
-   && "$BIN_SRC" completion bash > "$COMPL_DST" 2>/dev/null; then
+   && { printf '%s\n' "$COMPL_OWNER"; "$BIN_SRC" completion bash; } \
+      > "$COMPL_DST" 2>/dev/null; then
     echo "wrote    $COMPL_DST  (bash completion)"
 else
     rm -f "$COMPL_DST" 2>/dev/null || true

--- a/tests/test_install_scripts.py
+++ b/tests/test_install_scripts.py
@@ -48,6 +48,10 @@ class InstallScriptTests(unittest.TestCase):
             }
         )
 
+        self.completion = (
+            self.data_home / "bash-completion" / "completions" / "venice"
+        )
+
     @staticmethod
     def _shell_quote(value):
         return "'" + value.replace("'", "'\\''") + "'"
@@ -85,6 +89,10 @@ class InstallScriptTests(unittest.TestCase):
         self.assertEqual(os.readlink(lib_link), str(ROOT / "src/venice"))
         config_dir = self.home / ".config/venice"
         self.assertEqual(stat.S_IMODE(config_dir.stat().st_mode), 0o700)
+        self.assertEqual(
+            self.completion.read_text(encoding="utf-8").splitlines()[0],
+            f"# venice source completion owner: {ROOT}",
+        )
 
         credentials = config_dir / "credentials"
         credentials.write_text("test-fake-key\n", encoding="utf-8")
@@ -94,10 +102,52 @@ class InstallScriptTests(unittest.TestCase):
         self.assertEqual(uninstalled.returncode, 0, uninstalled.stderr)
         self.assertFalse(bin_link.exists())
         self.assertFalse(lib_link.exists())
+        self.assertFalse(self.completion.exists())
         self.assertTrue(credentials.exists())
         self.assertNotIn("shred", uninstalled.stdout)
         self.assertIn("rm -f ~/.config/venice/credentials", uninstalled.stdout)
         self.assertIn("rmdir ~/.config/venice", uninstalled.stdout)
+
+    def test_uninstall_preserves_foreign_completion_with_registration(self):
+        self.completion.parent.mkdir(parents=True)
+        content = (
+            "# user-managed completion\n"
+            "_venice() { :; }\n"
+            "complete -F _venice venice\n"
+        )
+        self.completion.write_text(content, encoding="utf-8")
+
+        uninstalled = self.run_script("uninstall.sh")
+        self.assertEqual(uninstalled.returncode, 0, uninstalled.stderr)
+        self.assertEqual(self.completion.read_text(encoding="utf-8"), content)
+        self.assertIn(f"skip     {self.completion} (not ours)", uninstalled.stdout)
+
+    def test_uninstall_preserves_completion_owned_by_another_checkout(self):
+        self.completion.parent.mkdir(parents=True)
+        content = (
+            f"# venice source completion owner: {self.temp / 'other checkout'}\n"
+            "complete -F _venice venice\n"
+        )
+        self.completion.write_text(content, encoding="utf-8")
+
+        uninstalled = self.run_script("uninstall.sh")
+        self.assertEqual(uninstalled.returncode, 0, uninstalled.stderr)
+        self.assertEqual(self.completion.read_text(encoding="utf-8"), content)
+
+    def test_uninstall_preserves_completion_symlink(self):
+        self.completion.parent.mkdir(parents=True)
+        target = self.temp / "foreign completion"
+        content = (
+            f"# venice source completion owner: {ROOT}\n"
+            "complete -F _venice venice\n"
+        )
+        target.write_text(content, encoding="utf-8")
+        self.completion.symlink_to(target)
+
+        uninstalled = self.run_script("uninstall.sh")
+        self.assertEqual(uninstalled.returncode, 0, uninstalled.stderr)
+        self.assertTrue(self.completion.is_symlink())
+        self.assertEqual(target.read_text(encoding="utf-8"), content)
 
     def test_install_refuses_to_replace_a_regular_file(self):
         bin_dst = self.home / ".local/bin/venice"

--- a/uninstall.sh
+++ b/uninstall.sh
@@ -48,12 +48,21 @@ unlink_if_ours() {
 unlink_if_ours "$HOME/.local/bin/venice" "$REPO/bin/venice"
 unlink_if_ours "$HOME/.local/lib/venice" "$REPO/src/venice"
 
-# Remove the bash completion install.sh wrote -- but only if it's ours (carries
-# the generated `complete -F _venice venice` line), never a hand-placed file.
+# Remove the bash completion install.sh wrote, but only when its checkout-
+# specific marker proves this exact source install owns the regular file.
 COMPL_DST="${XDG_DATA_HOME:-$HOME/.local/share}/bash-completion/completions/venice"
-if [ -f "$COMPL_DST" ] && grep -q "complete -F _venice venice" "$COMPL_DST" 2>/dev/null; then
-    rm -f "$COMPL_DST"
-    echo "removed  $COMPL_DST"
+COMPL_OWNER="# venice source completion owner: $REPO"
+if [ -L "$COMPL_DST" ]; then
+    echo "skip     $COMPL_DST (not ours)"
+elif [ -f "$COMPL_DST" ]; then
+    first_line=
+    IFS= read -r first_line < "$COMPL_DST" || true
+    if [ "$first_line" = "$COMPL_OWNER" ]; then
+        rm -f "$COMPL_DST"
+        echo "removed  $COMPL_DST"
+    else
+        echo "skip     $COMPL_DST (not ours)"
+    fi
 elif [ -e "$COMPL_DST" ]; then
     echo "skip     $COMPL_DST (not ours)"
 fi


### PR DESCRIPTION
Closes #152

## Summary
- stamp source-installed Bash completions with the resolved checkout owner
- remove only regular completion files owned by this exact checkout
- preserve generic foreign completions, other-checkout files, and symlinks
- add isolated lifecycle regression coverage

## Validation
- VENICE_API_KEY=test-fake-key PYTHONPATH=src python3 -m unittest -v tests.test_install_scripts
- VENICE_API_KEY=test-fake-key make test (1789 tests)
- VENICE_API_KEY=test-fake-key make drive (37 tests)
- VENICE_API_KEY=test-fake-key make lint
- VENICE_API_KEY=test-fake-key make scan
- sh -n install.sh uninstall.sh
- git diff --check