### PR TITLE
fix(code): validate and record auxiliary models

### DIFF
--- a/README.md
+++ b/README.md
@@ -1000,7 +1000,9 @@ venice code --web-search --auto \
 - **Model.** Web search needs a model advertising `supportsWebSearch`. By default the
   coding `--model` is used when it qualifies, else the first capable model in the catalog;
   override with `--web-search-model MODEL` (or `defaults.code.web_search_model`). No model id
-  is hard-coded — it's resolved against the live `/models` catalog.
+  is hard-coded — it's resolved against the live `/models` catalog. The resolved id and
+  whether it came from the flag, config, or automatic selection are printed before the
+  first paid call; unknown ids and models known to lack web search fail at startup.
 - **Billed, bounded.** It rides the normal completion path (same key, same billing) rather
   than a scraper, so there's no new dependency or secret. It isn't per-call spend-gated; its
   cost is bounded by the agent's tool-call budget, and each result carries a best-effort
@@ -1530,6 +1532,12 @@ external diff helpers. Use the confirmed `run` tool for other Git forms.
 | `-i`, `--json`, `--model`, `--system` | interactive REPL · JSON envelope · model · extra system instructions |
 | `--persona NAME` | load `~/.config/venice/personas/NAME.md` as the system prompt at launch (`/persona` in the REPL) |
 
+When review or web search is enabled, `--json` includes a `resolved_models` object whose
+`review` / `web_search` rows carry the resolved `id`, a `source` of `flag`, `config`, or
+`auto`, and the exact `config_key` for config-sourced values. Saved session envelopes carry
+the same object. Disabled rails have no row, and invalid auxiliary models fail before the
+planning or agent completion.
+
 With `--assets`, generated files land in `$VENICE_MCP_OUTPUT_DIR` or, by default, under
 the project root, and paid calls are capped per call by `$VENICE_MCP_MAX_SPEND` (default
 **$0.10**) — **except** that `--auto` auto-approves every call and so bypasses that cap;
@@ -1760,7 +1768,10 @@ early as soon as a pass finds nothing new.
 **different family** than the catalog default (`qwen3-4b` and `qwen-2.5-coder` count as
 the same family — a different id alone is not decorrelation). If the catalog offers no
 alternative it reviews with the same model and says so loudly; that is never a hard
-error, but the output carries `decorrelated: false` so a caller can tell.
+error, but the output carries `decorrelated: false` so a caller can tell. Under `venice
+code --review`, the selected reviewer id and its flag/config/automatic provenance are
+reported before the first paid call; an unknown or known non-function-calling reviewer
+fails at startup.
 
 | flag | effect |
 | --- | --- |

--- a/src/venice/commands/_repl.py
+++ b/src/venice/commands/_repl.py
@@ -611,7 +611,7 @@ def _dispatch_slash(line, messages, state, args, models, oai=None, gen_kwargs=No
 def run(args, oai, openai, client, models, model, initial=None, *,
         tools_session=None, gen_kwargs=None, label="venice chat",
         max_tool_calls=8, session=None, ephemeral=False, root=None,
-        system_reseed=False, ledger=None) -> int:
+        system_reseed=False, ledger=None, resolved_models=None) -> int:
     """Drive the interactive REPL until `/exit`, `/quit`, or EOF (Ctrl-D).
 
     `initial` is an already-resolved first message (e.g. `venice chat -i "hi"`);
@@ -633,7 +633,8 @@ def run(args, oai, openai, client, models, model, initial=None, *,
     `--resume <id>`/`--continue` restore settings + usage, not just messages.
     `root` (code) is recorded on the session; `system_reseed` overwrites a stale
     leading system message with `args.system` (code rebuilds it against the live
-    root each launch).
+    root each launch). `resolved_models` records the current invocation's enabled
+    auxiliary-model selections; it replaces stale selection metadata on resume.
     """
     from . import chat  # lazy: chat imports this module at top (avoid a cycle)
 
@@ -722,7 +723,9 @@ def run(args, oai, openai, client, models, model, initial=None, *,
                 model=state["model"], system=_current_system(messages),
                 gen_kwargs=gen_kwargs, root=root,
                 max_tool_calls=state["max_tool_calls"], messages=messages,
+                resolved_models=resolved_models,
             )
+            active.resolved_models = dict(resolved_models or {})
             if root is not None:
                 active.root = root
         state["session"] = active

--- a/src/venice/commands/_session.py
+++ b/src/venice/commands/_session.py
@@ -86,6 +86,7 @@ class Session:
     label: str = "venice chat"
     max_tool_calls: Optional[int] = None
     usage: Optional[dict] = None
+    resolved_models: dict = field(default_factory=dict)
     messages: list = field(default_factory=list)
 
     def to_envelope(self) -> dict:
@@ -102,6 +103,7 @@ class Session:
             "label": self.label,
             "max_tool_calls": self.max_tool_calls,
             "usage": self.usage,
+            "resolved_models": self.resolved_models,
             "messages": self.messages,
         }
 
@@ -122,20 +124,25 @@ class Session:
             label=d.get("label") or "venice chat",
             max_tool_calls=d.get("max_tool_calls"),
             usage=d.get("usage") if isinstance(d.get("usage"), dict) else None,
+            resolved_models=(
+                dict(d.get("resolved_models"))
+                if isinstance(d.get("resolved_models"), dict) else {}
+            ),
             messages=_validate_messages(d.get("messages") or []),
         )
 
 
 def new_session(command: str, *, label: str = "venice chat", model=None,
                 system=None, gen_kwargs=None, root=None, max_tool_calls=None,
-                messages=None) -> Session:
+                messages=None, resolved_models=None) -> Session:
     """Mint a brand-new active session (fresh id + timestamps)."""
     now = _now_iso()
     return Session(
         id=new_id(), command=command, created=now, updated=now,
         model=model, system=system,
         gen_kwargs=dict(gen_kwargs or {}), root=root, label=label,
-        max_tool_calls=max_tool_calls, messages=list(messages or []),
+        max_tool_calls=max_tool_calls,
+        resolved_models=dict(resolved_models or {}), messages=list(messages or []),
     )
 
 

--- a/src/venice/commands/code.py
+++ b/src/venice/commands/code.py
@@ -607,9 +607,128 @@ def _prompt_accept(*, no_plan: bool = False) -> str:
         print("Please answer a, s, e, or n.", file=sys.stderr)
 
 
-def _emit_plan_only(args, root, task, plan_text, *, usage=None) -> int:
+def _model_provenance(args, dest: str) -> dict:
+    """Describe whether an auxiliary model came from a flag, config, or auto-pick."""
+    sources = getattr(args, "_config_sources", None)
+    config_key = sources.get(dest) if isinstance(sources, dict) else None
+    if config_key:
+        return {"source": "config", "config_key": config_key}
+    if getattr(args, dest, None) is not None:
+        return {"source": "flag"}
+    return {"source": "auto"}
+
+
+def _config_model_recovery(provenance: dict) -> None:
+    """Point a config-sourced auxiliary-model failure at its durable fix."""
+    key = provenance.get("config_key")
+    if key:
+        print(
+            f"code: that model came from {key}; update it or run: "
+            f"venice config unset {key}",
+            file=sys.stderr,
+        )
+
+
+def _record_auxiliary_model(args, dest: str, role: str, flag: str,
+                            model: str) -> dict:
+    """Build the public selection row and announce it before any paid call."""
+    row = {"id": model, **_model_provenance(args, dest)}
+    if row["source"] == "config":
+        source = f"config {row['config_key']}"
+    elif row["source"] == "flag":
+        source = f"flag {flag}"
+    else:
+        source = "auto"
+    print(f"code: {role} model: {model} (source: {source})", file=sys.stderr)
+    return row
+
+
+def _resolve_auxiliary_models(args, models, author_model: str):
+    """Resolve enabled review/web-search models before a paid completion (#103).
+
+    Returns ``(state, rc)``. ``state['resolved_models']`` is the stable public
+    provenance map; the other keys are the already-validated values consumed by
+    the tool factories. Disabled rails are intentionally ignored, including stale
+    defaults for their otherwise-unused model flags.
+    """
+    state = {
+        "resolved_models": {},
+        "review_model": None,
+        "review_decorrelated": False,
+        "web_search_model": None,
+    }
+
+    if bool(getattr(args, "review", None)):
+        provenance = _model_provenance(args, "review_model")
+        picked, decorrelated = _review.resolve_reviewer_model(
+            models, getattr(args, "review_model", None), author_model,
+        )
+        review_model, rc = _models.resolve_model(
+            picked, models, label="code", noun="review model",
+        )
+        if rc is not None:
+            _config_model_recovery(provenance)
+            return None, rc
+        ok, rc = _agent.check_function_calling(
+            models, review_model, label="code",
+            degraded_tail=(
+                "venice code --review needs a tool-calling model "
+                "(pass --review-model)."
+            ),
+            unverified_tail="attempting the review anyway",
+            degrade=False,
+        )
+        if not ok:
+            _config_model_recovery(provenance)
+            return None, rc
+        state["review_model"] = review_model
+        state["review_decorrelated"] = decorrelated
+        state["resolved_models"]["review"] = _record_auxiliary_model(
+            args, "review_model", "review", "--review-model", review_model,
+        )
+
+    if bool(getattr(args, "web_search", None)):
+        provenance = _model_provenance(args, "web_search_model")
+        picked = _agent.resolve_web_search_model(
+            models, getattr(args, "web_search_model", None), author_model,
+        )
+        if not picked:
+            print(
+                "code: no web-search-capable model available; pass "
+                "--web-search-model (or set defaults.code.web_search_model)",
+                file=sys.stderr,
+            )
+            _config_model_recovery(provenance)
+            return None, 2
+        web_model, rc = _models.resolve_model(
+            picked, models, label="code", noun="web-search model",
+        )
+        if rc is not None:
+            _config_model_recovery(provenance)
+            return None, rc
+        if _agent.supports_web_search(models, web_model) is False:
+            print(
+                f"code: web-search model {web_model!r} does not advertise "
+                "supportsWebSearch",
+                file=sys.stderr,
+            )
+            _config_model_recovery(provenance)
+            return None, 2
+        state["web_search_model"] = web_model
+        state["resolved_models"]["web_search"] = _record_auxiliary_model(
+            args, "web_search_model", "web-search", "--web-search-model", web_model,
+        )
+
+    return state, None
+
+
+def _emit_plan_only(args, root, task, plan_text, *, usage=None,
+                    resolved_models=None) -> int:
     if args.json:
-        doc = {"root": root, "task": task, "plan": plan_text, "mode": "plan_only"}
+        doc = {
+            "root": root, "task": task, "plan": plan_text, "mode": "plan_only",
+            "resolved_models": dict(resolved_models or {}),
+        }
         if usage is not None:
             doc["usage"] = usage  # #81: a plan turn is a real call and a real wait
         json.dump(doc, sys.stdout, indent=2, default=str, allow_nan=False)
@@ -686,6 +805,14 @@ def _run(args) -> int:
     if not ok:
         return rc  # degrade_to_chat is False for code -> rc == 2
 
+    auxiliary, rc = _resolve_auxiliary_models(args, models, model)
+    if rc is not None:
+        return rc
+    resolved_models = auxiliary["resolved_models"]
+    review_model = auxiliary["review_model"]
+    decorrelated = auxiliary["review_decorrelated"]
+    web_search_model = auxiliary["web_search_model"]
+
     oai = _openai.build_openai(openai, client)
     doc = userconfig.load_config()  # #58 tool defaults + #33 shell policy
     pol = userconfig.shell_policy(doc)
@@ -755,7 +882,7 @@ def _run(args) -> int:
     if bool(getattr(args, "web_search", None)):
         ws_tool = _code.web_search_tool(
             oai, model, models=models,
-            search_model=getattr(args, "web_search_model", None),
+            search_model=web_search_model,
             parent_ledger=ledger,  # #117: bills the `web_search` bucket
         )
     # #52: per-subagent cumulative-token ceiling (None = uncapped); applies to BOTH the
@@ -782,8 +909,6 @@ def _run(args) -> int:
         # a costlier model. A reviewer from a different family than the author is the
         # point of the rail -- same-family is allowed but warned about, because
         # refusing would make --review useless on a single-model catalog.
-        review_model, decorrelated = _review.resolve_reviewer_model(
-            models, getattr(args, "review_model", None), model)
         if not decorrelated:
             print(f"code: --review will use {review_model}, the same model family "
                   "that is authoring -- blind spots are correlated. Pass "
@@ -824,16 +949,18 @@ def _run(args) -> int:
             session=session, ephemeral=bool(getattr(args, "ephemeral", None)),
             root=root, system_reseed=PROFILE.system_reseed,
             ledger=ledger,  # #117: the rails already hold this one
+            resolved_models=resolved_models,
         )
 
     return _run_oneshot(args, oai, openai, model, tools, system, gen_kwargs, root, task,
                         models, dispatches=dispatches,
                         ephemeral=bool(getattr(args, "ephemeral", None)),
-                        ledger=ledger)  # #117
+                        ledger=ledger, resolved_models=resolved_models)  # #117
 
 
 def _run_oneshot(args, oai, openai, model, tools, system, gen_kwargs, root, task,
-                 models=None, *, dispatches=None, ephemeral=False, ledger=None) -> int:
+                 models=None, *, dispatches=None, ephemeral=False, ledger=None,
+                 resolved_models=None) -> int:
     messages: List[dict] = [
         {"role": "system", "content": system},
         {"role": "user", "content": task},
@@ -889,7 +1016,8 @@ def _run_oneshot(args, oai, openai, model, tools, system, gen_kwargs, root, task
             if args.plan_only:
                 _finish(ledger, t0, human, json_out=args.json)
                 return _emit_plan_only(args, root, task, plan_text,
-                                       usage=ledger.to_dict())
+                                       usage=ledger.to_dict(),
+                                       resolved_models=resolved_models)
             if not args.json:
                 _show_plan(plan_text)
 
@@ -952,7 +1080,7 @@ def _run_oneshot(args, oai, openai, model, tools, system, gen_kwargs, root, task
         active = _session.new_session(
             "code", label=PROFILE.label, model=model, system=system,
             gen_kwargs=gen_kwargs, root=root, max_tool_calls=max_calls,
-            messages=messages,
+            messages=messages, resolved_models=resolved_models,
         )
         active.messages = messages  # share the live list so saves capture the transcript
         try:
@@ -1066,6 +1194,7 @@ def _run_oneshot(args, oai, openai, model, tools, system, gen_kwargs, root, task
         envelope = {
             "root": root, "task": task, "plan": plan_text, "mode": mode,
             "final": final_text,
+            "resolved_models": dict(resolved_models or {}),
             # #81: `to_dict()` verbatim, so `venice code --json | jq .usage` and
             # `jq .usage <session>.json` are the same shape and cannot drift apart.
             # Numbers here, `format_duration` only on the human line. FOUR surfaces

--- a/tests/test_code_command.py
+++ b/tests/test_code_command.py
@@ -50,6 +50,7 @@ def _code_args(**ov):
         auto_compact=None, compact_threshold=None, compact_keep_turns=None,
         session_max_spend=None, cache_guard=None, cont=None, ephemeral=None,
         review=None, review_model=None, review_rounds=None,   # #80 part 1a
+        web_search=None, web_search_model=None,
         browser=None, browser_allow=None, browser_deny=None,
     )
     base.update(ov)
@@ -64,6 +65,144 @@ def _write_call(cid, path, content):
 def _mem_call(cid, name, content, scope="project"):
     return _FnCall(cid, "memory_write",
                    json.dumps({"name": name, "content": content, "scope": scope}))
+
+
+class TestAuxiliaryModelResolution(unittest.TestCase):
+    _UNSET = object()
+    MODELS = [
+        {"id": "llama-author", "type": "text", "model_spec": {
+            "traits": ["default"],
+            "capabilities": {
+                "supportsFunctionCalling": True, "supportsWebSearch": False,
+            },
+        }},
+        {"id": "qwen-reviewer", "type": "text", "model_spec": {
+            "traits": [], "capabilities": {"supportsFunctionCalling": True},
+        }},
+        {"id": "searcher", "type": "text", "model_spec": {
+            "traits": [], "capabilities": {
+                "supportsFunctionCalling": True, "supportsWebSearch": True,
+            },
+        }},
+        {"id": "no-tools", "type": "text", "model_spec": {
+            "traits": [], "capabilities": {
+                "supportsFunctionCalling": False, "supportsWebSearch": False,
+            },
+        }},
+    ]
+
+    @staticmethod
+    def _args(**overrides):
+        values = {
+            "review": None, "review_model": None,
+            "web_search": None, "web_search_model": None,
+        }
+        values.update(overrides)
+        return argparse.Namespace(**values)
+
+    def _resolve(self, args, models=_UNSET):
+        err = io.StringIO()
+        with contextlib.redirect_stderr(err):
+            state, rc = code_command._resolve_auxiliary_models(
+                args, self.MODELS if models is self._UNSET else models, "llama-author",
+            )
+        return state, rc, err.getvalue()
+
+    def test_auto_picks_are_announced_and_structured(self):
+        state, rc, err = self._resolve(self._args(review=True, web_search=True))
+        self.assertIsNone(rc)
+        self.assertEqual(state["review_model"], "qwen-reviewer")
+        self.assertEqual(state["web_search_model"], "searcher")
+        self.assertEqual(state["resolved_models"], {
+            "review": {"id": "qwen-reviewer", "source": "auto"},
+            "web_search": {"id": "searcher", "source": "auto"},
+        })
+        self.assertIn("review model: qwen-reviewer (source: auto)", err)
+        self.assertIn("web-search model: searcher (source: auto)", err)
+
+    def test_flag_and_exact_config_provenance_are_distinct(self):
+        args = self._args(
+            review=True, review_model="qwen-reviewer",
+            web_search=True, web_search_model="searcher",
+            _config_sources={
+                "web_search_model": "defaults.code.web_search_model",
+            },
+        )
+        state, rc, err = self._resolve(args)
+        self.assertIsNone(rc)
+        self.assertEqual(state["resolved_models"], {
+            "review": {"id": "qwen-reviewer", "source": "flag"},
+            "web_search": {
+                "id": "searcher", "source": "config",
+                "config_key": "defaults.code.web_search_model",
+            },
+        })
+        self.assertIn("source: flag --review-model", err)
+        self.assertIn("source: config defaults.code.web_search_model", err)
+
+    def test_unknown_review_model_exits_six(self):
+        state, rc, err = self._resolve(
+            self._args(review=True, review_model="typo-reviewer"),
+        )
+        self.assertIsNone(state)
+        self.assertEqual(rc, 6)
+        self.assertIn("unknown review model 'typo-reviewer'", err)
+
+    def test_unknown_config_web_model_names_the_durable_fix(self):
+        args = self._args(
+            web_search=True, web_search_model="retired-searcher",
+            _config_sources={
+                "web_search_model": "defaults.code.web_search_model",
+            },
+        )
+        state, rc, err = self._resolve(args)
+        self.assertIsNone(state)
+        self.assertEqual(rc, 6)
+        self.assertIn("unknown web-search model 'retired-searcher'", err)
+        self.assertIn("venice config unset defaults.code.web_search_model", err)
+
+    def test_known_incapable_models_fail_at_startup(self):
+        cases = [
+            (self._args(review=True, review_model="no-tools"),
+             "does not support function calling"),
+            (self._args(web_search=True, web_search_model="no-tools"),
+             "does not advertise supportsWebSearch"),
+        ]
+        for args, message in cases:
+            with self.subTest(message=message):
+                state, rc, err = self._resolve(args)
+                self.assertIsNone(state)
+                self.assertEqual(rc, 2)
+                self.assertIn(message, err)
+
+    def test_no_capable_web_model_fails_before_tool_use(self):
+        models = [self.MODELS[0], self.MODELS[1], self.MODELS[3]]
+        state, rc, err = self._resolve(self._args(web_search=True), models=models)
+        self.assertIsNone(state)
+        self.assertEqual(rc, 2)
+        self.assertIn("no web-search-capable model available", err)
+
+    def test_unverifiable_catalog_preserves_attempt_anyway_behavior(self):
+        state, rc, err = self._resolve(
+            self._args(review=True, web_search=True), models=None,
+        )
+        self.assertIsNone(rc)
+        self.assertEqual(state["review_model"], "llama-author")
+        self.assertEqual(state["web_search_model"], "llama-author")
+        self.assertIn("could not verify function-calling support", err)
+
+    def test_disabled_rails_ignore_stale_unused_defaults(self):
+        args = self._args(
+            review_model="retired-reviewer", web_search_model="retired-searcher",
+            _config_sources={
+                "review_model": "defaults.code.review_model",
+                "web_search_model": "defaults.code.web_search_model",
+            },
+        )
+        state, rc, err = self._resolve(args)
+        self.assertIsNone(rc)
+        self.assertEqual(state["resolved_models"], {})
+        self.assertEqual(err, "")
 
 
 class TestCodeCommand(unittest.TestCase):
@@ -592,6 +731,48 @@ class TestCodeCommand(unittest.TestCase):
         self.assertTrue(env["acceptance"]["passed"])
         self.assertEqual(env["acceptance"]["verdict"], "pass")
         self.assertEqual(env["root"], self.root)
+        self.assertEqual(env["resolved_models"], {})
+
+    def test_plan_only_json_records_auxiliary_model_provenance(self):
+        out, err = io.StringIO(), io.StringIO()
+        rc, calls = self._run(
+            _code_args(
+                task="x", root=self.root, plan_only=True, json=True,
+                review=True, review_model="llama-3.3-70b",
+            ),
+            [FakeToolCompletion("plan text")], stdout=out, stderr=err,
+        )
+        self.assertEqual(rc, 0)
+        self.assertEqual(len(calls), 1)
+        self.assertEqual(json.loads(out.getvalue())["resolved_models"], {
+            "review": {"id": "llama-3.3-70b", "source": "flag"},
+        })
+        self.assertIn("source: flag --review-model", err.getvalue())
+
+    def test_full_json_and_session_share_resolved_models(self):
+        out = io.StringIO()
+        selection = {
+            "review": {"id": "llama-3.3-70b", "source": "flag"},
+        }
+        seq = [
+            FakeToolCompletion("plan text"),
+            FakeToolCompletion("done"),
+            FakeToolCompletion("ACCEPTANCE: PASS"),
+        ]
+        rc, _calls = self._run(
+            _code_args(
+                task="x", root=self.root, auto=True, json=True,
+                review=True, review_model="llama-3.3-70b",
+            ),
+            seq, stdout=out,
+        )
+        self.assertEqual(rc, 0)
+        self.assertEqual(json.loads(out.getvalue())["resolved_models"], selection)
+        session_files = list(Path(self._sess_dir).glob("*.json"))
+        self.assertEqual(len(session_files), 1)
+        self.assertEqual(
+            json.loads(session_files[0].read_text())["resolved_models"], selection,
+        )
 
     # --- --no-plan skips plan + verify ---
     def test_no_plan_executes_directly(self):
@@ -625,6 +806,7 @@ class TestCodeCommand(unittest.TestCase):
             captured["root"] = root
             captured["system_reseed"] = system_reseed
             captured["ledger"] = kw.get("ledger")
+            captured["resolved_models"] = kw.get("resolved_models")
             captured["gen_kwargs"] = gen_kwargs
             return 0
 
@@ -648,6 +830,7 @@ class TestCodeCommand(unittest.TestCase):
         self.assertEqual(captured["max_tool_calls"], code._DEFAULT_MAX_TOOL_CALLS)
         self.assertTrue(captured["system_reseed"])       # code always reseeds (#47)
         self.assertEqual(captured["root"], self.root)
+        self.assertEqual(captured["resolved_models"], {})
         # #117: the REPL is HANDED the hoisted ledger rather than building its own,
         # because the rails already mirror into that object.
         self.assertIsNotNone(captured["ledger"])

--- a/tests/test_repl.py
+++ b/tests/test_repl.py
@@ -980,6 +980,35 @@ class TestRepl(unittest.TestCase):
             self.assertEqual(rc2, 0)
             self.assertIn("over 2 turn(s)", err.getvalue())
 
+    def test_resume_replaces_stale_auxiliary_model_metadata(self):
+        from venice.commands import _session
+
+        selection = {"review": {"id": "reviewer", "source": "auto"}}
+        with tempfile.TemporaryDirectory() as d, \
+                mock.patch.dict(os.environ, {"VENICE_SESSIONS_DIR": d}), \
+                mock.patch("builtins.input", return_value="/exit"), \
+                mock.patch.object(sys, "stdout", io.StringIO()), \
+                mock.patch.object(sys, "stderr", io.StringIO()):
+            session = _session.new_session(
+                "code", model="author", resolved_models={
+                    "web_search": {"id": "stale", "source": "auto"},
+                },
+            )
+            rc = _repl.run(
+                _args(interactive=True), mock.MagicMock(), mock.MagicMock(),
+                None, [], "author", session=session, resolved_models=selection,
+            )
+            self.assertEqual(rc, 0)
+            self.assertEqual(_session.load(session.id, "code").resolved_models,
+                             selection)
+
+            rc = _repl.run(
+                _args(interactive=True), mock.MagicMock(), mock.MagicMock(),
+                None, [], "author", session=session, resolved_models={},
+            )
+            self.assertEqual(rc, 0)
+            self.assertEqual(_session.load(session.id, "code").resolved_models, {})
+
     def test_slash_compact_then_turn_sees_summary(self):
         with tempfile.TemporaryDirectory() as d:
             resume = self._resume_history(d, pairs=6)

--- a/tests/test_review.py
+++ b/tests/test_review.py
@@ -1353,7 +1353,7 @@ class TestReviewCommand(_RepoBase):
 class TestReviewRailWiring(_RepoBase):
     """`venice code --review` folds the rail in and keeps it operator-controlled."""
 
-    def _run(self, args, seq, models=None, stderr=None):
+    def _run(self, args, seq, models=None, stderr=None, config=None):
         from venice.commands import code
         fake, calls = _fake_openai_seq(seq)
         stdin = mock.MagicMock()
@@ -1364,7 +1364,7 @@ class TestReviewRailWiring(_RepoBase):
                                           "VENICE_SESSIONS_DIR": sess}), \
              mock.patch("venice.userconfig.load_config",
                         lambda *a, **k: {"version": 1, "mcpServers": {},
-                                         "defaults": {}}), \
+                                         "defaults": config or {}}), \
              mock.patch("venice.client.urllib.request.urlopen",
                         _catalog_urlopen(models or _TWO_FAMILY_MODELS)), \
              mock.patch("openai.OpenAI", return_value=fake), \
@@ -1426,6 +1426,19 @@ class TestReviewRailWiring(_RepoBase):
         with mock.patch.object(_review, "review_tool", _spy):
             self._run(self._args(review=True, review_model="llama-3.3-70b"), seq)
         self.assertEqual(built["model"], "llama-3.3-70b")
+
+    def test_unknown_config_reviewer_fails_before_a_completion_with_recovery(self):
+        err = io.StringIO()
+        rc, calls = self._run(
+            self._args(review=True), [], stderr=err,
+            config={"code": {"review_model": "retired-reviewer"}},
+        )
+        self.assertEqual(rc, 6)
+        self.assertEqual(calls, [])
+        self.assertIn("unknown review model 'retired-reviewer'", err.getvalue())
+        self.assertIn(
+            "venice config unset defaults.code.review_model", err.getvalue(),
+        )
 
     def test_single_family_catalog_warns_instead_of_failing(self):
         solo = [{"id": "llama-3.3-70b", "type": "text",

--- a/tests/test_sessions.py
+++ b/tests/test_sessions.py
@@ -62,6 +62,24 @@ class TestStore(_Base):
         self.assertEqual(r.usage["cache_read_tokens"], 4)
         self.assertEqual([m["content"] for m in r.messages], ["hi"])
 
+    def test_resolved_models_round_trip_and_old_envelopes_default_empty(self):
+        selection = {
+            "review": {"id": "reviewer", "source": "auto"},
+            "web_search": {
+                "id": "searcher", "source": "config",
+                "config_key": "defaults.code.web_search_model",
+            },
+        }
+        sess = self._mk(command="code", resolved_models=selection)
+        S.save(sess)
+        self.assertEqual(S.load(sess.id, "code").resolved_models, selection)
+
+        old = sess.to_envelope()
+        old.pop("resolved_models")
+        self.assertEqual(S.Session.from_envelope(old).resolved_models, {})
+        old["resolved_models"] = ["not", "a", "mapping"]
+        self.assertEqual(S.Session.from_envelope(old).resolved_models, {})
+
     def test_save_rejects_non_finite_usage_without_replacing_destination(self):
         sess = self._mk()
         path = S.save(sess)

--- a/tests/test_web_search.py
+++ b/tests/test_web_search.py
@@ -10,6 +10,7 @@ Reuses the fake OpenAI helpers from `tests.test_chat`.
 """
 import argparse
 import io
+import json
 import os
 import sys
 import tempfile
@@ -397,7 +398,7 @@ class TestWebSearchWiring(unittest.TestCase):
         self.tmp = os.path.realpath(tempfile.mkdtemp())
         self.addCleanup(lambda: __import__("shutil").rmtree(self.tmp, ignore_errors=True))
 
-    def _run(self, args, seq, config=None):
+    def _run(self, args, seq, config=None, stdout=None, stderr=None):
         from venice.commands import code
         fake, calls = _fake_openai_seq(seq)
         stdin = mock.MagicMock()
@@ -413,8 +414,8 @@ class TestWebSearchWiring(unittest.TestCase):
              mock.patch("venice.client.urllib.request.urlopen", _urlopen_ok()), \
              mock.patch("openai.OpenAI", return_value=fake), \
              mock.patch.object(sys, "stdin", stdin), \
-             mock.patch.object(sys, "stdout", io.StringIO()), \
-             mock.patch.object(sys, "stderr", io.StringIO()):
+             mock.patch.object(sys, "stdout", stdout or io.StringIO()), \
+             mock.patch.object(sys, "stderr", stderr or io.StringIO()):
             rc = code._run(args)
         return rc, calls
 
@@ -439,6 +440,37 @@ class TestWebSearchWiring(unittest.TestCase):
             config={"code": {"web_search": True}})
         self.assertEqual(rc, 0)
         self.assertIn(_agent.WEB_SEARCH_TOOL_NAME, calls[0]["messages"][0]["content"])
+
+    def test_unknown_config_model_fails_before_a_completion_with_recovery(self):
+        err = io.StringIO()
+        rc, calls = self._run(
+            _code_args(task="do x", root=self.tmp, plan_only=True, web_search=True),
+            [], config={"code": {"web_search_model": "retired-searcher"}},
+            stderr=err,
+        )
+        self.assertEqual(rc, 6)
+        self.assertEqual(calls, [])
+        self.assertIn("unknown web-search model 'retired-searcher'", err.getvalue())
+        self.assertIn(
+            "venice config unset defaults.code.web_search_model", err.getvalue(),
+        )
+
+    def test_plan_json_records_the_resolved_web_search_model(self):
+        out, err = io.StringIO(), io.StringIO()
+        rc, calls = self._run(
+            _code_args(
+                task="do x", root=self.tmp, plan_only=True, json=True,
+                web_search=True,
+            ),
+            list(self._PLAN), stdout=out, stderr=err,
+        )
+        self.assertEqual(rc, 0)
+        self.assertEqual(len(calls), 1)
+        self.assertEqual(json.loads(out.getvalue())["resolved_models"], {
+            "web_search": {"id": "llama-3.3-70b", "source": "auto"},
+        })
+        self.assertIn("web-search model: llama-3.3-70b (source: auto)",
+                      err.getvalue())
 
     def test_web_search_with_scout_makes_a_docs_scout(self):
         # Both the parent web tool AND the scout are advertised; the scout carries the


### PR DESCRIPTION
## Summary

- validate enabled review and web-search model ids against the live text catalog before any paid completion
- fail early for known reviewer/web-search capability mismatches while preserving attempt-anyway behavior when catalog metadata is unavailable
- report flag/config/auto provenance on stderr and in `resolved_models` for code JSON and saved sessions
- name exact stale config keys with `venice config unset` recovery guidance

## Validation

- `VENICE_API_KEY=test-fake-key make test` (1,822 tests)
- `VENICE_API_KEY=test-fake-key make drive` (40 tests)
- `make lint`
- `make scan`
- `make openapi-check`
- isolated package build + strict twine checks
- dependency-free base-wheel smoke
- `git diff --check`

No live Venice API calls were made.

Closes #103
