### PR TITLE
chat: report plain one-shot Ctrl+C

### DIFF
--- a/README.md
+++ b/README.md
@@ -594,6 +594,10 @@ git log --oneline -20 | venice chat - --system "Group these into release notes."
 venice chat "ping" --json | jq '.choices[0].message.content'
 ```
 
+Ctrl+C during a one-shot chat prints `chat: aborted` and exits 130. Because the
+default streamed form may already have written part of the reply to stdout, its
+notice is `chat: aborted (partial output may appear above)`.
+
 ### Interactive mode
 
 With `-i`/`--interactive` — or simply no message on a terminal — `venice chat`

--- a/src/venice/commands/chat.py
+++ b/src/venice/commands/chat.py
@@ -500,6 +500,12 @@ def _run(args) -> int:
         return _run_once(oai, kwargs, args.json)
     except openai.OpenAIError as e:
         return _openai.status_to_exit(openai, e, "chat")
+    except KeyboardInterrupt:
+        notice = "chat: aborted"
+        if stream:
+            notice += " (partial output may appear above)"
+        print(f"\n{notice}", file=sys.stderr)
+        return 130
 
 
 def _tools_for(args, client, models, model):

--- a/tests/_venice_fake_server.py
+++ b/tests/_venice_fake_server.py
@@ -159,6 +159,17 @@ class FakeVenice:
         with self._lock:
             self._chat.append({"deltas": list(deltas), "usage": _USAGE})
 
+    def reply_paused_stream(self, first_delta: str) -> threading.Event:
+        """Queue one SSE delta, then hold the connection open until released."""
+        release = threading.Event()
+        with self._lock:
+            self._chat.append({
+                "deltas": [first_delta],
+                "usage": _USAGE,
+                "pause_after_first": release,
+            })
+        return release
+
     def reply_tool_call(self, name: str, arguments: dict) -> None:
         """Queue one non-streamed assistant turn containing one tool call."""
         self.reply_tool_calls([(name, arguments)])
@@ -387,9 +398,13 @@ def _make_handler(api: FakeVenice):
             # ordering, so artificial delay would only buy flake.
             frame([{"index": 0, "delta": {"role": "assistant"},
                     "finish_reason": None}])
-            for piece in scripted["deltas"]:
+            for index, piece in enumerate(scripted["deltas"]):
                 frame([{"index": 0, "delta": {"content": piece},
                         "finish_reason": None}])
+                release = scripted.get("pause_after_first")
+                if index == 0 and release is not None:
+                    release.wait()
+                    return
             frame([{"index": 0, "delta": {}, "finish_reason": "stop"}])
             # `venice chat` always sends stream_options={"include_usage": true},
             # so the final usage frame (empty `choices`) is what produces the

--- a/tests/test_chat.py
+++ b/tests/test_chat.py
@@ -228,9 +228,11 @@ class TestChat(unittest.TestCase):
         _cfg.start()
         self.addCleanup(_cfg.stop)
 
-    def _run(self, args, result, stdout=None, stderr=None):
+    def _run(self, args, result, stdout=None, stderr=None, side_effect=None):
         from venice.commands import chat
         fake, captured = _fake_openai(result)
+        if side_effect is not None:
+            fake.chat.completions.create.side_effect = side_effect
         with mock.patch.dict(os.environ, {"VENICE_API_KEY": "fake"}), \
              mock.patch("venice.client.urllib.request.urlopen", _urlopen_ok()), \
              mock.patch("openai.OpenAI", return_value=fake), \
@@ -420,6 +422,43 @@ class TestChat(unittest.TestCase):
         self.assertEqual(out.getvalue().strip(), "Hello")
         self.assertTrue(captured["stream"])
         self.assertEqual(captured["stream_options"], {"include_usage": True})
+
+    def test_non_stream_interrupt_prints_command_notice_and_exits_130(self):
+        for args in (
+            _args(message="hi", stream=False),
+            _args(message="hi", json=True),
+        ):
+            with self.subTest(json=args.json):
+                out, err = io.StringIO(), io.StringIO()
+                rc, _fake, _captured = self._run(
+                    args,
+                    FakeCompletion("unused"),
+                    stdout=out,
+                    stderr=err,
+                    side_effect=KeyboardInterrupt,
+                )
+                self.assertEqual(rc, 130)
+                self.assertEqual(out.getvalue(), "")
+                self.assertEqual(err.getvalue(), "\nchat: aborted\n")
+
+    def test_stream_interrupt_warns_that_stdout_may_be_partial(self):
+        def interrupted_stream():
+            yield FakeChunk("PARTIAL-FROM-FAKE")
+            raise KeyboardInterrupt
+
+        out, err = io.StringIO(), io.StringIO()
+        rc, _fake, _captured = self._run(
+            _args(message="hi", stream=True),
+            interrupted_stream(),
+            stdout=out,
+            stderr=err,
+        )
+        self.assertEqual(rc, 130)
+        self.assertEqual(out.getvalue(), "PARTIAL-FROM-FAKE")
+        self.assertEqual(
+            err.getvalue(),
+            "\nchat: aborted (partial output may appear above)\n",
+        )
 
     def test_venice_parameters_extra_body(self):
         rc, fake, captured = self._run(

--- a/tests/test_drive_cli.py
+++ b/tests/test_drive_cli.py
@@ -146,6 +146,24 @@ class TestDriveHttp(_DriveCase):
         self.assertEqual(self.api.paths, ["/api_keys/rate_limits"])
         self.assertTrue(self.api.requests[0]["has_auth"])
 
+    @needs_openai
+    def test_plain_streaming_chat_ctrl_c_reports_partial_output(self):
+        release = self.api.reply_paused_stream("PARTIAL-FROM-FAKE")
+        self.addCleanup(release.set)
+
+        with self.cli("chat", "Say something") as d:
+            # Seeing the first delta proves the child is inside the plain streaming
+            # handler before SIGINT is delivered; the fake holds the SSE connection
+            # open, so this synchronization has no sleep or timing race.
+            d.expect("PARTIAL-FROM-FAKE")
+            d.ctrl_c()
+            d.expect("chat: aborted (partial output may appear above)")
+            self.assertEqual(d.wait(), 130)
+            self.assertNotIn("Traceback", d.transcript)
+
+        release.set()
+        self.assertEqual(self.api.paths, ["/models", "/chat/completions"])
+
 
 # --------------------------------------------------------------------------
 # C. the charge-confirmation gate (_shared.confirm_or_exit)


### PR DESCRIPTION
## Summary

- catch Ctrl+C in the plain one-shot chat path and preserve exit 130
- distinguish streamed output with a partial-output notice
- add unit coverage plus a deterministic real-SIGINT PTY case

## Validation

- 1,839 tests pass with the declared MCP 2.x dependency
- make drive
- make lint
- make scan
- git diff --check
- mutation check proves the new handler tests fail when the handler is removed

Closes #91.