### PR TITLE
CI: test Python 3.14 and newest stable

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,7 +18,10 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
+        # Keep explicit supported-version legs plus a newest-stable guard. The
+        # 3.x leg intentionally duplicates the current newest classifier until
+        # the next CPython release, when it advances without a metadata gap.
+        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13", "3.14", "3.x"]
 
     steps:
       - uses: actions/checkout@v5
@@ -69,7 +72,7 @@ jobs:
 
       - uses: actions/setup-python@v6
         with:
-          python-version: "3.12"
+          python-version: "3.14"
           cache: pip
           cache-dependency-path: pyproject.toml
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,6 +35,7 @@ classifiers = [
   "Programming Language :: Python :: 3.11",
   "Programming Language :: Python :: 3.12",
   "Programming Language :: Python :: 3.13",
+  "Programming Language :: Python :: 3.14",
   "Topic :: Multimedia :: Sound/Audio",
   "Topic :: Multimedia :: Graphics",
   "Topic :: Utilities",
@@ -55,7 +56,7 @@ openai = ["openai>=1.40"]
 # Upper-bounded as of 2026-07-29 (#95): mcp 2.0.0, published 2026-07-28, deletes
 # `mcp.server.fastmcp` -- `mcp.server` now exposes `mcpserver` instead. The old
 # unbounded `mcp>=1.2` turned that into a red CI on every branch within the hour,
-# on 3.10-3.13 only (2.0 declares requires-python >=3.10, so the 3.9 job kept
+# on 3.10-3.14 only (2.0 declares requires-python >=3.10, so the 3.9 job kept
 # resolving 1.x and stayed green). 1.29.0 is the current 1.x and still ships
 # FastMCP. Lift this when `mcp_serve.py` is ported to the 2.x server API.
 mcp = ["mcp>=1.2,<2; python_version>='3.10'"]


### PR DESCRIPTION
## Summary

- add explicit Python 3.14 to the full CI matrix and package classifiers
- add a rolling 3.x newest-stable leg to catch future metadata drift
- run the isolated base-wheel package job on Python 3.14

## Validation

- make lint
- make scan
- make test (1,790 tests)
- make drive (37 tests)
- git diff --check
- workflow YAML parse

The optional local package build was unavailable because the shared Python environment lacks the build module; the package CI job installs build and twine and is the authoritative check.

Closes #123