### PR TITLE
fix(agent): keep subagent prompt prefixes stable

### DIFF
--- a/src/venice/commands/_agent.py
+++ b/src/venice/commands/_agent.py
@@ -3683,17 +3683,20 @@ def _run_disposable(
     budget: Optional[_compact.Budget] = None,
     ledger: Optional[CostLedger] = None,
     focus: Optional[str] = None,
+    role: Optional[str] = None,
 ) -> dict:
     """Run one disposable subagent turn-loop on a FRESH context and return its report.
 
     The shared core behind :func:`run_scout` (read-only) and :func:`run_spawn`
-    (write/paid-capable): seeds a fresh ``messages`` list (only ``system`` + ``task`` --
-    nothing from the caller's context leaks in), drives :func:`run_loop` with the given
-    ``tools`` under a stdout firewall (the printed final answer is captured and
-    discarded), and returns ``{"status","report","tool_calls","truncated"}``. The report
-    is recovered from the message tail -- the final assistant turn in both the natural-
-    stop and cap-forced paths. ``openai.OpenAIError`` from the loop propagates to the
-    caller (the Tool wrapper turns it into an error envelope).
+    (write/paid-capable): seeds a fresh ``messages`` list (only static ``system`` + one
+    user task -- nothing from the caller's context leaks in), drives :func:`run_loop`
+    with the given ``tools`` under a stdout firewall (the printed final answer is
+    captured and discarded), and returns
+    ``{"status","report","tool_calls","truncated"}``. Dynamic focus/role guidance rides
+    in that user turn so repeated rail invocations keep a byte-identical cacheable
+    system prefix. The report is recovered from the message tail -- the final assistant
+    turn in both the natural-stop and cap-forced paths. ``openai.OpenAIError`` from the
+    loop propagates to the caller (the Tool wrapper turns it into an error envelope).
 
     Capability-agnostic: the read-only-vs-write distinction and any self-spawn guard live
     in the two thin wrappers, not here. Runs with ``yes=True`` -- for the worker that is
@@ -3704,12 +3707,15 @@ def _run_disposable(
     if not task:
         return {"status": "error", "message": "subagent requires a non-empty task"}
 
-    sys_prompt = system
+    guidance = []
+    if role:
+        guidance.append(f"Your role: {role}.")
     if focus:
-        sys_prompt = f"{system}\nFocus hint (not a hard scope): {focus}\n"
+        guidance.append(f"Focus hint (not a hard scope): {focus}")
+    user_task = "\n".join(guidance) + f"\n\n{task}" if guidance else task
     messages: List[dict] = [
-        {"role": "system", "content": sys_prompt},
-        {"role": "user", "content": task},
+        {"role": "system", "content": system},
+        {"role": "user", "content": user_task},
     ]
     # #128: this is a fresh conversation, not a continuation of the parent. Replace
     # (rather than inherit) its routing key; every call inside this disposable loop
@@ -3952,11 +3958,10 @@ def run_spawn(
             "worker subagent tools must not include a spawn, scout, merge, or review "
             f"tool (no nested subagents; merging is the planner's job); got: {bad}"
         )
-    if role:
-        system = f"{system}\nYour role: {role}.\n"
     out = _run_disposable(
         oai, model, task, tools, base_kwargs, system=system,
         max_tool_calls=max_tool_calls, budget=budget, ledger=ledger, focus=focus,
+        role=role,
     )
     if out.get("status") == "ok":
         out["fields"] = _parse_sections(out.get("report", ""), SPAWN_SECTIONS)

--- a/src/venice/commands/_review.py
+++ b/src/venice/commands/_review.py
@@ -381,9 +381,10 @@ def collect_diff(root: str, base: str, *, paths=None, context: str = "function",
 def build_task(collected: dict, *, prior=None) -> str:
     """Assemble the reviewer's user turn: provenance, caveats, then the diff.
 
-    Prior findings ride HERE, not in the system prompt, so ``REVIEW_SYSTEM`` stays
-    byte-identical across rounds (a stable prompt prefix is what keeps the input
-    cache hot -- aiforge#19 SS5 -- and it keeps the prompt pins meaningful).
+    Prior findings ride HERE after the closing diff fence, not in the system prompt or
+    ahead of the diff. ``REVIEW_SYSTEM`` and the entire first-round task therefore stay
+    a byte-identical prefix of later rounds (what keeps the input cache hot --
+    aiforge#19 SS5 -- and keeps the prompt pins meaningful).
     """
     head = [
         f"Review the following diff. Base: {collected['base']} "
@@ -403,12 +404,15 @@ def build_task(collected: dict, *, prior=None) -> str:
         head.append(
             "Skipped as non-code: "
             + ", ".join(f"{s['path']} ({s['reason']})" for s in collected["files_skipped"]))
+    task = "\n".join(head) + "\n\n```diff\n" + collected["diff"] + "\n```\n"
     if prior:
-        head.append(
-            "ALREADY REPORTED in an earlier pass over this same diff -- do NOT repeat "
-            "these; look for what they missed:\n"
-            + "\n".join(f"  - {f['file']}:{f['line']} {f['summary']}" for f in prior))
-    return "\n".join(head) + "\n\n```diff\n" + collected["diff"] + "\n```\n"
+        task += (
+            "\nALREADY REPORTED in an earlier pass over this same diff -- do NOT "
+            "repeat these; look for what they missed:\n"
+            + "\n".join(f"  - {f['file']}:{f['line']} {f['summary']}" for f in prior)
+            + "\n"
+        )
+    return task
 
 
 # --------------------------------------------------------------------------- #

--- a/tests/test_agent.py
+++ b/tests/test_agent.py
@@ -8,6 +8,7 @@ import contextlib
 import io
 import json
 import os
+import subprocess
 import sys
 import tempfile
 import threading
@@ -3283,6 +3284,73 @@ class TestToolRegistry(unittest.TestCase):
         names = {t.name for t in _agent.builtin_tools(
             object(), only=_agent.select(categories={"image", "audio", "video"}))}
         self.assertEqual(names, self._ASSETS)
+
+    def test_system_and_selected_tool_bytes_ignore_python_hash_seed(self):
+        # #102: select() deliberately returns a set, but builtin_tools() filters the
+        # ordered registry by membership. Serializing in fresh processes pins that
+        # boundary: iterating the set instead makes this output seed-dependent.
+        root = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+        script = """
+import json
+from venice.commands import _agent
+
+selected = _agent.select(categories={"image", "audio", "video"})
+tools = _agent.builtin_tools(object(), only=selected)
+print(json.dumps(
+    {"system": _agent.SPAWN_SYSTEM, "tools": _agent.to_openai_tools(tools)},
+    separators=(",", ":"),
+))
+"""
+        outputs = []
+        for seed in ("1", "2"):
+            env = dict(os.environ)
+            env["PYTHONHASHSEED"] = seed
+            env["PYTHONPATH"] = os.pathsep.join(
+                filter(None, (os.path.join(root, "src"), env.get("PYTHONPATH")))
+            )
+            proc = subprocess.run(
+                [sys.executable, "-c", script], cwd=root, env=env,
+                check=True, capture_output=True, text=True,
+            )
+            outputs.append(proc.stdout)
+
+        self.assertEqual(outputs[0], outputs[1])
+        payload = json.loads(outputs[0])
+        self.assertEqual(payload["system"], _agent.SPAWN_SYSTEM)
+        selected = _agent.select(categories={"image", "audio", "video"})
+        expected = [spec.name for spec in _agent._REGISTRY if spec.name in selected]
+        self.assertEqual(
+            [tool["function"]["name"] for tool in payload["tools"]], expected,
+        )
+
+
+class TestToolSchemaStability(unittest.TestCase):
+    def test_tool_array_is_snapshotted_once_for_the_run(self):
+        tools = []
+
+        def mutate(_arguments, *, confirm=False):
+            tools.append(_tool("late", lambda a, *, confirm=False: {"status": "ok"}))
+            return {"status": "ok"}
+
+        tools.append(_tool("early", mutate))
+        fake, calls = _fake_oai([
+            FakeToolCompletion(tool_calls=[_FnCall("c1", "early", "{}")]),
+            FakeToolCompletion("done"),
+        ])
+        with mock.patch.object(sys, "stdout", io.StringIO()), \
+             mock.patch.object(sys, "stderr", io.StringIO()):
+            _agent.run_loop(
+                fake, "m", [{"role": "user", "content": "go"}], {}, tools,
+                max_tool_calls=0, yes=True, json_out=False,
+            )
+
+        self.assertEqual([t.name for t in tools], ["early", "late"])
+        self.assertEqual(len(calls), 2)
+        for call in calls:
+            self.assertEqual(
+                [tool["function"]["name"] for tool in call["tools"]], ["early"],
+            )
+        self.assertIs(calls[0]["tools"], calls[1]["tools"])
 
 
 # --------------------------------------------------------------------------- #

--- a/tests/test_review.py
+++ b/tests/test_review.py
@@ -627,9 +627,15 @@ class TestRunCycle(_RepoBase):
             [_report(["src/pool.cc:1 [major] first"]),
              _report(["src/pool.cc:2 [major] second"])], rounds=2)
         self.assertEqual(len(seen), 2)
+        # The entire first-round task, including the closing diff fence, is the
+        # byte-identical prefix of round two. Prior findings may only follow it.
+        self.assertTrue(seen[1].startswith(seen[0]))
         self.assertIn("ALREADY REPORTED", seen[1])
         self.assertIn("first", seen[1])
         self.assertNotIn("ALREADY REPORTED", seen[0])
+        self.assertGreater(
+            seen[1].index("ALREADY REPORTED"), seen[1].index("\n```\n")
+        )
         self.assertEqual(len(out["findings"]), 2)
 
     def test_stops_early_when_a_round_adds_nothing_new(self):

--- a/tests/test_spawn.py
+++ b/tests/test_spawn.py
@@ -256,13 +256,19 @@ class TestRunScout(_ScoutBase):
             )
         self.assertEqual(parent["extra_body"]["prompt_cache_key"], "parent-key")
 
-    def test_focus_hint_threaded_into_system(self):
+    def test_focus_hint_rides_in_user_task_not_system(self):
         seq = [FakeToolCompletion(_REPORT)]
         fake, calls = _fake_openai_seq(seq)
         _agent.run_scout(fake, "m", "t", _code.read_only_tools(self.root), {},
                          max_tool_calls=4, focus="src/venice/commands/_repl.py")
-        self.assertIn("src/venice/commands/_repl.py",
-                      calls[0]["messages"][0]["content"])
+        messages = calls[0]["messages"]
+        self.assertEqual(messages[0]["content"], _agent.SCOUT_SYSTEM)
+        self.assertEqual(
+            messages[1],
+            {"role": "user", "content": (
+                "Focus hint (not a hard scope): src/venice/commands/_repl.py\n\nt"
+            )},
+        )
 
     def test_empty_task_short_circuits(self):
         fake, calls = _fake_openai_seq([])
@@ -536,11 +542,12 @@ class TestRunSpawn(_ScoutBase):
                          max_tool_calls=5, focus="src/x.py", role="code")
         first = calls[0]["messages"]
         self.assertEqual(len(first), 2)
-        self.assertEqual(first[0]["role"], "system")
-        self.assertIn("WORKER", first[0]["content"])
-        self.assertIn("Your role: code", first[0]["content"])   # role folded in
-        self.assertIn("src/x.py", first[0]["content"])          # focus hint threaded
-        self.assertEqual(first[1], {"role": "user", "content": "do the thing"})
+        self.assertEqual(first[0], {"role": "system", "content": _agent.SPAWN_SYSTEM})
+        self.assertEqual(first[1], {"role": "user", "content": (
+            "Your role: code.\n"
+            "Focus hint (not a hard scope): src/x.py\n\n"
+            "do the thing"
+        )})
 
     def test_budget_cap_forces_final_and_marks_truncated(self):
         seq = [


### PR DESCRIPTION
Closes #102

Summary:
- move dynamic worker role and subagent focus guidance into the first user turn so rail system prompts remain byte-stable
- append prior review findings after the complete diff fence so later review rounds reuse the full earlier prefix
- pin tool schema ordering across hash seeds and snapshot the advertised tools once per run

Validation:
- VENICE_API_KEY=test-fake-key make test (1,804 tests)
- VENICE_API_KEY=test-fake-key make drive (40 tests)
- VENICE_API_KEY=test-fake-key make lint
- VENICE_API_KEY=test-fake-key make scan
- git diff --check
- mutation check: direct set iteration made the hash-seed byte-stability test fail; ordered filtering restored it to green

No live Venice API calls were made.