### PR TITLE
v0.83: report non-stream chat usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -594,6 +594,12 @@ git log --oneline -20 | venice chat - --system "Group these into release notes."
 venice chat "ping" --json | jq '.choices[0].message.content'
 ```
 
+Plain human-readable chat reports each response's token counts on stderr as
+`usage: prompt=N completion=N total=N`, for both streamed and `--no-stream`
+calls. `--json` keeps stderr quiet because the raw response on stdout already
+contains the same `usage` object. Tool-calling chat instead reports its distinct
+whole-run time and cost footer, including under `--json`.
+
 Ctrl+C during a one-shot chat prints `chat: aborted` and exits 130. Because the
 default streamed form may already have written part of the reply to stdout, its
 notice is `chat: aborted (partial output may appear above)`.

--- a/src/venice/commands/chat.py
+++ b/src/venice/commands/chat.py
@@ -694,6 +694,7 @@ def _run_once(oai, kwargs: dict, as_json: bool) -> int:
         content = resp.choices[0].message.content or ""
     print(content)
     _print_citations(getattr(resp, "venice_parameters", None))
+    _print_usage(getattr(resp, "usage", None))
     return 0
 
 

--- a/tests/test_chat.py
+++ b/tests/test_chat.py
@@ -82,13 +82,16 @@ class _Choice:
 
 
 class FakeCompletion:
-    def __init__(self, content, venice_parameters=None):
+    def __init__(self, content, venice_parameters=None, usage=None):
         self.choices = [_Choice(content)]
         self.venice_parameters = venice_parameters
+        self.usage = usage
         self._dump = {
             "choices": [{"message": {"content": content}}],
             "venice_parameters": venice_parameters,
         }
+        if usage is not None:
+            self._dump["usage"] = usage
 
     def model_dump(self):
         return self._dump
@@ -267,6 +270,32 @@ class TestChat(unittest.TestCase):
         self.assertEqual(captured["model"], "llama-3.3-70b")
         self.assertEqual(captured["messages"][-1], {"role": "user", "content": "hi"})
 
+    def test_non_stream_reports_usage_on_stderr(self):
+        out, err = io.StringIO(), io.StringIO()
+        rc, _fake, _captured = self._run(
+            _args(message="hi", stream=False),
+            FakeCompletion("hello", usage={
+                "prompt_tokens": 11,
+                "completion_tokens": 3,
+                "total_tokens": 14,
+            }),
+            stdout=out,
+            stderr=err,
+        )
+        self.assertEqual(rc, 0)
+        self.assertEqual(out.getvalue(), "hello\n")
+        self.assertEqual(err.getvalue(), "usage: prompt=11 completion=3 total=14\n")
+
+    def test_non_stream_without_usage_keeps_stderr_quiet(self):
+        err = io.StringIO()
+        rc, _fake, _captured = self._run(
+            _args(message="hi", stream=False),
+            FakeCompletion("hello"),
+            stderr=err,
+        )
+        self.assertEqual(rc, 0)
+        self.assertEqual(err.getvalue(), "")
+
     def test_config_default_model_applied(self):
         cfg = {"version": 1, "mcpServers": {},
                "defaults": {"chat": {"model": "venice-uncensored"}}}
@@ -395,16 +424,23 @@ class TestChat(unittest.TestCase):
         self.assertEqual(fake.chat.completions.create.call_count, 0)
 
     def test_json_dumps_raw_and_forces_non_stream(self):
-        out = io.StringIO()
+        out, err = io.StringIO(), io.StringIO()
         rc, fake, captured = self._run(
             _args(message="hi", json=True),  # stream default True
-            FakeCompletion("hello", venice_parameters={"enable_web_search": "on"}),
+            FakeCompletion(
+                "hello",
+                venice_parameters={"enable_web_search": "on"},
+                usage={"prompt_tokens": 1, "completion_tokens": 2, "total_tokens": 3},
+            ),
             stdout=out,
+            stderr=err,
         )
         self.assertEqual(rc, 0)
         doc = json.loads(out.getvalue())
         self.assertEqual(doc["choices"][0]["message"]["content"], "hello")
         self.assertEqual(doc["venice_parameters"], {"enable_web_search": "on"})
+        self.assertEqual(doc["usage"]["total_tokens"], 3)
+        self.assertEqual(err.getvalue(), "")
         # --json must not stream
         self.assertNotIn("stream", captured)
 

--- a/tests/test_drive_cli.py
+++ b/tests/test_drive_cli.py
@@ -147,6 +147,18 @@ class TestDriveHttp(_DriveCase):
         self.assertTrue(self.api.requests[0]["has_auth"])
 
     @needs_openai
+    def test_plain_non_stream_chat_reports_usage_on_stderr(self):
+        self.api.reply("HELLO-FROM-FAKE")
+        cp = self.run_cli("chat", "Say something", "--no-stream")
+        self.assertEqual(cp.returncode, 0, cp.stderr)
+        self.assertEqual(cp.stdout, "HELLO-FROM-FAKE\n")
+        self.assertEqual(
+            cp.stderr,
+            "usage: prompt=11 completion=3 total=14\n",
+        )
+        self.assertEqual(self.api.paths, ["/models", "/chat/completions"])
+
+    @needs_openai
     def test_plain_streaming_chat_ctrl_c_reports_partial_output(self):
         release = self.api.reply_paused_stream("PARTIAL-FROM-FAKE")
         self.addCleanup(release.set)


### PR DESCRIPTION
Closes #90

## Summary
- print the existing one-response usage footer for plain non-streamed chat
- keep raw JSON stderr quiet and preserve the distinct tools whole-run footer
- document the output contract and cover it through unit and real-process fake-API tests

## Validation
- focused chat and drive regression tests
- make drive (43 tests)
- make test with MCP 2.1 (1,842 tests)
- make lint
- make scan
- make openapi-check
- git diff --check