### PR TITLE
feat(code): guard against prompt cache collapse

### DIFF
--- a/README.md
+++ b/README.md
@@ -1416,6 +1416,16 @@ Rows are capped at the first 50 plus the most recent 200, so a long session keep
 both its cold-start evidence and its current state; each row carries its `n`, so a
 jump in the sequence is itself the drop marker.
 
+`venice code` also watches that trace for the narrow total-collapse case. Once the
+selected model advertises `pricing.cache_input`, API call 2 or later has at least
+2,000 prompt tokens, and the provider explicitly reports **zero** cached tokens, the
+default `--cache-guard warn` prints one stderr diagnostic for that run. An absent
+cache field is unknown and never trips the guard. `--cache-guard stop` completes any
+tool results required by the response that exposed the collapse, then requests one
+final answer with tools disabled; if the response was already final it buys no extra
+call. `off` disables the policy. Compaction and the fresh-prefix off-loop rails stay
+outside the guard for the same reason they stay outside the trace.
+
 Compaction's summarization call and every subagent rail **are** metered, each into its
 own `usage.buckets` partition rather than into the rows above — they are fresh prefixes,
 so they read ~0% cached every time and would fabricate a cache cliff if averaged in with
@@ -1516,6 +1526,7 @@ external diff helpers. Use the confirmed `run` tool for other Git forms.
 | `--review-model MODEL` | model for `--review` (default: a function-calling model from a **different family** than the coding model; falls back to the coding model with a warning); config `defaults.code.review_model` |
 | `--review-rounds N` | passes `venice_review` makes over the same diff (default **1**, max 3); config `defaults.code.review_rounds` |
 | `--auto-compact` | summarize older history once the prompt crosses `--compact-threshold` tokens (default 100 000), keeping the last `--compact-keep-turns` turns (default 10); long runs stay in-context |
+| `--cache-guard off\|warn\|stop` | react when a cache-priced model explicitly reports zero cached tokens after the cold first API call and a 2,000-token prompt; default **warn**, config `defaults.code.cache_guard` |
 | `-i`, `--json`, `--model`, `--system` | interactive REPL · JSON envelope · model · extra system instructions |
 | `--persona NAME` | load `~/.config/venice/personas/NAME.md` as the system prompt at launch (`/persona` in the REPL) |
 
@@ -1527,7 +1538,7 @@ model and a sane `--max-tool-calls` when running unattended.
 
 Per-flag config defaults live under `defaults.code.*` (e.g. `model`, `root`, `auto`,
 `assets`, `scout`, `spawn`, `spawn_max_spend`, `subagent_max_tokens`, `planner`,
-`max_tool_calls`, `review`, `review_model`, `review_rounds`).
+`max_tool_calls`, `review`, `review_model`, `review_rounds`, `cache_guard`).
 
 #### Scout subagent (`--scout`)
 
@@ -2012,7 +2023,7 @@ schema is forward-compatible.
 ```sh
 venice models                          # count by type
 venice models --type music             # list ids, one per line
-venice models --type music --detail    # ids + name + pricing + capabilities
+venice models --type music --detail    # ids + name + pricing + cache + capabilities
 venice models elevenlabs-sound-effects-v2   # full JSON for one model
 venice models --type all --json        # everything, raw
 ```

--- a/src/venice/commands/_agent.py
+++ b/src/venice/commands/_agent.py
@@ -177,6 +177,17 @@ def to_openai_tools(tools: List[Tool]) -> List[dict]:
 # *between* turns: once accumulated cost crosses the cap, no new paid turn
 # starts and the loop forces a final answer (mirroring --max-tool-calls).
 # --------------------------------------------------------------------------- #
+CACHE_GUARD_CHOICES = ("off", "warn", "stop")
+CACHE_GUARD_MIN_PROMPT_TOKENS = 2_000
+
+
+class CacheGuardEvent(NamedTuple):
+    """One once-per-ledger reported-zero cache event (#105)."""
+
+    action: str
+    message: str
+
+
 def _usd_per_token(pricing, key) -> Optional[float]:
     """`pricing.<key>.usd` as a per-token rate (catalog prices are per 1M)."""
     if not isinstance(pricing, dict):
@@ -358,7 +369,8 @@ class CostLedger:
     _CALLS_TAIL = 200
 
     def __init__(self, max_spend: Optional[float] = None,
-                 max_tokens: Optional[int] = None, *, mirror=None):
+                 max_tokens: Optional[int] = None, *, mirror=None,
+                 cache_guard: str = "off"):
         # A non-positive cap means "uncapped" (mirrors --max-tool-calls 0).
         cap = _numeric.finite_float(max_spend) if max_spend is not None else None
         self.max_spend = cap if (cap is not None and cap > 0) else None
@@ -366,6 +378,17 @@ class CostLedger:
         # per-subagent runs (`--subagent-max-tokens`). Same non-positive->None rule.
         tcap = int(max_tokens) if max_tokens is not None else None
         self.max_tokens = tcap if (tcap is not None and tcap > 0) else None
+        if cache_guard not in CACHE_GUARD_CHOICES:
+            raise ValueError(
+                "cache_guard must be one of: " + ", ".join(CACHE_GUARD_CHOICES)
+            )
+        # #105: code opts its PARENT ledger into this policy. Chat and disposable
+        # subagent ledgers keep the constructor default (`off`), so fresh-prefix
+        # off-loop calls cannot manufacture a cache-collapse warning. This is runtime
+        # policy, not session data: a resumed process may warn again if the regression
+        # is still live.
+        self.cache_guard = cache_guard
+        self._cache_guard_fired = False
         self.total = 0.0
         self.prompt_tokens = 0
         self.completion_tokens = 0
@@ -1087,6 +1110,50 @@ class CostLedger:
             )
         return cost
 
+    def cache_guard_event(self, model: str) -> Optional[CacheGuardEvent]:
+        """Return the first qualifying reported-zero cache event, else ``None``.
+
+        The call trace is the authoritative three-state input (#98/#99): ``None``
+        means the provider did not report a cache field and must never be treated as
+        zero. The ordinal is the API-call ordinal, not a REPL/human turn -- one tool
+        loop can make hundreds of calls, which is the failure #105 exists to stop.
+
+        Only a valid ordinary-input + cache-input price pair makes the model eligible.
+        Missing pricing cannot support either the "advertised" claim or the estimated
+        missed discount. Invalid pricing is handled earlier by ``invalid_pricing``.
+        """
+        if self.cache_guard == "off" or self._cache_guard_fired:
+            return None
+        rows = self.api_calls()
+        if not rows or self._in is None or self._cache_in is None:
+            return None
+        row = rows[-1]
+        prompt_tokens = row.get("prompt_tokens")
+        if (
+            row.get("n", 0) < 2
+            or not isinstance(prompt_tokens, int)
+            or prompt_tokens < CACHE_GUARD_MIN_PROMPT_TOKENS
+            or row.get("cache_read_tokens") != 0
+        ):
+            return None
+
+        self._cache_guard_fired = True
+        if self._cache_in == 0:
+            advertised = "free cache input"
+        elif self._in <= self._cache_in:
+            advertised = "cache-input pricing"
+        else:
+            ratio = self._in / self._cache_in
+            advertised = f"a {ratio:.1f}x cache discount"
+        missed = max(self._in - self._cache_in, 0.0) * prompt_tokens
+        amount = f"${missed:.4f}" if missed < 1 else f"${missed:.2f}"
+        return CacheGuardEvent(
+            self.cache_guard,
+            f"cache: {model} advertises {advertised} but returned 0 cached "
+            f"tokens on API call {row['n']}; this run is paying full input price "
+            f"(est. +{amount} so far)",
+        )
+
     def over(self) -> bool:
         """True when accumulated spend has reached/exceeded the cap.
 
@@ -1653,14 +1720,17 @@ def _pricing_for(models, model_id):
 
 
 def _build_ledger(cap, models, model_id, *, max_tokens=None,
-                  mirror=None) -> CostLedger:
+                  mirror=None, cache_guard="off") -> CostLedger:
     """A CostLedger bound to `model_id`'s catalog pricing (cap may be None).
 
     The ONLY caller of `bind_pricing`, deliberately: pricing a ledger is exactly
     "look this model up in the catalog", and a second site would be a second place
     to forget the lookup (which is how every rail ended up unpriced before #117).
     """
-    ledger = CostLedger(max_spend=cap, max_tokens=max_tokens, mirror=mirror)
+    ledger = CostLedger(
+        max_spend=cap, max_tokens=max_tokens, mirror=mirror,
+        cache_guard=cache_guard,
+    )
     pricing = _pricing_for(models, model_id)
     if pricing is not None:
         ledger.bind_pricing(pricing)
@@ -1691,7 +1761,10 @@ def usage_ledger(args, models, model_id) -> CostLedger:
     session. `--session-max-spend`, when set, still supplies the cap; an uncapped
     ledger meters usage without gating (`over()` is None-safe).
     """
-    return _build_ledger(getattr(args, "session_max_spend", None), models, model_id)
+    return _build_ledger(
+        getattr(args, "session_max_spend", None), models, model_id,
+        cache_guard=getattr(args, "cache_guard", None) or "off",
+    )
 
 
 def subagent_ledger(models, model_id, *, max_tokens=None,
@@ -3378,10 +3451,22 @@ def run_loop(
             # wall and `_call_lines` needs no `[concurrent]` marker.
             ledger.record(getattr(resp, "usage", None),
                           seconds=time.monotonic() - _t0)
+        cache_event = (
+            ledger.cache_guard_event(model) if ledger is not None else None
+        )
         msg = resp.choices[0].message if getattr(resp, "choices", None) else None
         messages.append(_assistant_dict(msg))
         tool_calls = getattr(msg, "tool_calls", None) if msg is not None else None
+        if cache_event is not None and cache_event.action == "warn":
+            print(cache_event.message, file=sys.stderr)
         if not tool_calls:
+            if cache_event is not None and cache_event.action == "stop":
+                # The model already supplied a final response. Buying another
+                # completion would contradict the circuit breaker's purpose.
+                print(
+                    f"{cache_event.message}; response is already final",
+                    file=sys.stderr,
+                )
             return _emit_final(resp, json_out)
 
         # Every tool_call in the turn must get a result (message-contract), even
@@ -3417,6 +3502,15 @@ def run_loop(
                         "content": json.dumps(result, default=str, allow_nan=False),
                     }
                 )
+
+        if cache_event is not None and cache_event.action == "stop":
+            # The assistant tool-call message must receive one result per call before
+            # another assistant message is legal. Once that contract is satisfied,
+            # reuse the existing no-tools finalization seam; do not invent a second
+            # teardown path for the cache gate.
+            return _force_final(
+                f"{cache_event.message}; requesting a final answer"
+            )
 
         if not unlimited and calls_made >= max_tool_calls:
             # The forced-final is the turn a long, over-budget run most needs

--- a/src/venice/commands/code.py
+++ b/src/venice/commands/code.py
@@ -391,6 +391,13 @@ def register(subparsers) -> None:
         "the cap. Distinct from --max-spend (the per-call asset-tool cap).",
     )
     grp.add_argument(
+        "--cache-guard", choices=_agent.CACHE_GUARD_CHOICES, default=None,
+        dest="cache_guard",
+        help="React when a cache-priced model explicitly reports 0 cached tokens "
+        "after the cold first API call: off, warn (default), or stop and request "
+        "a final answer. Config: defaults.code.cache_guard (#105).",
+    )
+    grp.add_argument(
         "--compact-threshold", type=int, default=None, dest="compact_threshold",
         metavar="TOKENS",
         help="Auto-compact once the prompt passes this many tokens "
@@ -631,6 +638,7 @@ def _run(args) -> int:
         return 2
     _session.apply_to_args(args, session, "code")
     userconfig.apply_defaults(args, "code")
+    userconfig.apply_literals(args, cache_guard="warn")
     if getattr(args, "browser", None):
         print(f"code: {_browser.UNAVAILABLE_MESSAGE}", file=sys.stderr)
         return 2

--- a/src/venice/commands/models.py
+++ b/src/venice/commands/models.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 import json
+import math
 import sys
 from typing import Iterable, List, Optional
 
@@ -105,6 +106,40 @@ def _format_pricing(pricing) -> str:
     return " ".join(parts)
 
 
+def _format_cache(pricing) -> str:
+    """Human cache expectation derived from catalog pricing (#105).
+
+    Presence of ``cache_input`` is the catalog's cache advertisement. Keep an
+    invalid/malformed advertisement distinct from absence, and never mutate the raw
+    model object printed by slug/JSON lookup.
+    """
+    if not isinstance(pricing, dict) or "cache_input" not in pricing:
+        return "not advertised"
+    cache_node = pricing.get("cache_input")
+    input_node = pricing.get("input")
+    if not isinstance(cache_node, dict) or "usd" not in cache_node:
+        return "advertised (discount unavailable)"
+    try:
+        cache_price = float(cache_node["usd"])
+        input_price = float(input_node["usd"])
+    except (KeyError, TypeError, ValueError):
+        return "advertised (discount unavailable)"
+    if (
+        isinstance(cache_node["usd"], bool)
+        or isinstance(input_node["usd"], bool)
+        or not math.isfinite(cache_price)
+        or not math.isfinite(input_price)
+        or cache_price < 0
+        or input_price < 0
+    ):
+        return "advertised (discount unavailable)"
+    if cache_price == 0:
+        return "free cache input"
+    if input_price <= cache_price:
+        return "advertised (no discount)"
+    return f"{input_price / cache_price:.1f}x discount"
+
+
 def _format_caps(caps) -> str:
     if not isinstance(caps, dict):
         return ""
@@ -123,12 +158,14 @@ def _print_listing(models: Iterable[dict], detail: bool) -> None:
         name = spec.get("name", "")
         caps = _format_caps(spec.get("capabilities"))
         price = _format_pricing(spec.get("pricing"))
+        cache = _format_cache(spec.get("pricing"))
         line = mid
         if name:
             line += f"  -- {name}"
         print(line)
         if price:
             print(f"    pricing: {price}")
+        print(f"    cache: {cache}")
         if caps:
             print(f"    capabilities: {caps}")
 

--- a/src/venice/userconfig.py
+++ b/src/venice/userconfig.py
@@ -476,6 +476,10 @@ _COMMAND_MAP = {
         "compact_threshold": ("compact_threshold", int),
         "compact_keep_turns": ("compact_keep_turns", int),
         "session_max_spend": ("session_max_spend", _numeric.finite_float),
+        "cache_guard": (
+            "cache_guard",
+            _one_of("venice.commands._agent", "CACHE_GUARD_CHOICES"),
+        ),
         # #80 part 1a: the cold-context reviewer rail. `review_model` is the
         # decorrelation knob -- the reviewer should not be the model that authored.
         "review": ("review", _as_bool),

--- a/tests/test_agent.py
+++ b/tests/test_agent.py
@@ -519,6 +519,78 @@ class TestCostLedger(unittest.TestCase):
         self.assertEqual(L._in, 2.0 / 1e6)
         self.assertIsNone(L._out)  # no output price advertised
 
+    def test_usage_factory_binds_code_cache_guard_only_when_requested(self):
+        models = [{
+            "id": "m",
+            "model_spec": {"pricing": {
+                "input": {"usd": 3.75}, "cache_input": {"usd": 0.375},
+            }},
+        }]
+        args = type(
+            "A", (), {"session_max_spend": None, "cache_guard": "stop"}
+        )()
+        self.assertEqual(_agent.usage_ledger(args, models, "m").cache_guard, "stop")
+        plain = type("A", (), {"session_max_spend": None})()
+        self.assertEqual(_agent.usage_ledger(plain, models, "m").cache_guard, "off")
+
+    def test_cache_guard_uses_api_ordinal_and_three_state_usage(self):
+        def usage(prompt, cached_marker):
+            block = None if cached_marker is None else {
+                "cached_tokens": cached_marker,
+            }
+            return {
+                "prompt_tokens": prompt,
+                "completion_tokens": 10,
+                "prompt_tokens_details": block,
+            }
+
+        pricing = {
+            "input": {"usd": 3.75}, "cache_input": {"usd": 0.375},
+        }
+        cases = (
+            ("cold first call", [usage(3_000, 0)], True, None),
+            ("below floor", [usage(3_000, 100), usage(1_999, 0)], True, None),
+            ("unreported", [usage(3_000, 100), usage(3_000, None)], True, None),
+            ("cache hit", [usage(3_000, 100), usage(3_000, 1)], True, None),
+            ("not advertised", [usage(3_000, 100), usage(3_000, 0)], False, None),
+        )
+        for name, rows, advertised, expected in cases:
+            with self.subTest(case=name):
+                ledger = _agent.CostLedger(cache_guard="warn")
+                ledger.bind_pricing(
+                    pricing if advertised else {"input": {"usd": 3.75}}
+                )
+                event = None
+                for row in rows:
+                    ledger.record(row)
+                    event = ledger.cache_guard_event("kimi-k3")
+                self.assertIs(event, expected)
+
+    def test_cache_guard_event_is_once_only_and_estimates_discount(self):
+        ledger = _agent.CostLedger(cache_guard="warn")
+        ledger.bind_pricing({
+            "input": {"usd": 3.75}, "cache_input": {"usd": 0.375},
+        })
+        ledger.record({
+            "prompt_tokens": 3_000, "completion_tokens": 10,
+            "prompt_tokens_details": {"cached_tokens": 100},
+        })
+        self.assertIsNone(ledger.cache_guard_event("kimi-k3"))
+        ledger.record({
+            "prompt_tokens": 120_000, "completion_tokens": 10,
+            "prompt_tokens_details": {"cached_tokens": 0},
+        })
+        event = ledger.cache_guard_event("kimi-k3")
+        self.assertEqual(event.action, "warn")
+        self.assertIn("10.0x cache discount", event.message)
+        self.assertIn("API call 2", event.message)
+        self.assertIn("+$0.4050", event.message)
+        self.assertIsNone(ledger.cache_guard_event("kimi-k3"))
+
+    def test_cache_guard_rejects_unknown_policy(self):
+        with self.assertRaisesRegex(ValueError, "off, warn, stop"):
+            _agent.CostLedger(cache_guard="explode")
+
     # -- cache-bucket accounting (#75) -------------------------------------- #
 
     def test_cache_buckets_priced_distinctly(self):
@@ -2385,6 +2457,112 @@ class TestCallTrace(unittest.TestCase):
         L = _agent.CostLedger()
         L.record_compaction({"messages_before": 4, "messages_after": 2})
         self.assertNotIn("cost", L.context_events[0])
+
+
+class TestRunLoopCacheGuard(unittest.TestCase):
+    """#105: cache collapse is detected per API call inside one tool loop."""
+
+    @staticmethod
+    def _usage(*, cached, prompt=3_000):
+        return {
+            "prompt_tokens": prompt,
+            "completion_tokens": 10,
+            "prompt_tokens_details": {"cached_tokens": cached},
+        }
+
+    @staticmethod
+    def _tool():
+        return _agent.Tool(
+            "t", "t", {"type": "object", "properties": {}},
+            lambda a, *, confirm=False: {"status": "ok"},
+        )
+
+    @staticmethod
+    def _ledger(policy):
+        ledger = _agent.CostLedger(cache_guard=policy)
+        ledger.bind_pricing({
+            "input": {"usd": 3.75}, "cache_input": {"usd": 0.375},
+        })
+        return ledger
+
+    def test_warn_emits_once_and_continues_the_same_tool_loop(self):
+        seq = [
+            FakeToolCompletion(
+                tool_calls=[_FnCall("c1", "t", "{}")],
+                usage=self._usage(cached=500),
+            ),
+            FakeToolCompletion(
+                tool_calls=[_FnCall("c2", "t", "{}")],
+                usage=self._usage(cached=0),
+            ),
+            FakeToolCompletion("done", usage=self._usage(cached=0)),
+        ]
+        fake, calls = _fake_oai(seq)
+        err = io.StringIO()
+        with mock.patch.object(sys, "stdout", io.StringIO()), \
+             mock.patch.object(sys, "stderr", err):
+            rc = _agent.run_loop(
+                fake, "kimi-k3", [{"role": "user", "content": "go"}], {},
+                [self._tool()], max_tool_calls=0, yes=True, json_out=False,
+                ledger=self._ledger("warn"),
+            )
+        self.assertEqual(rc, 0)
+        self.assertEqual(len(calls), 3)
+        self.assertEqual(err.getvalue().count("returned 0 cached tokens"), 1)
+        self.assertIn("API call 2", err.getvalue())
+
+    def test_stop_finishes_returned_tools_then_uses_no_tools_final(self):
+        seq = [
+            FakeToolCompletion(
+                tool_calls=[_FnCall("c1", "t", "{}")],
+                usage=self._usage(cached=500),
+            ),
+            FakeToolCompletion(
+                tool_calls=[_FnCall("c2", "t", "{}")],
+                usage=self._usage(cached=0),
+            ),
+            FakeToolCompletion("wrapped up", usage=self._usage(cached=0)),
+        ]
+        fake, calls = _fake_oai(seq)
+        err = io.StringIO()
+        messages = [{"role": "user", "content": "go"}]
+        with mock.patch.object(sys, "stdout", io.StringIO()), \
+             mock.patch.object(sys, "stderr", err):
+            rc = _agent.run_loop(
+                fake, "kimi-k3", messages, {}, [self._tool()],
+                max_tool_calls=0, yes=True, json_out=False,
+                ledger=self._ledger("stop"),
+            )
+        self.assertEqual(rc, 0)
+        self.assertEqual(len(calls), 3)
+        self.assertEqual(calls[-1]["tool_choice"], "none")
+        self.assertTrue(any(
+            m.get("role") == "tool" and m.get("tool_call_id") == "c2"
+            for m in calls[-1]["messages"]
+        ))
+        self.assertEqual(err.getvalue().count("returned 0 cached tokens"), 1)
+        self.assertIn("requesting a final answer", err.getvalue())
+
+    def test_stop_buys_no_extra_call_when_triggering_response_is_final(self):
+        seq = [
+            FakeToolCompletion(
+                tool_calls=[_FnCall("c1", "t", "{}")],
+                usage=self._usage(cached=500),
+            ),
+            FakeToolCompletion("done", usage=self._usage(cached=0)),
+        ]
+        fake, calls = _fake_oai(seq)
+        err = io.StringIO()
+        with mock.patch.object(sys, "stdout", io.StringIO()), \
+             mock.patch.object(sys, "stderr", err):
+            rc = _agent.run_loop(
+                fake, "kimi-k3", [{"role": "user", "content": "go"}], {},
+                [self._tool()], max_tool_calls=0, yes=True, json_out=False,
+                ledger=self._ledger("stop"),
+            )
+        self.assertEqual(rc, 0)
+        self.assertEqual(len(calls), 2)
+        self.assertIn("response is already final", err.getvalue())
 
 
 class TestRunLoopSpendGate(unittest.TestCase):

--- a/tests/test_code_command.py
+++ b/tests/test_code_command.py
@@ -48,7 +48,7 @@ def _code_args(**ov):
         plan_only=False, no_plan=False, no_verify=False, max_tool_calls=None,
         exec_timeout=None, interactive=False, resume=None, assets=None,
         auto_compact=None, compact_threshold=None, compact_keep_turns=None,
-        session_max_spend=None, cont=None, ephemeral=None,
+        session_max_spend=None, cache_guard=None, cont=None, ephemeral=None,
         review=None, review_model=None, review_rounds=None,   # #80 part 1a
         browser=None, browser_allow=None, browser_deny=None,
     )

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -270,6 +270,35 @@ class TestApplyDefaults(_Base):
         uc.apply_defaults(args, "code", doc)
         self.assertIs(args.parallel, True)
 
+    def test_code_cache_guard_cli_config_and_literal_precedence(self):
+        parser = _build_parser(code)
+
+        args = parser.parse_args(["code", "do x"])
+        self.assertIsNone(args.cache_guard)
+        uc.apply_defaults(
+            args, "code", {"defaults": {"code": {"cache_guard": "stop"}}}
+        )
+        uc.apply_literals(args, cache_guard="warn")
+        self.assertEqual(args.cache_guard, "stop")
+
+        explicit = parser.parse_args(["code", "--cache-guard", "off", "do x"])
+        uc.apply_defaults(
+            explicit, "code", {"defaults": {"code": {"cache_guard": "stop"}}}
+        )
+        uc.apply_literals(explicit, cache_guard="warn")
+        self.assertEqual(explicit.cache_guard, "off")
+
+        invalid = parser.parse_args(["code", "do x"])
+        _, _, err = _capture(
+            uc.apply_defaults,
+            invalid,
+            "code",
+            {"defaults": {"code": {"cache_guard": "explode"}}},
+        )
+        uc.apply_literals(invalid, cache_guard="warn")
+        self.assertEqual(invalid.cache_guard, "warn")
+        self.assertIn("expected one of: off, stop, warn", err)
+
     def test_apply_fills_code_web_search(self):
         # #77: defaults.code.web_search (_as_bool) backs --web-search; explicit wins.
         doc = {"defaults": {"code": {"web_search": True}}}

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -164,8 +164,29 @@ class TestModels(unittest.TestCase):
         out = buf.getvalue()
         self.assertIn("pricing:", out)
         self.assertIn("$1.5", out)
+        self.assertIn("cache: not advertised", out)
         self.assertIn("capabilities:", out)
         self.assertIn("WebSearch", out)
+
+    def test_cache_discount_formats_without_mutating_raw_pricing(self):
+        from venice.commands import models
+
+        cases = (
+            ({"input": {"usd": 3.75}, "cache_input": {"usd": 0.375}},
+             "10.0x discount"),
+            ({"input": {"usd": 3.75}, "cache_input": {"usd": 0}},
+             "free cache input"),
+            ({"input": {"usd": 0.375}, "cache_input": {"usd": 3.75}},
+             "advertised (no discount)"),
+            ({"input": {"usd": 3.75}}, "not advertised"),
+            ({"input": {"usd": 3.75}, "cache_input": {"usd": "bad"}},
+             "advertised (discount unavailable)"),
+        )
+        for pricing, expected in cases:
+            with self.subTest(expected=expected):
+                before = json.loads(json.dumps(pricing))
+                self.assertEqual(models._format_cache(pricing), expected)
+                self.assertEqual(pricing, before)
 
     def test_slug_lookup_prints_json_for_one(self):
         from venice.commands import models
@@ -182,6 +203,7 @@ class TestModels(unittest.TestCase):
         doc = json.loads(buf.getvalue())
         self.assertEqual(doc["id"], "mmaudio-v2-text-to-audio")
         self.assertEqual(doc["type"], "music")
+        self.assertNotIn("cache", doc)  # raw catalog JSON gains no derived field
 
     def test_current_type_slugs_are_found_in_the_all_catalog(self):
         from venice.commands import models

--- a/tests/test_planner.py
+++ b/tests/test_planner.py
@@ -498,7 +498,7 @@ def _code_args(**ov):
         planner=None, memory=None,
         parallel=None,
         auto_compact=None, compact_threshold=None, compact_keep_turns=None,
-        session_max_spend=None, cont=None, ephemeral=None,
+        session_max_spend=None, cache_guard=None, cont=None, ephemeral=None,
         web_search=None, web_search_model=None,
     )
     base.update(ov)

--- a/tests/test_review.py
+++ b/tests/test_review.py
@@ -1375,7 +1375,7 @@ class TestReviewRailWiring(_RepoBase):
             plan_only=True, no_plan=False, no_verify=False, max_tool_calls=None,
             exec_timeout=None, interactive=False, resume=None, assets=None,
             auto_compact=None, compact_threshold=None, compact_keep_turns=None,
-            session_max_spend=None, cont=None, ephemeral=None,
+            session_max_spend=None, cache_guard=None, cont=None, ephemeral=None,
             review=None, review_model=None, review_rounds=None,
         )
         base.update(ov)

--- a/tests/test_spawn.py
+++ b/tests/test_spawn.py
@@ -431,6 +431,7 @@ def _code_args(**ov):
         exec_timeout=None, interactive=False, resume=None, assets=None,
         scout=None, spawn=None, spawn_max_spend=None, auto_compact=None,
         compact_threshold=None, compact_keep_turns=None, session_max_spend=None,
+        cache_guard=None,
         cont=None, ephemeral=None, web_search=None, web_search_model=None,
     )
     base.update(ov)

--- a/tests/test_web_search.py
+++ b/tests/test_web_search.py
@@ -385,7 +385,7 @@ def _code_args(**ov):
         exec_timeout=None, interactive=False, resume=None, assets=None,
         scout=None, spawn=None, spawn_max_spend=None, planner=None, memory=None,
         auto_compact=None, compact_threshold=None, compact_keep_turns=None,
-        session_max_spend=None, cont=None, ephemeral=None,
+        session_max_spend=None, cache_guard=None, cont=None, ephemeral=None,
         web_search=None, web_search_model=None,
     )
     base.update(ov)


### PR DESCRIPTION
Closes #105

## Summary
- add `venice code --cache-guard off|warn|stop` with CLI/config/literal precedence and a default of `warn`
- detect one explicit reported-zero cache collapse per parent code ledger, excluding unknown usage, cold/short prompts, cache hits, compaction, and off-loop rails
- surface catalog cache expectations in human `models --detail` output without changing raw JSON
- document the policy and cover warning, stopping, configuration, pricing, and message-contract behavior

## Validation
- `VENICE_API_KEY=test-fake-key make test` (1,799 tests)
- `VENICE_API_KEY=test-fake-key make drive` (37 tests)
- `VENICE_API_KEY=test-fake-key make lint`
- `VENICE_API_KEY=test-fake-key make scan`
- `git diff --check`