### PR TITLE
agent: name the session spend gate correctly

### DIFF
--- a/src/venice/commands/_agent.py
+++ b/src/venice/commands/_agent.py
@@ -3648,7 +3648,7 @@ def run_loop(
             return 2
         if ledger is not None and ledger.over():
             return _force_final(
-                f"chat: reached --max-spend ({ledger.summary()}); "
+                f"reached --session-max-spend ({ledger.summary()}); "
                 "requesting a final answer"
             )
         # Token gate (#52): a per-subagent cumulative-token ceiling, orthogonal to the USD

--- a/tests/test_agent.py
+++ b/tests/test_agent.py
@@ -2718,8 +2718,9 @@ class TestRunLoopSpendGate(unittest.TestCase):
         fake, calls = _fake_oai(seq)
         ledger = _agent.CostLedger(max_spend=0.001)
         ledger.bind_pricing({"input": {"usd": 1.0}, "output": {"usd": 1.0}})
+        err = io.StringIO()
         with mock.patch.object(sys, "stdout", io.StringIO()), \
-             mock.patch.object(sys, "stderr", io.StringIO()):
+             mock.patch.object(sys, "stderr", err):
             rc = _agent.run_loop(
                 fake, "m", [{"role": "user", "content": "go"}], {},
                 [self._tool()], max_tool_calls=0, yes=True, json_out=False,
@@ -2729,6 +2730,9 @@ class TestRunLoopSpendGate(unittest.TestCase):
         self.assertEqual(len(calls), 2)                      # turn 1 + forced final
         self.assertEqual(calls[-1]["tool_choice"], "none")   # forced, no tools
         self.assertTrue(ledger.over())
+        self.assertIn("reached --session-max-spend", err.getvalue())
+        self.assertNotIn("chat: reached", err.getvalue())
+        self.assertNotIn("reached --max-spend", err.getvalue())
 
     def test_no_ledger_means_no_gate(self):
         usage = {"prompt_tokens": 10**9, "completion_tokens": 10**9}
@@ -2807,7 +2811,7 @@ class TestRunLoopSpendGate(unittest.TestCase):
         # warning nobody asked for. Both gates asserted -- one is not the other.
         usage = {"prompt_tokens": 900, "completion_tokens": 200}
         for kw, expect in ((dict(max_tokens=1000), "token cap"),
-                           (dict(max_spend=0.0001), "--max-spend")):
+                           (dict(max_spend=0.0001), "--session-max-spend")):
             with self.subTest(gate=expect):
                 seq = [
                     FakeToolCompletion(tool_calls=[_FnCall("c1", "t", "{}")],


### PR DESCRIPTION
Closes #89

## Summary
- name the shared agent-loop cap as --session-max-spend
- remove the incorrect chat-only prefix from the command-neutral loop
- pin the corrected stderr contract with focused regression assertions

## Validation
- focused TestRunLoopSpendGate: 7 passed
- make test: 1,833 passed with the declared MCP 2.1.1 environment
- make drive: 40 passed
- make lint
- make scan
- make openapi-check
- git diff --check

No live Venice API calls were made.