### PR TITLE
v0.83: port MCP transport to SDK 2.x

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,8 +77,9 @@ Extras are per-feature and additive, so the pattern holds as the CLI grows:
 | `venice-cli[mcp]` | MCP server/client transport; needs Python ≥ 3.10, and does not itself provide `[openai]` |
 | `venice-cli[all]` | every extra (`openai` + `mcp`) |
 
-The `[mcp]` extra pulls in the [`mcp`](https://pypi.org/project/mcp/) SDK, which
-requires Python ≥ 3.10. The base CLI still supports 3.9 — on 3.9 the extra
+The `[mcp]` extra pulls in version 2.x of the
+[`mcp`](https://pypi.org/project/mcp/) SDK, which requires Python ≥ 3.10. The
+base CLI still supports 3.9 — on 3.9 the extra
 resolves to nothing and only `venice mcp-serve` and `venice chat --mcp` are
 unavailable.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,17 +49,14 @@ dependencies = []
 
 [project.optional-dependencies]
 openai = ["openai>=1.40"]
-# The MCP server (`venice mcp-serve`) uses the FastMCP server from the `mcp` SDK.
+# The MCP server (`venice mcp-serve`) uses MCPServer from the `mcp` SDK.
 # The SDK requires Python >=3.10, so the dep is gated by an environment marker:
 # on 3.9 the extra resolves to nothing (the CLI stays 3.9-compatible; only this
 # one optional command needs 3.10+). Imported lazily, like the openai extra.
-# Upper-bounded as of 2026-07-29 (#95): mcp 2.0.0, published 2026-07-28, deletes
-# `mcp.server.fastmcp` -- `mcp.server` now exposes `mcpserver` instead. The old
-# unbounded `mcp>=1.2` turned that into a red CI on every branch within the hour,
-# on 3.10-3.14 only (2.0 declares requires-python >=3.10, so the 3.9 job kept
-# resolving 1.x and stayed green). 1.29.0 is the current 1.x and still ships
-# FastMCP. Lift this when `mcp_serve.py` is ported to the 2.x server API.
-mcp = ["mcp>=1.2,<2; python_version>='3.10'"]
+# Keep the major bound explicit: SDK 2.x renamed FastMCP to MCPServer and moved
+# protocol-model attributes to snake_case, so a future major must be reviewed
+# deliberately rather than becoming an ambient resolver break like #95.
+mcp = ["mcp>=2,<3; python_version>='3.10'"]
 # Test-only: `pexpect` drives the real CLI on a pty in tests/test_drive_cli.py.
 # Deliberately NOT in `all` -- `all` is a *runtime* install, and the CI `package`
 # job's "a base install pulls in nothing third-party" proof must stay meaningful.

--- a/src/venice/commands/_agent.py
+++ b/src/venice/commands/_agent.py
@@ -6,7 +6,7 @@ own endpoints as **in-process** function tools and the completion runs in a loop
 the self-contained-agent foundation for the vcoder epic (#25).
 
 Import discipline: this module reuses the print-free `*_tool` primitives in
-``commands._mcp`` but NEVER imports the ``mcp``/FastMCP SDK -- the whole point of
+``commands._mcp`` but NEVER imports the ``mcp``/MCPServer SDK -- the whole point of
 #15 is that the agent loop needs only the ``[openai]`` extra. (`_mcp` is itself
 import-clean, so pulling it in at CLI startup is cheap and mcp-free.)
 

--- a/src/venice/commands/_mcp.py
+++ b/src/venice/commands/_mcp.py
@@ -3,7 +3,7 @@
 Import-clean by design: this module must NOT import `mcp` (or `openai`) at module
 scope, so `venice --help` and the base, stdlib-only install keep working, and the
 tests here run on Python 3.9 where the `mcp` SDK cannot even be installed. The thin
-FastMCP wiring lives in `venice.mcp_server`; everything with real logic lives here:
+MCPServer wiring lives in `venice.mcp_server`; everything with real logic lives here:
 the lazy `import_mcp` probe, the spend gate, the output-dir resolver, and the
 print-free `*_tool` functions the server delegates to.
 

--- a/src/venice/commands/_mcp_client.py
+++ b/src/venice/commands/_mcp_client.py
@@ -10,7 +10,7 @@ changes -- it consumes a `list[Tool]`; we just append more entries.
 Two hard problems shape the design:
 
 1. **Async vs sync.** The `mcp` SDK client (`ClientSession`, `stdio_client`,
-   `streamablehttp_client`, `sse_client`) is entirely async/anyio-based, while
+   `streamable_http_client`, `sse_client`) is entirely async/anyio-based, while
    `run_loop` and the `openai` SDK it drives are synchronous. We bridge with a
    dedicated **background thread running its own asyncio loop**. A single
    "supervisor" coroutine owns every session for the whole `venice chat` (or REPL)
@@ -142,15 +142,15 @@ def _is_side_effecting(annotations) -> bool:
     """
     if annotations is None:
         return True
-    return getattr(annotations, "readOnlyHint", None) is not True
+    return getattr(annotations, "read_only_hint", None) is not True
 
 
 def _translate_result(result) -> dict:
     """Turn an MCP ``CallToolResult`` into the loop's JSON-serializable result dict.
 
-    Joins text blocks; marks (never inlines) non-text content; maps ``isError`` to
+    Joins text blocks; marks (never inlines) non-text content; maps ``is_error`` to
     a ``{"status": "error"}`` dict the model can recover from; carries
-    ``structuredContent`` through when present.
+    ``structured_content`` through when present.
     """
     parts: List[str] = []
     for block in getattr(result, "content", None) or []:
@@ -161,13 +161,13 @@ def _translate_result(result) -> dict:
             btype = getattr(block, "type", None) or type(block).__name__
             parts.append(f"[non-text content: {btype}]")
     joined = "\n".join(parts)
-    is_error = bool(getattr(result, "isError", False))
+    is_error = bool(getattr(result, "is_error", False))
     out: dict = {"status": "error" if is_error else "ok"}
     if is_error:
         out["message"] = joined or "tool call failed"
     else:
         out["content"] = joined
-    structured = getattr(result, "structuredContent", None)
+    structured = getattr(result, "structured_content", None)
     if structured is not None:
         out["structured"] = structured
     return out
@@ -325,7 +325,7 @@ class _Bridge:
                         "real": t.name,
                         "description": t.description
                         or f"{t.name} (via MCP server {name!r})",
-                        "parameters": t.inputSchema
+                        "parameters": t.input_schema
                         or {"type": "object", "properties": {}},
                         "side_effecting": _is_side_effecting(
                             getattr(t, "annotations", None)
@@ -367,13 +367,21 @@ class _Bridge:
             )
             return read, write
 
-        from mcp.client.streamable_http import streamablehttp_client
-
-        # streamablehttp yields (read, write, get_session_id); drop the third.
-        transport = await stack.enter_async_context(
-            streamablehttp_client(url, headers=headers)
+        from mcp.client.streamable_http import (
+            create_mcp_http_client,
+            streamable_http_client,
         )
-        return transport[0], transport[1]
+
+        # v2 moved headers off the transport helper and onto a caller-owned
+        # httpx2 client. Enter both contexts on the supervisor's one stack so
+        # sockets and anyio scopes still unwind in the same task.
+        http_client = await stack.enter_async_context(
+            create_mcp_http_client(headers)
+        )
+        read, write = await stack.enter_async_context(
+            streamable_http_client(url, http_client=http_client)
+        )
+        return read, write
 
     async def _serve(self, sessions) -> None:
         assert self._request_q is not None

--- a/src/venice/commands/_openai.py
+++ b/src/venice/commands/_openai.py
@@ -91,15 +91,15 @@ def build_openai(module, client=None, *, base_url=None, api_key=None, verify=Non
 
     `verify` overrides TLS verification for that alternate backend (a CA-bundle
     path to trust a private CA, or False to disable checks for a self-signed
-    cert). It is opt-in and only reaches non-Venice endpoints. When set we hand
-    the SDK an httpx client (httpx ships transitively with the openai SDK). The
+    cert). It is opt-in and only reaches non-Venice endpoints. When set we use
+    the SDK's own HTTP-client factory, which follows the transport bundled by
+    that SDK version (`httpx` on older releases, `httpx2` on newer ones). The
     client is not explicitly closed -- fine for a one-shot CLI process that exits
     right after; don't copy this into a long-lived caller without closing it.
     """
     extra = {}
     if verify is not None:
-        import httpx
-        extra["http_client"] = httpx.Client(verify=verify)
+        extra["http_client"] = module.DefaultHttpxClient(verify=verify)
     if base_url is not None:
         return module.OpenAI(
             api_key=api_key or "not-needed", base_url=base_url, **extra

--- a/src/venice/commands/mcp_serve.py
+++ b/src/venice/commands/mcp_serve.py
@@ -48,7 +48,7 @@ def _run(args) -> int:
         print(str(e), file=sys.stderr)
         return 2
 
-    from ..mcp_server import serve  # lazy: only import FastMCP after the probe passes
+    from ..mcp_server import serve  # lazy: only import MCPServer after the probe passes
 
     doc = userconfig.load_config()  # #58: honor defaults.<section>.* in exposed tools
 

--- a/src/venice/mcp_server.py
+++ b/src/venice/mcp_server.py
@@ -1,4 +1,4 @@
-"""FastMCP wiring for `venice mcp-serve` -- the ONLY module that imports the mcp SDK.
+"""MCPServer wiring for `venice mcp-serve` -- the ONLY module that imports the mcp SDK.
 
 Imported lazily from `commands.mcp_serve._run`, and only after the `[mcp]` extra is
 confirmed present, so the base (stdlib-only) install and Python 3.9 never load it.
@@ -6,14 +6,14 @@ Each registered `venice_*` tool is a thin, typed wrapper that delegates 1:1 to t
 matching `commands._mcp.*_tool` implementation -- the wrapper carries the MCP schema
 and the LLM-facing docstring; the impl carries the (print-free, unit-tested) logic.
 
-Do NOT add `from __future__ import annotations` here: FastMCP builds each tool's
+Do NOT add `from __future__ import annotations` here: MCPServer builds each tool's
 input schema via typing.get_type_hints, so the annotations must stay concrete
 (`typing.Optional[int]`, not stringized `int | None`).
 """
 import os
 from typing import Annotated, List, Literal, Optional
 
-from mcp.server.fastmcp import FastMCP
+from mcp.server.mcpserver import MCPServer
 from pydantic import Field
 
 from . import userconfig
@@ -22,22 +22,22 @@ from .commands import _mcp, _shared, upscale as _upscale
 
 def _merged(defaults: dict, host: dict) -> dict:
     """Layer config `defaults` UNDER host-supplied args (#58): an explicit (non-None)
-    host value wins; where the host omitted an arg (FastMCP fills the wrapper's None
+    host value wins; where the host omitted an arg (MCPServer fills the wrapper's None
     default) the config default applies; keys the wrapper never exposes (e.g. image
     safe_mode/hide_watermark) come purely from config. Same precedence as
     `_agent._make_paid`'s `{**defaults, **_clean(arguments)}`."""
     return {**defaults, **{k: v for k, v in host.items() if v is not None}}
 
 
-def build_server(client, doc=None, root=None) -> FastMCP:
-    """Build a FastMCP server exposing venice tools, all bound to `client`.
+def build_server(client, doc=None, root=None) -> MCPServer:
+    """Build an MCPServer exposing venice tools, all bound to `client`.
 
     `doc` is a userconfig document (issue #58): `defaults.<section>.*` values are
     layered UNDER each host-supplied tool arg, so an explicit arg still wins
     (precedence: host arg > config default > tool hardcoded default) -- the same
     contract `venice chat`/`code` already honor. `doc=None` loads the config file.
     """
-    server = FastMCP("venice")
+    server = MCPServer("venice")
     path_authority = _shared.MediaPathAuthority(
         os.path.realpath(root or os.getcwd())
     )

--- a/tests/_mcp_fake_server.py
+++ b/tests/_mcp_fake_server.py
@@ -6,14 +6,14 @@ read-only hint). The leading underscore keeps unittest's discovery from importin
 this module (its ``import mcp`` would fail on Python 3.9), so it is only ever
 launched as a subprocess by a test already gated on the `mcp` SDK being present.
 """
-from mcp.server.fastmcp import FastMCP
+from mcp.server.mcpserver import MCPServer
 from mcp.types import ToolAnnotations
 
 # Quiet the SDK's per-request INFO logging so it doesn't clutter test output.
-server = FastMCP("fake", log_level="WARNING")
+server = MCPServer("fake", log_level="WARNING")
 
 
-@server.tool(annotations=ToolAnnotations(readOnlyHint=True))
+@server.tool(annotations=ToolAnnotations(read_only_hint=True))
 def echo(text: str) -> str:
     """Return the text unchanged (read-only)."""
     return f"echo: {text}"

--- a/tests/test_embed.py
+++ b/tests/test_embed.py
@@ -419,7 +419,7 @@ class TestEmbed(unittest.TestCase):
     # --- TLS override for the alternate backend (#28) ---
 
     def test_ca_bundle_reaches_sdk_on_alt_path(self):
-        with mock.patch("httpx.Client", return_value="httpx-sentinel") as Hx:
+        with mock.patch("openai.DefaultHttpxClient", return_value="httpx-sentinel") as Hx:
             rc, built, captured, urlopen = self._run_alt(
                 _args(text="hi", embed_base_url="https://embed.local/v1",
                       embed_model="local-embed", embed_ca_bundle="/ca.pem"),
@@ -431,7 +431,7 @@ class TestEmbed(unittest.TestCase):
 
     def test_insecure_disables_verification_and_warns(self):
         err = io.StringIO()
-        with mock.patch("httpx.Client", return_value="httpx-sentinel") as Hx:
+        with mock.patch("openai.DefaultHttpxClient", return_value="httpx-sentinel") as Hx:
             rc, built, captured, urlopen = self._run_alt(
                 _args(text="hi", embed_base_url="https://embed.local/v1",
                       embed_model="local-embed", embed_insecure=True),
@@ -443,7 +443,7 @@ class TestEmbed(unittest.TestCase):
         self.assertIn("TLS verification disabled", err.getvalue())
 
     def test_ca_bundle_from_env_on_alt_path(self):
-        with mock.patch("httpx.Client", return_value="httpx-sentinel") as Hx:
+        with mock.patch("openai.DefaultHttpxClient", return_value="httpx-sentinel") as Hx:
             rc, built, captured, urlopen = self._run_alt(
                 _args(text="hi", embed_base_url="https://embed.local/v1",
                       embed_model="local-embed"),
@@ -456,7 +456,7 @@ class TestEmbed(unittest.TestCase):
     def test_ca_bundle_from_config_on_alt_path(self):
         doc = {"version": 1, "mcpServers": {}, "defaults": {"embed": {
             "embed_ca_bundle": "/cfg-ca.pem"}}}
-        with mock.patch("httpx.Client", return_value="httpx-sentinel") as Hx:
+        with mock.patch("openai.DefaultHttpxClient", return_value="httpx-sentinel") as Hx:
             rc, built, captured, urlopen = self._run_alt(
                 _args(text="hi", embed_base_url="https://embed.local/v1",
                       embed_model="local-embed"),

--- a/tests/test_index.py
+++ b/tests/test_index.py
@@ -350,7 +350,7 @@ class TestIndexCLI(unittest.TestCase):
     # --- #42: TLS override reaches the SDK through CLI env/config layering ---
 
     def _run_tls(self, *, env=None, doc=None, **arg_ov):
-        """Drive index._run against the local backend with httpx.Client patched to
+        """Drive index._run with the SDK HTTP-client factory patched to
         a sentinel; returns (rc, Hx_mock) so a test can assert the verify value."""
         from venice.commands import index
         tmp = tempfile.TemporaryDirectory()
@@ -360,7 +360,7 @@ class TestIndexCLI(unittest.TestCase):
         if env:
             base_env.update(env)
         fake, _ = fake_openai()
-        with mock.patch("httpx.Client", return_value="httpx-sentinel") as Hx, \
+        with mock.patch("openai.DefaultHttpxClient", return_value="httpx-sentinel") as Hx, \
              mock.patch("openai.OpenAI", return_value=fake), \
              mock.patch("venice.userconfig.load_config",
                         return_value=doc or _clean_doc()), \
@@ -398,13 +398,13 @@ class TestIndexTLS(_EngineBase):
     """#42: TLS escape hatch on the local embedding backend (engine level)."""
 
     def _build(self, *, stderr=None, **ov):
-        """build_index on self.root via the local backend, httpx.Client patched to
+        """build_index on self.root with the SDK HTTP-client factory patched to
         a sentinel. Returns (Hx_mock, OAI_mock); propagates IndexingError."""
         write(self.root, "a.txt", "alpha\n")
         fake, _ = fake_openai()
         kw = dict(embed_base_url="http://local/v1", embed_model="m")
         kw.update(ov)
-        with mock.patch("httpx.Client", return_value="httpx-sentinel") as Hx, \
+        with mock.patch("openai.DefaultHttpxClient", return_value="httpx-sentinel") as Hx, \
              mock.patch("openai.OpenAI", return_value=fake) as OAI, \
              mock.patch.dict(os.environ, _no_key_env(), clear=True), \
              mock.patch.object(sys, "stderr", stderr or io.StringIO()):

--- a/tests/test_mcp_client.py
+++ b/tests/test_mcp_client.py
@@ -8,6 +8,8 @@ Three layers:
 - A real end-to-end `attach()` test spawns a tiny stdio MCP server subprocess; it is
   skipped unless the `mcp` SDK is importable (absent on Python 3.9).
 """
+import asyncio
+import contextlib
 import importlib.util
 import os
 import subprocess
@@ -24,8 +26,8 @@ _FAKE_SERVER = os.path.join(os.path.dirname(__file__), "_mcp_fake_server.py")
 # --- duck-typed stand-ins for the mcp SDK's result/annotation objects --------
 
 class _Ann:
-    def __init__(self, readOnlyHint=None):
-        self.readOnlyHint = readOnlyHint
+    def __init__(self, read_only_hint=None):
+        self.read_only_hint = read_only_hint
 
 
 class _Block:
@@ -35,10 +37,10 @@ class _Block:
 
 
 class _CallResult:
-    def __init__(self, content=None, isError=False, structuredContent=None):
+    def __init__(self, content=None, is_error=False, structured_content=None):
         self.content = content or []
-        self.isError = isError
-        self.structuredContent = structuredContent
+        self.is_error = is_error
+        self.structured_content = structured_content
 
 
 class TestPureHelpers(unittest.TestCase):
@@ -128,9 +130,9 @@ class TestPureHelpers(unittest.TestCase):
 
     def test_is_side_effecting_defaults_true(self):
         self.assertTrue(mc._is_side_effecting(None))
-        self.assertTrue(mc._is_side_effecting(_Ann(readOnlyHint=None)))
-        self.assertTrue(mc._is_side_effecting(_Ann(readOnlyHint=False)))
-        self.assertFalse(mc._is_side_effecting(_Ann(readOnlyHint=True)))
+        self.assertTrue(mc._is_side_effecting(_Ann(read_only_hint=None)))
+        self.assertTrue(mc._is_side_effecting(_Ann(read_only_hint=False)))
+        self.assertFalse(mc._is_side_effecting(_Ann(read_only_hint=True)))
 
     def test_translate_ok_joins_text(self):
         r = mc._translate_result(_CallResult([_Block(text="hi"), _Block(text="yo")]))
@@ -142,13 +144,13 @@ class TestPureHelpers(unittest.TestCase):
         self.assertIn("non-text content: image", r["content"])
 
     def test_translate_error(self):
-        r = mc._translate_result(_CallResult([_Block(text="boom")], isError=True))
+        r = mc._translate_result(_CallResult([_Block(text="boom")], is_error=True))
         self.assertEqual(r["status"], "error")
         self.assertEqual(r["message"], "boom")
 
     def test_translate_carries_structured(self):
         r = mc._translate_result(
-            _CallResult([_Block(text="x")], structuredContent={"a": 1})
+            _CallResult([_Block(text="x")], structured_content={"a": 1})
         )
         self.assertEqual(r["structured"], {"a": 1})
 
@@ -203,6 +205,45 @@ class TestAttachIntegration(unittest.TestCase):
 
     def _specs(self):
         return [("fake", {"command": sys.executable, "args": [_FAKE_SERVER]})]
+
+    def test_streamable_http_uses_v2_client_and_preserves_headers(self):
+        class AsyncCM:
+            def __init__(self, value):
+                self.value = value
+
+            async def __aenter__(self):
+                return self.value
+
+            async def __aexit__(self, exc_type, exc, tb):
+                return False
+
+        async def exercise():
+            bridge = mc._Bridge([], connect_timeout=20, call_timeout=20)
+            http_client = object()
+            with mock.patch(
+                "mcp.client.streamable_http.create_mcp_http_client",
+                return_value=AsyncCM(http_client),
+            ) as create_client, mock.patch(
+                "mcp.client.streamable_http.streamable_http_client",
+                return_value=AsyncCM(("read", "write")),
+            ) as connect:
+                async with contextlib.AsyncExitStack() as stack:
+                    streams = await bridge._open_transport(
+                        stack,
+                        {
+                            "url": "https://mcp.example.test/rpc",
+                            "headers": {"Authorization": "Bearer fake-token"},
+                        },
+                    )
+                create_client.assert_called_once_with(
+                    {"Authorization": "Bearer fake-token"}
+                )
+                connect.assert_called_once_with(
+                    "https://mcp.example.test/rpc", http_client=http_client
+                )
+                return streams
+
+        self.assertEqual(asyncio.run(exercise()), ("read", "write"))
 
     def test_lists_namespaces_and_calls(self):
         with mc.attach(self._specs(), connect_timeout=20, call_timeout=20) as tools:

--- a/tests/test_mcp_serve.py
+++ b/tests/test_mcp_serve.py
@@ -1,13 +1,15 @@
-"""Tests for the `venice mcp-serve` subcommand and FastMCP wiring.
+"""Tests for the `venice mcp-serve` subcommand and MCPServer wiring.
 
 Two layers: the missing-`mcp`-extra path runs everywhere (it patches the SDK out);
 the `build_server` wiring test is skipped unless the `mcp` SDK is importable (it is
 absent on Python 3.9, where the extra's environment marker excludes it).
 """
 import argparse
+import asyncio
 import importlib.util
 import inspect
 import io
+import json
 import sys
 import tempfile
 import unittest
@@ -47,6 +49,43 @@ class TestServerWiring(unittest.TestCase):
         server = build_server(FakeClient())
         names = {t.name for t in server._tool_manager.list_tools()}
         self.assertEqual(names, EXPECTED_TOOLS)
+
+    def test_v2_client_lists_and_calls_the_public_server_surface(self):
+        from mcp import Client
+
+        from venice.commands import _mcp
+        from venice.mcp_server import build_server
+
+        class FakeClient:
+            api_key = "fake"
+            base_url = "https://api.venice.ai/api/v1"
+
+        server = build_server(FakeClient(), doc={})
+
+        async def exercise():
+            async with Client(server) as client:
+                listed = await client.list_tools()
+                names = {tool.name for tool in listed.tools}
+                chat = next(tool for tool in listed.tools if tool.name == "venice_chat")
+                result = await client.call_tool("venice_chat", {"message": "ping"})
+                return names, chat.input_schema, result
+
+        with mock.patch.object(
+            _mcp,
+            "chat_tool",
+            return_value={"status": "ok", "content": "pong"},
+        ) as impl:
+            names, schema, result = asyncio.run(exercise())
+
+        self.assertEqual(names, EXPECTED_TOOLS)
+        self.assertEqual(schema["required"], ["message"])
+        self.assertFalse(result.is_error)
+        self.assertIsNone(result.structured_content)
+        self.assertEqual(
+            json.loads(result.content[0].text),
+            {"status": "ok", "content": "pong"},
+        )
+        impl.assert_called_once()
 
     def test_server_captures_startup_root_for_media_authority(self):
         from venice.mcp_server import build_server

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -184,13 +184,13 @@ class TestSearchTLS(_Base):
     backend base_url comes from stored index meta (a local-backed index)."""
 
     def _search_tls(self, *, env=None, stderr=None, **ov):
-        """search_index against the local-backed store with httpx.Client patched
+        """search_index with the SDK HTTP-client factory patched
         to a sentinel; returns (Hx_mock, OAI_mock)."""
         fake, _ = fake_openai()
         base_env = _no_key_env()
         if env:
             base_env.update(env)
-        with mock.patch("httpx.Client", return_value="httpx-sentinel") as Hx, \
+        with mock.patch("openai.DefaultHttpxClient", return_value="httpx-sentinel") as Hx, \
              mock.patch("openai.OpenAI", return_value=fake) as OAI, \
              mock.patch.dict(os.environ, base_env, clear=True), \
              mock.patch.object(sys, "stderr", stderr or io.StringIO()):
@@ -231,7 +231,7 @@ class TestSearchTLS(_Base):
         self.addCleanup(os.chdir, cwd)
         os.chdir(self.root)
         fake, _ = fake_openai()
-        with mock.patch("httpx.Client", return_value="httpx-sentinel") as Hx, \
+        with mock.patch("openai.DefaultHttpxClient", return_value="httpx-sentinel") as Hx, \
              mock.patch("openai.OpenAI", return_value=fake), \
              mock.patch.dict(os.environ, {**_no_key_env(),
                                           "VENICE_EMBED_CA_BUNDLE": "/env-ca.pem"},

--- a/tests/test_shared_openai.py
+++ b/tests/test_shared_openai.py
@@ -234,6 +234,11 @@ class _StubOpenAI:
 
     def __init__(self):
         self.built = None
+        self.http_client_built = None
+
+    def DefaultHttpxClient(self, **kwargs):
+        self.http_client_built = kwargs
+        return "http-client-sentinel"
 
     def OpenAI(self, **kwargs):
         self.built = kwargs
@@ -328,33 +333,27 @@ class TestBuildOpenAI(unittest.TestCase):
             stub.built, {"api_key": "not-needed", "base_url": "http://localhost:1234/v1"}
         )
 
-    def test_verify_ca_bundle_builds_httpx_client(self):
+    def test_verify_ca_bundle_builds_sdk_http_client(self):
         stub = _StubOpenAI()
-        with mock.patch("httpx.Client") as HttpxClient:
-            HttpxClient.return_value = "httpx-sentinel"
-            _openai.build_openai(
-                stub, base_url="https://embed.local/v1", verify="/ca.pem"
-            )
-        HttpxClient.assert_called_once_with(verify="/ca.pem")
-        self.assertEqual(stub.built["http_client"], "httpx-sentinel")
+        _openai.build_openai(
+            stub, base_url="https://embed.local/v1", verify="/ca.pem"
+        )
+        self.assertEqual(stub.http_client_built, {"verify": "/ca.pem"})
+        self.assertEqual(stub.built["http_client"], "http-client-sentinel")
         self.assertEqual(stub.built["base_url"], "https://embed.local/v1")
 
     def test_verify_false_disables_verification(self):
         stub = _StubOpenAI()
-        with mock.patch("httpx.Client") as HttpxClient:
-            HttpxClient.return_value = "httpx-sentinel"
-            _openai.build_openai(
-                stub, base_url="https://embed.local/v1", verify=False
-            )
-        HttpxClient.assert_called_once_with(verify=False)
-        self.assertEqual(stub.built["http_client"], "httpx-sentinel")
+        _openai.build_openai(
+            stub, base_url="https://embed.local/v1", verify=False
+        )
+        self.assertEqual(stub.http_client_built, {"verify": False})
+        self.assertEqual(stub.built["http_client"], "http-client-sentinel")
 
     def test_verify_none_adds_no_http_client(self):
         stub = _StubOpenAI()
-        # Default path must not touch httpx or pass http_client at all.
-        with mock.patch("httpx.Client") as HttpxClient:
-            _openai.build_openai(stub, base_url="http://localhost:1234/v1")
-        HttpxClient.assert_not_called()
+        _openai.build_openai(stub, base_url="http://localhost:1234/v1")
+        self.assertIsNone(stub.http_client_built)
         self.assertNotIn("http_client", stub.built)
 
 


### PR DESCRIPTION
Closes #95

## Summary
- port the MCP server and external-client bridge to the MCP SDK 2.x API
- preserve Streamable HTTP headers through the v2 caller-owned HTTP client lifecycle
- use the OpenAI SDK HTTP-client factory so current `httpx2` and the declared OpenAI floor both retain TLS override support
- add public v2 server/client and transport regression coverage

## Validation
- `make test` — 1,833 passed
- `make drive`
- `make lint`
- `make scan`
- `make openapi-check`
- MCP focused suite on `mcp==2.0.0` and `mcp==2.1.1` — 39 passed each
- `python -m build` + `twine check --strict dist/*`
- dependency-free base wheel smoke test

No live Venice API calls were made.