### PR TITLE
fix(agent): make resume accounting model-aware

### DIFF
--- a/README.md
+++ b/README.md
@@ -625,8 +625,8 @@ catalog), `/models` (list the available models, marking the current and the
 default), `/auto` and `/manual` (toggle auto-accepting paid/side-effecting tool
 calls for following turns), `/compact [N]` (summarize older history into one
 message, keeping the last `N` turns verbatim),
-`/cost` (this session's estimated spend so far, with the cache hit rate on the
-same line; `--session-max-spend` adds a
+`/cost` (this session's estimated spend so far, with the active model's
+current-run cache hit rate on the same line; `--session-max-spend` adds a
 cap), `/usage` (a token + cost breakdown for the session, keeping the
 cache-read/cache-write/uncached input split distinct so cache-heavy sessions
 cost out correctly — the split and the hit rate report `n/a` when the model's
@@ -637,8 +637,9 @@ governs `/cost` and both run footers — plus a
 for the time the CLI kept you waiting, measured from submitting a turn to
 getting the prompt back, so thinking time at the prompt is never counted; it
 accumulates across `--resume` — plus a **per-API-call trace** with a row per model
-call and a marker wherever compaction moved the prefix, which is what tells a cache
-that was cold from the start apart from one that decayed or is sawtoothing),
+call and a marker wherever compaction or a resume reseed moved the prefix, plus
+cumulative and current-run rows per model — which keeps a model switch or resume
+from averaging two unrelated cache histories together),
 `/reset` (clear history, keep the system prompt),
 `/save [file]` (write the transcript JSON; defaults to the `--resume` file),
 `/paste` (compose a multi-line message a line at a time, ending with `/end` —
@@ -705,6 +706,12 @@ for back-compat (it's imported into a fresh session, leaving the file untouched)
 Pass `--ephemeral` (alias `--no-save`) to run without persisting a session (which
 also makes the run unsteerable). `/save [file]` remains an explicit, separate
 transcript export.
+
+`venice code` rebuilds its root/tool-aware system prompt on resume. If those live
+instructions differ from the stored prompt, it keeps the live sandbox accurate,
+prints `code: resumed with a different system prompt; prompt cache will be cold`,
+and records a `resume_reseed` marker in `usage.context_events`. Prompt text and
+hashes are not copied into the usage record.
 
 #### Mid-run steering (`venice sessions send`)
 
@@ -1308,24 +1315,26 @@ always carry a `usage` blob in their session file — previously only
 `--session-max-spend` runs metered at all.
 
 **Watching the cache.** A prompt-cache collapse is a silent 3-5× cost event, so the
-hit rate rides that same footer (and `/cost`), not just `/usage`. It reports `cache
-n/a` when the model's usage block carried no cache fields at all — a printed
-percentage always means the provider measured something. The machine-readable half
-is `usage.cache_hit_percent`, a number 0-100 or `null`, in both the `--json` envelope
-and the session file:
+active model's current-run hit rate rides that same footer (and `/cost`), not just
+`/usage`. It reports `cache n/a` when the model's usage block carried no cache fields
+at all — a printed percentage always means the provider measured something. The
+machine-readable model dimensions are `usage.models` (cumulative session usage) and
+`usage.current_run_models` (only this process/resume leg), both keyed by exact model
+id. Each row carries `cache_hit_percent`, token/cost counters, reporting flags, and
+the main-loop API-call count:
 
 ```sh
-venice code --json "..." | jq '.usage.cache_hit_percent'
-jq -r '[input_filename, (.usage.cache_hit_percent|tostring)] | @tsv' \
-  ~/.config/venice/sessions/*.json      # date a regression across past runs
+venice code --json "..." | jq '.usage.current_run_models'
+jq '.usage.models' ~/.config/venice/sessions/<id>.json
 ```
 
-If you alert on that number, gate the alert on `.usage.cache_read_unreported` being
-`false`. A run where only *some* turns reported their cache fields yields a real but
-understated percentage, and the human line marks it `[partially unreported]` while the
-JSON does not — so an unguarded `cache_hit_percent < 50` pages you for a provider that
-merely went quiet. `VENICE_USAGE_RAW=1` dumps each response's raw `usage` block to
-stderr when you need to see which turns those were.
+The legacy top-level counters and `usage.cache_hit_percent` remain cumulative for
+JSON compatibility and as the `--session-max-spend` authority; do not use that
+cross-model percentage for cache forensics. Alert on a row under
+`current_run_models` and gate on that row's `cache_read_unreported` being `false`.
+A partially reported row is marked `[partially unreported]` in human output.
+`VENICE_USAGE_RAW=1` dumps each response's raw `usage` block to stderr when you need
+to see which turns those were.
 
 **Where the time went.** "The model is slow" and "my test suite is slow" call for
 completely different responses, so the wall figure carries a tool-time clause —
@@ -1409,14 +1418,17 @@ dispatches tools makes several API calls. The machine-readable half is
 
 ```sh
 # every call's hit rate, in order -- null means the provider reported nothing
-venice code --json "..." | jq '.usage.api_calls[] | {n, prompt_tokens, cache_read_tokens}'
+venice code --json "..." | jq '.usage.api_calls[] | {n, model, prompt_tokens, cache_read_tokens}'
 # did compaction fire, and what did it cost the prefix?
 jq '.usage.context_events' ~/.config/venice/sessions/<id>.json
 ```
 
 Rows are capped at the first 50 plus the most recent 200, so a long session keeps
 both its cold-start evidence and its current state; each row carries its `n`, so a
-jump in the sequence is itself the drop marker.
+jump in the sequence is itself the drop marker. Sessions saved before model-aware
+accounting are attributed to their saved session model when one is available; an
+import with no model provenance retains its cumulative totals without inventing a
+model bucket.
 
 `venice code` also watches that trace for the narrow total-collapse case. Once the
 selected model advertises `pricing.cache_input`, API call 2 or later has at least

--- a/src/venice/commands/_agent.py
+++ b/src/venice/commands/_agent.py
@@ -232,6 +232,71 @@ def _as_float(v) -> float:
     return 0.0
 
 
+_MODEL_USAGE_NUMERIC_FIELDS = (
+    "total",
+    "prompt_tokens",
+    "completion_tokens",
+    "cache_read_tokens",
+    "cache_write_tokens",
+    "reasoning_tokens",
+    "api_calls_total",
+)
+_MODEL_USAGE_FLAG_FIELDS = (
+    "unpriced",
+    "cache_read_unreported",
+    "cache_write_unreported",
+)
+
+
+def _new_model_usage_row() -> dict:
+    """One model's main-loop usage counters (#104)."""
+    return {
+        "total": 0.0,
+        "prompt_tokens": 0,
+        "completion_tokens": 0,
+        "cache_read_tokens": 0,
+        "cache_write_tokens": 0,
+        "reasoning_tokens": 0,
+        "api_calls_total": 0,
+        "unpriced": False,
+        "cache_read_unreported": False,
+        "cache_write_unreported": False,
+    }
+
+
+def _restore_model_usage_row(dest: dict, source) -> None:
+    """Add a tolerant persisted model row into ``dest`` (#104)."""
+    if not isinstance(source, dict):
+        return
+    dest["total"] += _as_float(source.get("total"))
+    for key in _MODEL_USAGE_NUMERIC_FIELDS[1:]:
+        dest[key] += _as_int(source.get(key))
+    for key in _MODEL_USAGE_FLAG_FIELDS:
+        if source.get(key):
+            dest[key] = True
+
+
+def _model_cache_hit_percent(row, *, round_to=None):
+    """A model row's three-state cache hit percentage (#104)."""
+    if not isinstance(row, dict):
+        return None
+    prompt = _as_int(row.get("prompt_tokens"))
+    cached = _as_int(row.get("cache_read_tokens"))
+    if prompt == 0:
+        return None
+    if row.get("cache_read_unreported") and cached == 0:
+        return None
+    pct = cached / prompt * 100.0
+    return pct if round_to is None else round(pct, round_to)
+
+
+def _public_model_usage_row(row) -> dict:
+    """Copy one model row and add its derived cache percentage (#104)."""
+    out = dict(row) if isinstance(row, dict) else _new_model_usage_row()
+    out["cache_hit_percent"] = _model_cache_hit_percent(out, round_to=1)
+    return out
+
+
 def _detail(usage: dict, section: str, key: str):
     """A nested usage sub-field (e.g. ``prompt_tokens_details.cached_tokens``).
 
@@ -370,7 +435,7 @@ class CostLedger:
 
     def __init__(self, max_spend: Optional[float] = None,
                  max_tokens: Optional[int] = None, *, mirror=None,
-                 cache_guard: str = "off"):
+                 cache_guard: str = "off", model_id=None, models=None):
         # A non-positive cap means "uncapped" (mirrors --max-tool-calls 0).
         cap = _numeric.finite_float(max_spend) if max_spend is not None else None
         self.max_spend = cap if (cap is not None and cap > 0) else None
@@ -389,6 +454,15 @@ class CostLedger:
         # is still live.
         self.cache_guard = cache_guard
         self._cache_guard_fired = False
+        self._cache_guard_fired_models = set()
+        # #104: production ledgers are bound to an exact model id and retain the
+        # catalog so `/model` can atomically switch both routing and pricing. Bare
+        # ledgers remain supported for focused tests and internal callers.
+        self.model_id = None
+        self._models = models
+        self.models: Dict[str, dict] = {}
+        # Never restored: this is the current process/resume leg, not session history.
+        self.current_run_models: Dict[str, dict] = {}
         self.total = 0.0
         self.prompt_tokens = 0
         self.completion_tokens = 0
@@ -503,6 +577,8 @@ class CostLedger:
         self._cache_in = None    # per-token cache-read rate (USD); None -> use _in
         self._cache_write = None  # per-token cache-write rate (USD); None -> use _in
         self.invalid_pricing = False
+        if model_id is not None:
+            self.bind_model(model_id, models)
 
     def bind_pricing(self, pricing) -> None:
         """Set the per-token rates from a catalog `model_spec.pricing` block.
@@ -519,6 +595,15 @@ class CostLedger:
         except ValueError:
             self._in = self._out = self._cache_in = self._cache_write = None
             self.invalid_pricing = True
+
+    def bind_model(self, model_id, models=None) -> None:
+        """Select the active model and atomically rebind its catalog pricing (#104)."""
+        if models is not None:
+            self._models = models
+        self.model_id = str(model_id) if model_id is not None else None
+        # Always bind, including the missing-price case, so switching away from a
+        # priced model cannot accidentally retain the previous model's rates.
+        self.bind_pricing(_pricing_for(self._models, self.model_id))
 
     def to_dict(self) -> dict:
         """Serialize the running accumulators for cross-resume persistence (#47/#75).
@@ -578,9 +663,18 @@ class CostLedger:
             # `json.dump` while the ledger is still live -- cannot reach back in here.
             "api_calls": [dict(r) for r in self.api_calls()],
             "context_events": [dict(e) for e in self.context_events],
+            # #104: additive public dimensions. `models` is cumulative session usage;
+            # `current_run_models` begins empty after every restore.
+            "models": {
+                k: _public_model_usage_row(self.models[k]) for k in sorted(self.models)
+            },
+            "current_run_models": {
+                k: _public_model_usage_row(self.current_run_models[k])
+                for k in sorted(self.current_run_models)
+            },
         }
 
-    def restore(self, d) -> None:
+    def restore(self, d, *, legacy_model=None) -> None:
         """Seed the accumulators from a :meth:`to_dict` snapshot (resume, #47).
 
         Additive onto the current (freshly-priced) ledger so a session resumed
@@ -590,6 +684,11 @@ class CostLedger:
         """
         if not isinstance(d, dict):
             return
+        # A restore is the boundary between process legs. These diagnostics must never
+        # inherit the previous leg, even if a caller reuses a ledger object.
+        self.current_run_models.clear()
+        self._cache_guard_fired_models.clear()
+        self._cache_guard_fired = False
         self.total += _as_float(d.get("total"))
         self.prompt_tokens += _as_int(d.get("prompt_tokens"))
         self.completion_tokens += _as_int(d.get("completion_tokens"))
@@ -685,10 +784,13 @@ class CostLedger:
                 for row in raw_calls:
                     if not isinstance(row, dict):
                         continue  # tolerant PER ROW, like `tools` above
+                    row = dict(row)
+                    if legacy_model and not row.get("model"):
+                        row["model"] = str(legacy_model)
                     if len(self._calls_head) < self._CALLS_HEAD:
-                        self._calls_head.append(dict(row))
+                        self._calls_head.append(row)
                     else:
-                        self._calls_tail.append(dict(row))
+                        self._calls_tail.append(row)
         if not self.context_events:
             raw_events = d.get("context_events")
             if isinstance(raw_events, list):
@@ -706,6 +808,29 @@ class CostLedger:
         self.api_calls_total = max(
             self.api_calls_total, len(self._calls_head) + len(self._calls_tail)
         )
+        # #104: new envelopes carry exact model buckets. Older envelopes are attributed
+        # to the session's SAVED model (passed by the REPL), never to a command-line
+        # override selected for the new leg. If provenance is unavailable the aggregate
+        # above remains authoritative and no model id is invented.
+        raw_models = d.get("models")
+        if isinstance(raw_models, dict):
+            for model, row in raw_models.items():
+                key = str(model).strip()
+                if not key or not isinstance(row, dict):
+                    continue
+                _restore_model_usage_row(
+                    self.models.setdefault(key, _new_model_usage_row()), row
+                )
+        elif legacy_model:
+            _restore_model_usage_row(
+                self.models.setdefault(str(legacy_model), _new_model_usage_row()),
+                {
+                    key: d.get(key)
+                    for key in _MODEL_USAGE_NUMERIC_FIELDS + _MODEL_USAGE_FLAG_FIELDS
+                },
+            )
+        # Deliberately ignore persisted `current_run_models`: a resume starts a fresh
+        # diagnostic leg while the cumulative `models` map above survives.
 
     def record_turn(self, seconds) -> None:
         """Add one blocked window's wall-clock and count the turn (#81).
@@ -791,8 +916,8 @@ class CostLedger:
         """How many trace rows the cap discarded (#99); 0 when nothing was dropped."""
         return self.api_calls_total - len(self._calls_head) - len(self._calls_tail)
 
-    def record_compaction(self, event: dict) -> None:
-        """Log one prefix-affecting event, anchored to the trace (#99).
+    def record_context_event(self, event: dict) -> None:
+        """Log one context-affecting event, anchored to the trace (#99/#104).
 
         `after_n` is the ordinal of the last call recorded BEFORE the event, so the
         measured post-compaction prompt size is simply the next row's `prompt_tokens` --
@@ -808,6 +933,10 @@ class CostLedger:
             after_n=self.api_calls_total,
             **row,
         ))
+
+    def record_compaction(self, event: dict) -> None:
+        """Compatibility wrapper for the compaction worker's duck-typed hook."""
+        self.record_context_event(dict(event, kind="compaction"))
 
     def record_bucket(self, name: str, *, cost: float = 0.0,
                       prompt_tokens: int = 0, completion_tokens: int = 0,
@@ -940,6 +1069,31 @@ class CostLedger:
         """
         return self.total + self.bucket_cost()
 
+    def _record_model_usage(self, *, usage_present: bool, cost: float,
+                            prompt_tokens: int, completion_tokens: int,
+                            cache_read_tokens: int, cache_write_tokens: int,
+                            reasoning_tokens: int, cache_read_reported: bool,
+                            cache_write_reported: bool, unpriced: bool) -> None:
+        """Accumulate one main-loop call into both #104 model views."""
+        if not self.model_id:
+            return
+        for rows in (self.models, self.current_run_models):
+            row = rows.setdefault(self.model_id, _new_model_usage_row())
+            row["api_calls_total"] += 1
+            if not usage_present:
+                continue
+            row["total"] += cost
+            row["prompt_tokens"] += prompt_tokens
+            row["completion_tokens"] += completion_tokens
+            row["cache_read_tokens"] += cache_read_tokens
+            row["cache_write_tokens"] += cache_write_tokens
+            row["reasoning_tokens"] += min(reasoning_tokens, completion_tokens)
+            row["unpriced"] = row["unpriced"] or unpriced
+            if not cache_read_reported:
+                row["cache_read_unreported"] = True
+            if not cache_write_reported:
+                row["cache_write_unreported"] = True
+
     def record(self, usage, *, seconds=None, bucket=None) -> float:
         """Add one turn's `usage` (dict or SDK obj); return this turn's cost.
 
@@ -995,6 +1149,7 @@ class CostLedger:
         # prefix, so it gets a row -- with null tokens rather than a fabricated 0, the
         # #98 rule applied one level down.
         pt = ct = raw_read = raw_write = None
+        cache_read = cache_write = reasoning = 0
         if usage is not None:
             pt = _as_int(usage.get("prompt_tokens"))
             ct = _as_int(usage.get("completion_tokens"))
@@ -1050,6 +1205,19 @@ class CostLedger:
             if bucket is None:
                 self.unpriced = unpriced_turn or self.unpriced
                 self.total += cost
+        if bucket is None:
+            self._record_model_usage(
+                usage_present=usage is not None,
+                cost=cost,
+                prompt_tokens=_as_int(pt),
+                completion_tokens=_as_int(ct),
+                cache_read_tokens=cache_read,
+                cache_write_tokens=cache_write,
+                reasoning_tokens=reasoning,
+                cache_read_reported=raw_read is not None,
+                cache_write_reported=raw_write is not None,
+                unpriced=unpriced_turn,
+            )
         # The two landing sites are structurally exclusive, and the method still has
         # exactly ONE return: an off-loop call must NOT get a trace row, and a main-loop
         # call must get one on every path including the no-usage shapes. An early return
@@ -1067,7 +1235,7 @@ class CostLedger:
                 unpriced=unpriced_turn, unreported=usage is None,
             )
         else:
-            self._append_call({
+            call = {
                 "prompt_tokens": pt,
                 "cache_read_tokens": raw_read,
                 # Recorded although #99 only asked for cache-READ: a cache-WRITE spike at
@@ -1079,7 +1247,10 @@ class CostLedger:
                 # Rounded like `record_turn`'s, so the persisted envelope stays tidy.
                 # None stays None -- an unstamped window is unknown, not instant.
                 "seconds": None if seconds is None else round(_as_float(seconds), 3),
-            })
+            }
+            if self.model_id:
+                call["model"] = self.model_id
+            self._append_call(call)
         # #117: a SUBAGENT ledger also banks this call into its parent's off-loop bucket.
         # Placed at the one chokepoint every rail's usage already flows through, so the
         # two rails that call the API outside `run_loop` (`_review._retry_for_verdict`,
@@ -1122,22 +1293,36 @@ class CostLedger:
         Missing pricing cannot support either the "advertised" claim or the estimated
         missed discount. Invalid pricing is handled earlier by ``invalid_pricing``.
         """
-        if self.cache_guard == "off" or self._cache_guard_fired:
+        if self.cache_guard == "off":
             return None
+        bound_model = self.model_id or model
+        if self.model_id:
+            if bound_model in self._cache_guard_fired_models:
+                return None
+            model_calls = _as_int(
+                self.current_run_models.get(bound_model, {}).get("api_calls_total")
+            )
+        else:
+            if self._cache_guard_fired:
+                return None
+            model_calls = self.api_calls_total
         rows = self.api_calls()
         if not rows or self._in is None or self._cache_in is None:
             return None
         row = rows[-1]
         prompt_tokens = row.get("prompt_tokens")
         if (
-            row.get("n", 0) < 2
+            model_calls < 2
             or not isinstance(prompt_tokens, int)
             or prompt_tokens < CACHE_GUARD_MIN_PROMPT_TOKENS
             or row.get("cache_read_tokens") != 0
         ):
             return None
 
-        self._cache_guard_fired = True
+        if self.model_id:
+            self._cache_guard_fired_models.add(bound_model)
+        else:
+            self._cache_guard_fired = True
         if self._cache_in == 0:
             advertised = "free cache input"
         elif self._in <= self._cache_in:
@@ -1149,7 +1334,7 @@ class CostLedger:
         amount = f"${missed:.4f}" if missed < 1 else f"${missed:.2f}"
         return CacheGuardEvent(
             self.cache_guard,
-            f"cache: {model} advertises {advertised} but returned 0 cached "
+            f"cache: {bound_model} advertises {advertised} but returned 0 cached "
             f"tokens on API call {row['n']}; this run is paying full input price "
             f"(est. +{amount} so far)",
         )
@@ -1208,15 +1393,59 @@ class CostLedger:
         Vocabulary is `usage_report`'s verbatim -- an operator can run `/cost` and
         `/usage` seconds apart, and two words for one state reads as two states.
         """
-        pct = self.cache_hit_percent()
+        row = self.current_run_models.get(self.model_id) if self.model_id else None
+        if self.model_id and row is None:
+            return ""
+        pct = (_model_cache_hit_percent(row) if row is not None
+               else self.cache_hit_percent())
+        unreported = (bool(row.get("cache_read_unreported")) if row is not None
+                      else self.cache_read_unreported)
         if pct is None:
             # Distinguish "the provider never told us" (worth saying on a run footer --
             # it is the difference between a cache collapse and a blind spot) from
             # "nothing was recorded", which has nothing to report at all.
-            return "cache n/a" if self.cache_read_unreported else ""
-        if self.cache_read_unreported:
+            return "cache n/a" if unreported else ""
+        if unreported:
             return f"cache {pct:.1f}% hit [partially unreported]"
         return f"cache {pct:.1f}% hit"
+
+    @staticmethod
+    def _model_usage_lines_for(title: str, rows: dict) -> List[str]:
+        """Render one bounded per-model accounting section (#104)."""
+        if not rows:
+            return []
+        lines = [f"  {title}:"]
+        for model in sorted(rows):
+            row = rows[model] if isinstance(rows[model], dict) else {}
+            pct = _model_cache_hit_percent(row)
+            if pct is None:
+                cache = (
+                    "n/a (no cache fields reported)"
+                    if row.get("cache_read_unreported")
+                    else "n/a (no input tokens)"
+                )
+            elif row.get("cache_read_unreported"):
+                cache = f"{pct:.1f}% [partially unreported]"
+            else:
+                cache = f"{pct:.1f}%"
+            cost = _as_float(row.get("total"))
+            money = "unpriced" if row.get("unpriced") and not cost else f"${cost:.4f}"
+            lines.append(
+                f"    {model}: {_as_int(row.get('prompt_tokens')):,} in, "
+                f"{_as_int(row.get('completion_tokens')):,} out, "
+                f"cache hit rate: {cache}, {money}, "
+                f"{_as_int(row.get('api_calls_total'))} call(s)"
+            )
+        return lines
+
+    def _model_usage_lines(self) -> List[str]:
+        """Cumulative and current-resume-leg model views (#104)."""
+        return (
+            self._model_usage_lines_for("models (session)", self.models)
+            + self._model_usage_lines_for(
+                "models (current run)", self.current_run_models
+            )
+        )
 
     def summary(self, *, cache: bool = False) -> str:
         """A one-line human-readable total (for stderr / --json).
@@ -1348,6 +1577,7 @@ class CostLedger:
                 # real spend that the token counters above cannot account for.
                 + (self._cost_lines() if self.billed_total() > 0 else [])
                 + ([self._timing_line()] if self.turns else [])
+                + self._model_usage_lines()
                 + self._tool_lines() + self._call_lines() + self._bucket_lines()
             )
         uncached = self.prompt_tokens - self.cache_read_tokens - self.cache_write_tokens
@@ -1376,7 +1606,9 @@ class CostLedger:
         # #100: the rate itself comes from `cache_hit_percent` so `/usage`, `/cost` and
         # both run footers cannot drift apart on what "unknown" means.
         hit = self.cache_hit_percent()
-        if hit is None:
+        if self.models:
+            lines.append("  cache hit rate: see per-model breakdown")
+        elif hit is None:
             # Two distinct unknowns. `no input tokens` is only reachable past the
             # early-return above with completion tokens but no prompt tokens -- which
             # `restore()` can seed from a partial envelope, since (unlike `record`) it
@@ -1392,6 +1624,7 @@ class CostLedger:
         else:
             lines.append(f"  cache hit rate: {hit:.1f}%")
         lines.extend(self._cost_lines())
+        lines.extend(self._model_usage_lines())
         if self.turns:  # #81
             lines.append(self._timing_line())
         lines.extend(self._tool_lines())  # #82 -- own gate; see `_tool_lines`
@@ -1659,6 +1892,11 @@ class CostLedger:
     @staticmethod
     def _event_lines(ev: dict) -> List[str]:
         """The one-or-two-line `/usage` marker for a context event (#99)."""
+        if ev.get("kind") == "resume_reseed":
+            return [
+                "    -- system prompt reseeded on resume "
+                f"after #{ev.get('after_n', '?')}; cache prefix is cold"
+            ]
         out = [f"    -- compacted ({ev.get('trigger', 'auto')}) "
                f"after #{ev.get('after_n', '?')}: "
                f"{ev.get('messages_before', '?')} -> {ev.get('messages_after', '?')} msgs, "
@@ -1727,14 +1965,10 @@ def _build_ledger(cap, models, model_id, *, max_tokens=None,
     "look this model up in the catalog", and a second site would be a second place
     to forget the lookup (which is how every rail ended up unpriced before #117).
     """
-    ledger = CostLedger(
+    return CostLedger(
         max_spend=cap, max_tokens=max_tokens, mirror=mirror,
-        cache_guard=cache_guard,
+        cache_guard=cache_guard, model_id=model_id, models=models,
     )
-    pricing = _pricing_for(models, model_id)
-    if pricing is not None:
-        ledger.bind_pricing(pricing)
-    return ledger
 
 
 def ledger_from_args(args, models, model_id) -> Optional[CostLedger]:

--- a/src/venice/commands/_repl.py
+++ b/src/venice/commands/_repl.py
@@ -517,6 +517,9 @@ def _dispatch_slash(line, messages, state, args, models, oai=None, gen_kwargs=No
             if rc is not None:
                 pass  # resolve_model printed why; keep the current model
             else:
+                ledger = state.get("ledger")
+                if ledger is not None:
+                    ledger.bind_model(new, models)
                 state["model"] = new
                 if state["tools_on"] and (
                     _agent.supports_function_calling(models, new) is False
@@ -660,7 +663,17 @@ def run(args, oai, openai, client, models, model, initial=None, *,
         gen_kwargs = _session.merge_gen_kwargs(session.gen_kwargs, gen_kwargs)
     # `venice code` rebuilds its system prompt against the live root each launch, so
     # on resume replace the persisted (stale) leading system message with the fresh one.
+    resume_reseeded = False
     if system_reseed and getattr(args, "system", None):
+        resume_reseeded = (
+            session is not None and _current_system(messages) != args.system
+        )
+        if resume_reseeded:
+            print(
+                f"{_session.command_from_label(label)}: resumed with a different "
+                "system prompt; prompt cache will be cold",
+                file=sys.stderr,
+            )
         _set_system(messages, args.system)
 
     # `--tools`/`--mcp` (or an injected `tools_session`) turns the REPL into an
@@ -710,7 +723,9 @@ def run(args, oai, openai, client, models, model, initial=None, *,
         # Carry usage across resume (#47/#75): seed the fresh, currently-priced
         # ledger with the saved totals so `/usage` and `/cost` are cumulative.
         if session is not None and session.usage:
-            state["ledger"].restore(session.usage)
+            state["ledger"].restore(session.usage, legacy_model=session.model)
+        if resume_reseeded:
+            state["ledger"].record_context_event({"kind": "resume_reseed"})
 
         # The active session (#47): the resumed one, or a freshly minted one.
         # --ephemeral means persist nothing -- so no active session at all, even on

--- a/tests/test_agent.py
+++ b/tests/test_agent.py
@@ -520,6 +520,139 @@ class TestCostLedger(unittest.TestCase):
         self.assertEqual(L._in, 2.0 / 1e6)
         self.assertIsNone(L._out)  # no output price advertised
 
+    def test_model_switch_rebinds_pricing_and_partitions_usage(self):
+        models = [
+            {"id": "author", "model_spec": {"pricing": {
+                "input": {"usd": 1.0}, "output": {"usd": 2.0},
+            }}},
+            {"id": "reviewer", "model_spec": {"pricing": {
+                "input": {"usd": 10.0}, "output": {"usd": 20.0},
+            }}},
+        ]
+        args = type("A", (), {"session_max_spend": None})()
+        ledger = _agent.usage_ledger(args, models, "author")
+        ledger.record({"prompt_tokens": 1000, "completion_tokens": 100})
+        ledger.bind_model("reviewer", models)
+        ledger.record({"prompt_tokens": 1000, "completion_tokens": 100})
+
+        self.assertAlmostEqual(ledger.total, 0.0012 + 0.012)
+        self.assertAlmostEqual(ledger.models["author"]["total"], 0.0012)
+        self.assertAlmostEqual(ledger.models["reviewer"]["total"], 0.012)
+        self.assertEqual(
+            [row["model"] for row in ledger.api_calls()], ["author", "reviewer"]
+        )
+
+    def test_resume_keeps_cumulative_models_but_resets_current_run(self):
+        models = [{"id": "m", "model_spec": {"pricing": {
+            "input": {"usd": 1.0}, "cache_input": {"usd": 0.1},
+        }}}]
+        args = type("A", (), {"session_max_spend": 1.0})()
+        first = _agent.usage_ledger(args, models, "m")
+        first.record({
+            "prompt_tokens": 100, "completion_tokens": 10,
+            "prompt_tokens_details": {"cached_tokens": 90},
+        })
+
+        resumed = _agent.usage_ledger(args, models, "m")
+        resumed.restore(first.to_dict(), legacy_model="m")
+        self.assertEqual(resumed.current_run_models, {})
+        resumed.record({
+            "prompt_tokens": 50, "completion_tokens": 5,
+            "prompt_tokens_details": {"cached_tokens": 0},
+        })
+
+        self.assertEqual(resumed.prompt_tokens, 150)
+        self.assertEqual(resumed.models["m"]["prompt_tokens"], 150)
+        self.assertEqual(resumed.current_run_models["m"]["prompt_tokens"], 50)
+        self.assertEqual(
+            resumed.to_dict()["current_run_models"]["m"]["cache_hit_percent"],
+            0.0,
+        )
+        # The footer's cache clause is current-run, not the blended session rate.
+        self.assertIn("cache 0.0% hit", resumed.summary(cache=True))
+
+    def test_legacy_usage_is_attributed_to_saved_not_overridden_model(self):
+        models = [{"id": "old", "model_spec": {}},
+                  {"id": "new", "model_spec": {}}]
+        args = type("A", (), {"session_max_spend": None})()
+        ledger = _agent.usage_ledger(args, models, "new")
+        ledger.restore(
+            {"prompt_tokens": 25, "completion_tokens": 2, "api_calls_total": 1},
+            legacy_model="old",
+        )
+        self.assertEqual(ledger.model_id, "new")
+        self.assertEqual(ledger.models["old"]["prompt_tokens"], 25)
+        self.assertNotIn("new", ledger.models)
+        self.assertEqual(ledger.current_run_models, {})
+
+    def test_model_restore_tolerates_junk_and_never_restores_current_run(self):
+        ledger = _agent.CostLedger(model_id="live", models=[])
+        ledger.current_run_models["preexisting"] = _agent._new_model_usage_row()
+        ledger.restore({
+            "models": {
+                "good": {"prompt_tokens": 7, "cache_read_tokens": 3},
+                "bad": "not a row",
+                "": {"prompt_tokens": 99},
+            },
+            "current_run_models": {
+                "stale": {"prompt_tokens": 1000},
+            },
+        })
+        self.assertEqual(ledger.models["good"]["prompt_tokens"], 7)
+        self.assertEqual(set(ledger.models), {"good"})
+        self.assertEqual(ledger.current_run_models, {})
+
+    def test_switch_from_valid_to_invalid_pricing_fails_closed(self):
+        models = [
+            {"id": "good", "model_spec": {"pricing": {
+                "input": {"usd": 1.0},
+            }}},
+            {"id": "bad", "model_spec": {"pricing": {
+                "input": {"usd": float("inf")},
+            }}},
+        ]
+        ledger = _agent.CostLedger(max_spend=1.0, model_id="good", models=models)
+        self.assertFalse(ledger.invalid_pricing)
+        ledger.bind_model("bad", models)
+        self.assertTrue(ledger.invalid_pricing)
+        self.assertTrue(ledger.over())
+
+    def test_legacy_trace_rows_gain_only_known_saved_model_provenance(self):
+        with_model = _agent.CostLedger()
+        with_model.restore(
+            {"api_calls": [{"n": 1}], "api_calls_total": 1},
+            legacy_model="saved",
+        )
+        self.assertEqual(with_model.api_calls()[0]["model"], "saved")
+
+        unknown = _agent.CostLedger()
+        unknown.restore({"api_calls": [{"n": 1}], "api_calls_total": 1})
+        self.assertNotIn("model", unknown.api_calls()[0])
+
+    def test_model_cache_guard_is_independent_after_a_switch(self):
+        pricing = {"input": {"usd": 3.0}, "cache_input": {"usd": 0.3}}
+        models = [
+            {"id": "a", "model_spec": {"pricing": pricing}},
+            {"id": "b", "model_spec": {"pricing": pricing}},
+        ]
+        args = type("A", (), {
+            "session_max_spend": None, "cache_guard": "warn",
+        })()
+        ledger = _agent.usage_ledger(args, models, "a")
+        usage = {
+            "prompt_tokens": 3000, "completion_tokens": 1,
+            "prompt_tokens_details": {"cached_tokens": 0},
+        }
+        ledger.record(usage)
+        self.assertIsNone(ledger.cache_guard_event("a"))
+        ledger.record(usage)
+        self.assertIsNotNone(ledger.cache_guard_event("a"))
+        ledger.bind_model("b", models)
+        ledger.record(usage)
+        self.assertIsNone(ledger.cache_guard_event("b"))
+        ledger.record(usage)
+        self.assertIsNotNone(ledger.cache_guard_event("b"))
+
     def test_usage_factory_binds_code_cache_guard_only_when_requested(self):
         models = [{
             "id": "m",

--- a/tests/test_code_command.py
+++ b/tests/test_code_command.py
@@ -845,7 +845,7 @@ class TestCodeCommand(unittest.TestCase):
         self.addCleanup(lambda: __import__("shutil").rmtree(zone, ignore_errors=True))
         return zone, _session
 
-    def _run_interactive(self, args, seq, inputs, zone):
+    def _run_interactive(self, args, seq, inputs, zone, *, stderr=None):
         from venice.commands import code
         fake, calls = _fake_openai_seq(seq)
         stdin = mock.MagicMock()
@@ -857,7 +857,7 @@ class TestCodeCommand(unittest.TestCase):
              mock.patch("builtins.input", side_effect=inputs), \
              mock.patch.object(sys, "stdin", stdin), \
              mock.patch.object(sys, "stdout", io.StringIO()), \
-             mock.patch.object(sys, "stderr", io.StringIO()):
+             mock.patch.object(sys, "stderr", stderr or io.StringIO()):
             rc = code._run(args)
         return rc, calls
 
@@ -874,16 +874,49 @@ class TestCodeCommand(unittest.TestCase):
             _session.save(stale)
         # Resume by id with an explicit --root: the leading system message must be
         # rebuilt against the NEW root, not the persisted stale one.
+        err = io.StringIO()
         rc, calls = self._run_interactive(
             _code_args(resume=stale.id, root=self.root, auto=True),
             [FakeToolCompletion("done")],           # one turn, no tool calls -> ends
-            ["carry on", "/exit"], zone,
+            ["carry on", "/exit"], zone, stderr=err,
         )
         self.assertEqual(rc, 0)
         sysmsg = calls[0]["messages"][0]
         self.assertEqual(sysmsg["role"], "system")
         self.assertIn(self.root, sysmsg["content"])
         self.assertNotIn("/nonexistent/oldroot", sysmsg["content"])
+        self.assertIn(
+            "code: resumed with a different system prompt; prompt cache will be cold",
+            err.getvalue(),
+        )
+        with open(Path(zone) / f"{stale.id}.json") as f:
+            usage = json.load(f)["usage"]
+        self.assertEqual(
+            usage["context_events"][0], {"kind": "resume_reseed", "after_n": 0}
+        )
+        self.assertNotIn("STALE", json.dumps(usage["context_events"]))
+
+    def test_identical_resume_prompt_emits_no_warning_or_event(self):
+        zone, _session = self._mk_zone()
+        rc, _ = self._run_interactive(
+            _code_args(task="first", root=self.root, interactive=True, auto=True),
+            [FakeToolCompletion("done")], ["/exit"], zone,
+        )
+        self.assertEqual(rc, 0)
+        saved = json.loads(next(Path(zone).glob("*.json")).read_text())
+
+        err = io.StringIO()
+        rc2, _ = self._run_interactive(
+            _code_args(resume=saved["id"], root=self.root, auto=True),
+            [], ["/exit"], zone, stderr=err,
+        )
+        self.assertEqual(rc2, 0)
+        self.assertNotIn("prompt cache will be cold", err.getvalue())
+        persisted = json.loads((Path(zone) / f"{saved['id']}.json").read_text())
+        self.assertNotIn(
+            "resume_reseed",
+            [event.get("kind") for event in persisted["usage"]["context_events"]],
+        )
 
     def test_resume_restores_saved_root_when_no_root_flag(self):
         zone, _session = self._mk_zone()

--- a/tests/test_repl.py
+++ b/tests/test_repl.py
@@ -198,6 +198,20 @@ class TestRepl(unittest.TestCase):
         self.assertEqual(rc, 0)
         self.assertEqual(calls[0]["model"], "venice-uncensored")
 
+    def test_slash_model_switch_rebinds_ledger_pricing(self):
+        models = [
+            {"id": "old", "model_spec": {"pricing": {"input": {"usd": 1.0}}}},
+            {"id": "new", "model_spec": {"pricing": {"input": {"usd": 9.0}}}},
+        ]
+        args = _args(interactive=True)
+        ledger = _agent.usage_ledger(args, models, "old")
+        state = {"model": "old", "tools_on": False, "ledger": ledger}
+        with mock.patch.object(sys, "stderr", io.StringIO()):
+            _repl._dispatch_slash("/model new", [], state, args, models)
+        self.assertEqual(state["model"], "new")
+        self.assertEqual(ledger.model_id, "new")
+        self.assertEqual(ledger._in, 9.0 / 1_000_000)
+
     def test_slash_model_unknown_keeps_current(self):
         err = io.StringIO()
         rc, fake, calls = _run_repl(


### PR DESCRIPTION
## Summary
- warn and record a context event when a resumed code session reseeds a changed system prompt
- rebind ledger pricing on model switches and persist cumulative plus current-run per-model usage
- preserve legacy aggregate/session compatibility while attributing old data only when saved-model provenance exists
- make cache diagnostics and cache guards model/run scoped

## Validation
- VENICE_API_KEY=test-fake-key make test (1,831 tests)
- VENICE_API_KEY=test-fake-key make drive (40 tests)
- make lint
- make scan
- git diff --check
- isolated wheel/sdist build, strict twine check, and dependency-free base-wheel smoke

Closes #104