### PR TITLE
cli: handle closed stdout pipes quietly

### DIFF
--- a/README.md
+++ b/README.md
@@ -2071,6 +2071,7 @@ The catalog is live and may add or retire models without a CLI release. Use
 | 9 | disk write error |
 | 10 | verdict unparseable / ambiguous — acceptance (`venice code`) or review (`venice review`) |
 | 130 | Ctrl-C |
+| 141 | stdout pipe closed by the downstream reader (SIGPIPE-equivalent producer exit) |
 
 `venice review` also uses **1** for "findings at or above `--fail-on` were reported".
 That reports what a run found; it is not a certification — see

--- a/src/venice/cli.py
+++ b/src/venice/cli.py
@@ -1,5 +1,6 @@
 """Top-level argparse dispatcher."""
 import argparse
+import os
 import sys
 
 from . import __version__
@@ -25,16 +26,30 @@ def main(argv=None) -> int:
         parser.print_help(sys.stderr)
         return 2
     try:
-        return int(handler(args) or 0)
-    except KeyboardInterrupt:
-        # The net under the per-command Ctrl-C handlers (#92). Each of those returns 130
-        # long before the exception could reach here, so this only ever catches what they
-        # miss -- and what they miss used to be a raw traceback. Deliberately silent: the
-        # command that owns the interrupt has already printed its own notice, and this
-        # must not print a second one over it. 130 is what CPython exited with anyway,
-        # so no exit code changes; see the table in the README.
-        print(file=sys.stderr)  # newline past a half-drawn prompt
-        return 130
+        try:
+            code = int(handler(args) or 0)
+        except KeyboardInterrupt:
+            # The net under the per-command Ctrl-C handlers (#92). Each of those
+            # returns 130 long before the exception could reach here, so this only
+            # ever catches what they miss -- and what they miss used to be a raw
+            # traceback. Deliberately silent: the command that owns the interrupt
+            # has already printed its own notice, and this must not print a second
+            # one over it. 130 is what CPython exited with anyway, so no exit code
+            # changes; see the table in the README.
+            print(file=sys.stderr)  # newline past a half-drawn prompt
+            code = 130
+
+        # A pipe can accept every write above, then close before CPython's buffered
+        # stdout is flushed during interpreter shutdown. Flush while the dispatcher
+        # can still turn that condition into the documented producer exit (#94).
+        sys.stdout.flush()
+        return code
+    except BrokenPipeError:
+        # Replacing the stream keeps CPython's shutdown flush from reporting the
+        # same EPIPE a second time as "Exception ignored in ...". Do not print a
+        # notice: the downstream reader deliberately stopped consuming output.
+        sys.stdout = open(os.devnull, "w", encoding="utf-8")
+        return 141  # 128 + SIGPIPE
 
 
 if __name__ == "__main__":

--- a/tests/_venice_fake_server.py
+++ b/tests/_venice_fake_server.py
@@ -104,6 +104,7 @@ class FakeVenice:
         self._lock = threading.Lock()
         self.requests = []  # [{"method", "path", "query", "body", "has_auth"}]
         self._chat = collections.deque()
+        self._model_overrides = {}
         self._next_tool_call_id = 0
         self._httpd = None
         self._thread = None
@@ -201,6 +202,20 @@ class FakeVenice:
                 })
             self._chat.append({"tool_calls": scripted, "usage": _USAGE})
 
+    def set_models(self, kind: str, rows) -> None:
+        """Override one ``/models?type=`` response for a process-level test."""
+        with self._lock:
+            self._model_overrides[kind] = list(rows)
+
+    def _models(self, kind: str):
+        with self._lock:
+            if kind in self._model_overrides:
+                return list(self._model_overrides[kind])
+        return {
+            "text": TEXT_MODELS,
+            "image": IMAGE_MODELS,
+        }.get(kind, [])
+
     def _next_chat(self) -> dict:
         with self._lock:
             if self._chat:
@@ -215,6 +230,7 @@ class FakeVenice:
         with self._lock:
             self.requests = []
             self._chat.clear()
+            self._model_overrides.clear()
             self._next_tool_call_id = 0
 
     @property
@@ -293,7 +309,7 @@ def _make_handler(api: FakeVenice):
             path, query, _ = self._dispatch("GET")
             if path == "/models":
                 kind = (query.get("type") or ["text"])[0]
-                data = {"text": TEXT_MODELS, "image": IMAGE_MODELS}.get(kind, [])
+                data = api._models(kind)
                 self._send_json({"object": "list", "data": data})
             elif path == "/api_keys/rate_limits":
                 self._send_json(RATE_LIMITS)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -16,7 +16,15 @@ def _capture(fn, *args):
     out, err = io.StringIO(), io.StringIO()
     with mock.patch.object(sys, "stdout", out), mock.patch.object(sys, "stderr", err):
         rc = fn(*args)
+        replacement = sys.stdout
+    if replacement is not out:
+        replacement.close()
     return rc, out.getvalue(), err.getvalue()
+
+
+class _BrokenOnFlush(io.StringIO):
+    def flush(self):
+        raise BrokenPipeError
 
 
 class TestDispatcher(unittest.TestCase):
@@ -53,6 +61,24 @@ class TestDispatcher(unittest.TestCase):
         with mock.patch("venice.commands.models._run", side_effect=RuntimeError("boom")):
             with self.assertRaises(RuntimeError):
                 _capture(cli.main, ["models"])
+
+    def test_broken_pipe_from_a_handler_is_quiet_exit_141(self):
+        with mock.patch("venice.commands.models._run", side_effect=BrokenPipeError):
+            rc, out, err = _capture(cli.main, ["models"])
+        self.assertEqual(rc, 141)
+        self.assertEqual(out, "")
+        self.assertEqual(err, "")
+
+    def test_broken_pipe_from_the_final_flush_is_quiet_exit_141(self):
+        out, err = _BrokenOnFlush(), io.StringIO()
+        with mock.patch.object(sys, "stdout", out), mock.patch.object(sys, "stderr", err):
+            with mock.patch("venice.commands.models._run", return_value=0):
+                rc = cli.main(["models"])
+            replacement = sys.stdout
+        if replacement is not out:
+            replacement.close()
+        self.assertEqual(rc, 141)
+        self.assertEqual(err.getvalue(), "")
 
 
 if __name__ == "__main__":

--- a/tests/test_drive_cli.py
+++ b/tests/test_drive_cli.py
@@ -26,6 +26,7 @@ import shutil
 import site
 import stat
 import subprocess
+import sys
 import tempfile
 import unittest
 from pathlib import Path
@@ -251,6 +252,41 @@ class TestDriveCharge(_DriveCase):
 # --------------------------------------------------------------------------
 
 class TestDriveNonInteractive(_DriveCase):
+    def test_broken_stdout_pipe_is_quiet_exit_141(self):
+        # More than a pipe buffer makes the EPIPE deterministic: `head` exits
+        # after its first line while the real CLI still has output left to write.
+        self.api.set_models("all", [
+            {"id": "pipe-model-%05d" % i, "type": "text"}
+            for i in range(10_000)
+        ])
+        producer = subprocess.Popen(
+            [sys.executable, "-m", "venice", "models", "--type", "all"],
+            env=_drive.build_env(self.home, base_url=self.base_url),
+            cwd=str(self.project),
+            stdin=subprocess.DEVNULL,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+        )
+        self.addCleanup(lambda: producer.kill() if producer.poll() is None else None)
+        self.assertIsNotNone(producer.stdout)
+        self.assertIsNotNone(producer.stderr)
+        head = subprocess.run(
+            ["head", "-1"],
+            stdin=producer.stdout,
+            capture_output=True,
+            text=True,
+            timeout=_drive.DEFAULT_TIMEOUT,
+        )
+        producer.stdout.close()
+        self.assertEqual(producer.wait(timeout=_drive.DEFAULT_TIMEOUT), 141)
+        producer_err = producer.stderr.read()
+        producer.stderr.close()
+
+        self.assertEqual(head.returncode, 0, head.stderr)
+        self.assertEqual(head.stdout, "### text (10000)\n")
+        self.assertEqual(producer_err, "")
+
     def test_image_non_interactive_requires_yes(self):
         cp = self.run_cli("image", "a cat", "--name", "drive-test")
         self.assertEqual(cp.returncode, 1)


### PR DESCRIPTION
Closes #94

## Summary
- convert handler-time and deferred stdout `BrokenPipeError` failures into the approved producer exit 141
- redirect broken stdout to devnull so interpreter shutdown cannot emit a second error
- document the public exit code and exercise a real `models | head -1` pipeline against the loopback fake API

## Validation
- focused dispatcher + real-pipeline tests with `ResourceWarning` promoted to error
- `make test`
- `make drive`
- `make lint`
- `make scan`
- `make openapi-check`
- `git diff --check`

No live Venice API calls were made; all process coverage used `VENICE_API_KEY=test-fake-key` and the loopback fake API.
