### PR TITLE
drive: exercise the real agent tool loop

### DIFF
--- a/tests/_venice_fake_server.py
+++ b/tests/_venice_fake_server.py
@@ -27,6 +27,9 @@ Usage::
 
     with FakeVenice() as api:
         api.reply("HELLO")                 # queue one chat completion
+        api.reply_tool_call(                # or one non-streamed tool turn
+            "venice_models", {"type": "image"}
+        )
         ...                                # drive the CLI at api.base_url
         assert api.paths == ["/models", "/chat/completions"]
 """
@@ -101,6 +104,7 @@ class FakeVenice:
         self._lock = threading.Lock()
         self.requests = []  # [{"method", "path", "query", "body", "has_auth"}]
         self._chat = collections.deque()
+        self._next_tool_call_id = 0
         self._httpd = None
         self._thread = None
 
@@ -154,6 +158,49 @@ class FakeVenice:
         with self._lock:
             self._chat.append({"deltas": list(deltas), "usage": _USAGE})
 
+    def reply_tool_call(self, name: str, arguments: dict) -> None:
+        """Queue one non-streamed assistant turn containing one tool call."""
+        self.reply_tool_calls([(name, arguments)])
+
+    def reply_tool_calls(self, calls) -> None:
+        """Queue one non-streamed assistant turn containing `calls` in order.
+
+        Each entry is a ``(name, arguments)`` pair.  The fake deliberately accepts
+        only JSON-object arguments: this is enough to drive ``_agent.run_loop`` while
+        keeping malformed/delta tool-call simulation out of this narrow fixture.
+        """
+        calls = list(calls)
+        if not calls:
+            raise ValueError("reply_tool_calls requires at least one call")
+        encoded = []
+        for name, arguments in calls:
+            if not isinstance(name, str) or not name:
+                raise ValueError("tool-call name must be a non-empty string")
+            if not isinstance(arguments, dict):
+                raise ValueError("tool-call arguments must be a dict")
+            encoded.append((
+                name,
+                json.dumps(
+                    arguments, sort_keys=True, separators=(",", ":"),
+                    allow_nan=False,
+                ),
+            ))
+
+        scripted = []
+        with self._lock:
+            for name, arguments_json in encoded:
+                call_id = f"call_fake_{self._next_tool_call_id}"
+                self._next_tool_call_id += 1
+                scripted.append({
+                    "id": call_id,
+                    "type": "function",
+                    "function": {
+                        "name": name,
+                        "arguments": arguments_json,
+                    },
+                })
+            self._chat.append({"tool_calls": scripted, "usage": _USAGE})
+
     def _next_chat(self) -> dict:
         with self._lock:
             if self._chat:
@@ -168,6 +215,7 @@ class FakeVenice:
         with self._lock:
             self.requests = []
             self._chat.clear()
+            self._next_tool_call_id = 0
 
     @property
     def paths(self):
@@ -276,6 +324,12 @@ def _make_handler(api: FakeVenice):
         # -- chat completions ----------------------------------------------
 
         def _send_completion(self, scripted, model):
+            tool_calls = scripted.get("tool_calls")
+            message = {"role": "assistant", "content": None}
+            if tool_calls is not None:
+                message["tool_calls"] = tool_calls
+            else:
+                message["content"] = "".join(scripted["deltas"])
             self._send_json({
                 "id": "chatcmpl-fake",
                 "object": "chat.completion",
@@ -283,11 +337,10 @@ def _make_handler(api: FakeVenice):
                 "model": model,
                 "choices": [{
                     "index": 0,
-                    "message": {
-                        "role": "assistant",
-                        "content": "".join(scripted["deltas"]),
-                    },
-                    "finish_reason": "stop",
+                    "message": message,
+                    "finish_reason": (
+                        "tool_calls" if tool_calls is not None else "stop"
+                    ),
                 }],
                 "usage": scripted["usage"],
             })

--- a/tests/test_drive_cli.py
+++ b/tests/test_drive_cli.py
@@ -207,6 +207,39 @@ class TestDriveCharge(_DriveCase):
         self.assertNotIn("/image/generate", self.api.paths)
         self.assertEqual(list(self.project.glob("*.png")), [])
 
+    @needs_openai
+    def test_agent_tool_call_confirm_accept_reaches_the_second_turn(self):
+        """#114: drive the real agent loop through a paid tool and back."""
+        self.api.reply_tool_call("venice_image", {"prompt": "a tiny cat"})
+        self.api.reply("TOOL-LOOP-COMPLETE")
+
+        with self.cli(
+            "chat", "make an image", "--tools", "--tool", "venice_image",
+            "--max-spend", "0", "--json",
+        ) as d:
+            d.expect("image: estimated cost $0.0100 is over the auto-approve cap")
+            d.expect("Proceed? [y]es / [a]ll (accept rest) / [N]o ")
+            d.send("y")
+            d.expect('"content": "TOOL-LOOP-COMPLETE"')
+            self.assertEqual(d.wait(), 0)
+
+        outputs = list(self.project.glob("venice-image-*.png"))
+        self.assertEqual(len(outputs), 1)
+        self.assertEqual(outputs[0].read_bytes(), fake.PNG_BYTES)
+        self.assertEqual(self.api.paths.count("/image/generate"), 1)
+
+        chat_bodies = self.api.bodies("/chat/completions")
+        self.assertEqual(len(chat_bodies), 2)
+        assistant, result = chat_bodies[1]["messages"][-2:]
+        self.assertEqual(assistant["role"], "assistant")
+        self.assertEqual(assistant["tool_calls"][0]["id"], "call_fake_0")
+        self.assertEqual(assistant["tool_calls"][0]["function"]["name"],
+                         "venice_image")
+        self.assertEqual(result["role"], "tool")
+        self.assertEqual(result["tool_call_id"], "call_fake_0")
+        self.assertEqual(result["name"], "venice_image")
+        self.assertEqual(json.loads(result["content"])["status"], "ok")
+
 
 # --------------------------------------------------------------------------
 # C'. the same gates with no pty at all

--- a/tests/test_fake_server.py
+++ b/tests/test_fake_server.py
@@ -121,6 +121,42 @@ class TestFakeServerViaOpenAI(_NoProxyCase):
         self.assertEqual(out.choices[0].message.content, "HELLO-FROM-FAKE")
         self.assertEqual(out.usage.total_tokens, 14)
 
+    def test_non_streamed_tool_call_completion(self):
+        self.api.reply_tool_call("venice_models", {"type": "image"})
+        out = self.oai.chat.completions.create(
+            model="llama-3.3-70b",
+            messages=[{"role": "user", "content": "find an image model"}],
+        )
+        choice = out.choices[0]
+        self.assertEqual(choice.finish_reason, "tool_calls")
+        self.assertIsNone(choice.message.content)
+        self.assertEqual(len(choice.message.tool_calls), 1)
+        call = choice.message.tool_calls[0]
+        self.assertEqual(call.id, "call_fake_0")
+        self.assertEqual(call.type, "function")
+        self.assertEqual(call.function.name, "venice_models")
+        self.assertEqual(json.loads(call.function.arguments), {"type": "image"})
+
+    def test_multiple_tool_calls_preserve_order_and_unique_ids(self):
+        self.api.reply_tool_calls([
+            ("venice_models", {"type": "text"}),
+            ("venice_model_details", {"model": "llama-3.3-70b"}),
+        ])
+        out = self.oai.chat.completions.create(
+            model="llama-3.3-70b",
+            messages=[{"role": "user", "content": "compare models"}],
+        )
+        calls = out.choices[0].message.tool_calls
+        self.assertEqual([call.id for call in calls], ["call_fake_0", "call_fake_1"])
+        self.assertEqual(
+            [call.function.name for call in calls],
+            ["venice_models", "venice_model_details"],
+        )
+        self.assertEqual(
+            [json.loads(call.function.arguments) for call in calls],
+            [{"type": "text"}, {"model": "llama-3.3-70b"}],
+        )
+
     def test_streamed_completion_yields_deltas_then_usage(self):
         self.api.reply_chunks("HELLO-", "FROM-", "FAKE")
         stream = self.oai.chat.completions.create(


### PR DESCRIPTION
Closes #114

## Summary
- add deterministic non-streamed tool-call scripting to the loopback fake API
- cover single and multi-call OpenAI SDK response parsing
- drive a paid `venice_image` call through the real CLI, terminal confirmation, execution, tool-result replay, and final model turn

## Validation
- `VENICE_API_KEY=test-fake-key make test` (1802 tests)
- `VENICE_API_KEY=test-fake-key make drive` (40 tests)
- `make lint`
- `make scan`
- `make openapi-check`
- `git diff --check`
- mutation check: disabling the fake tool-call response branch makes both the SDK and real-CLI guards fail