### PR TITLE
fix(chat): report aggregate JSON usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -917,18 +917,19 @@ Details and safety:
   Ctrl+C and API-error exits too, which are the runs most worth costing out. A run
   that never reaches a model call (an unknown `--tool`, a model that can't do
   function calling, a failed `--mcp` attach) prints nothing.
-  Unlike `venice code`, the line is **not** suppressed under `--json`: `code` has an
-  envelope to carry the numbers, whereas chat's `--json` is the raw completion object
-  written from inside the loop, so there is nowhere to put a run total that isn't
-  already stale. stdout under `--json` is unchanged. Beware that that object's own
-  `usage` key is the **final turn only** — it is not the run total, and on a
-  multi-turn tool run the two legitimately differ.
+  Under `--json`, the stderr line is suppressed and stdout is an aggregate envelope:
+  `{ "final": "...", "usage": {...}, "venice_parameters": {...} }`. Its `usage`
+  is the same whole-run ledger as the human footer, including every model turn,
+  wall/tool timing, cache accounting and off-loop spend. Before v0.83.36 this path
+  printed the raw final completion object, whose `usage` covered only the last turn;
+  the envelope is an intentional pre-1.0 contract break rather than retaining a
+  plausible-looking undercount.
   Before v0.77 a default `--tools` run metered nothing at all: the ledger only
   existed when `--session-max-spend` was set.
 - **Ctrl+C** during a `--tools` run prints `chat: aborted`, reports what the turns so
   far cost, and exits 130 (it used to raise a traceback).
 - **Non-streamed in v1.** The tool path buffers each turn, so `--stream` is ignored
-  when `--tools` is on; `--json` prints the final completion object.
+  when `--tools` is on; `--json` prints the aggregate envelope described above.
 
 | flag | effect |
 |---|---|

--- a/src/venice/commands/_agent.py
+++ b/src/venice/commands/_agent.py
@@ -3557,6 +3557,7 @@ def run_loop(
     ledger: Optional[CostLedger] = None,
     steer_drain: Optional[Callable[[], List[str]]] = None,
     parallel: bool = False,
+    final_emitter: Optional[Callable[[object], int]] = None,
 ) -> int:
     """Drive the function-calling loop until the model stops (or the cap is hit).
 
@@ -3587,6 +3588,10 @@ def run_loop(
     results were all appended -- and each message is appended as a tagged user turn
     so the model consumes it exactly as if the operator had typed it. Draining does
     NOT reset the spend/tool-call budgets (a steer is additive input, not a reset).
+
+    `final_emitter` is an internal output seam. By default the loop prints the final
+    response according to `json_out`; callers that need to build an envelope only
+    after their own accounting is finalized can capture the response instead.
     """
     oai_tools = to_openai_tools(tools)
     dispatch = dispatch_map(tools)
@@ -3605,6 +3610,12 @@ def run_loop(
         # Install the thread-local stdout router on the MAIN thread before any subagent
         # worker starts, so workers only ever push/pop a target and never race on install.
         _install_router()
+
+    emit_final = (
+        final_emitter
+        if final_emitter is not None
+        else lambda response: _emit_final(response, json_out)
+    )
 
     def _force_final(reason: str) -> int:
         print(reason, file=sys.stderr)
@@ -3625,7 +3636,7 @@ def run_loop(
                           seconds=time.monotonic() - _t0)
         msg = resp.choices[0].message if getattr(resp, "choices", None) else None
         messages.append(_assistant_dict(msg))
-        return _emit_final(resp, json_out)
+        return emit_final(resp)
 
     while True:
         # Mid-run steering (#78): drain any queued steers at the checkpoint boundary
@@ -3701,7 +3712,7 @@ def run_loop(
                     f"{cache_event.message}; response is already final",
                     file=sys.stderr,
                 )
-            return _emit_final(resp, json_out)
+            return emit_final(resp)
 
         # Every tool_call in the turn must get a result (message-contract), even
         # ones past the budget -- those are reported not-executed rather than run.

--- a/src/venice/commands/chat.py
+++ b/src/venice/commands/chat.py
@@ -383,7 +383,7 @@ def _print_usage(usage) -> None:
         print(f"usage: prompt={pt} completion={ct} total={tt}", file=sys.stderr)
 
 
-def _finish(ledger, t0) -> None:
+def _finish(ledger, t0, *, quiet: bool = False) -> None:
     """Close the tool-loop run's wall-clock window, once, and print the footer (#86).
 
     A one-shot `venice chat --tools` reported neither time nor cost: the ledger was
@@ -402,11 +402,9 @@ def _finish(ledger, t0) -> None:
     * No `human` accumulator. Chat has no plan/edit prompt to subtract, and the
       paid-tool confirm gate lives inside `run_loop` where this can't see it -- the
       same hole `code` has, so not a regression.
-    * Not suppressed under `--json`. `code` has an envelope to carry the number;
-      chat's `--json` is the raw SDK object, written by `_agent._emit_final` *inside*
-      `run_loop`, so anything threaded in there would be stamped 0.0s by construction.
-      stderr is the only surface left, and this path already writes to it unguarded
-      (the MCP-attached notice above). stdout stays byte-identical.
+    * `quiet=True` stamps without printing when a successful `--json` run is about to
+      carry this ledger in its envelope. Error and Ctrl+C paths still call the normal
+      form from `finally`, so a failed run with no envelope does not lose its cost.
 
     Idempotent via `ledger.turns`: a non-zero turn count means "already stamped".
     Sound here because a one-shot ledger is never `restore()`d -- `_agent.wants_interactive`
@@ -417,13 +415,25 @@ def _finish(ledger, t0) -> None:
     if ledger is None or ledger.turns:
         return
     ledger.record_turn(time.monotonic() - t0)
-    # cache=True (#100): same reasoning as `code._finish` -- and more load-bearing here,
-    # since chat's `--json` has no envelope to carry the number instead (#88). The same
-    # goes for tools_fragment (#82): this footer is the ONLY surface carrying it here.
-    # It reads `elapsed_seconds` for its "concurrent" check, so it must render after the
-    # `record_turn` above.
+    if quiet:
+        return
+    # cache=True (#100): the human footer and the JSON ledger must report the same
+    # aggregate. The same goes for tools_fragment (#82). It reads `elapsed_seconds`
+    # for its "concurrent" check, so it must render after the `record_turn` above.
     print(f"chat: {_agent.format_duration(ledger.elapsed_seconds)} wall"
           f"{ledger.tools_fragment()} -- {ledger.summary(cache=True)}", file=sys.stderr)
+
+
+def _agent_json_envelope(resp, ledger) -> dict:
+    """The aggregate machine contract for one `chat --tools` run (#88)."""
+    content = ""
+    if getattr(resp, "choices", None):
+        content = resp.choices[0].message.content or ""
+    return {
+        "final": content,
+        "usage": ledger.to_dict(),
+        "venice_parameters": _as_dict(getattr(resp, "venice_parameters", None)),
+    }
 
 
 def _run(args) -> int:
@@ -638,6 +648,12 @@ def _run_agent(args, oai, openai, client, models, model, kwargs) -> Optional[int
     # operator spent waiting on us, and `_finish` is inert until a ledger exists.
     t0 = time.monotonic()
     ledger = None
+    final_response = []
+
+    def _capture_final(resp) -> int:
+        final_response.append(resp)
+        return 0
+
     try:
         with _tools_session(args, client, models, model) as (tools, rc):
             if tools is None:
@@ -656,7 +672,7 @@ def _run_agent(args, oai, openai, client, models, model, kwargs) -> Optional[int
             # gating: `_build_ledger` leaves max_tokens None and both `over()` and
             # `over_tokens()` short-circuit on a None cap. --session-max-spend still caps.
             ledger = _agent.usage_ledger(args, models, model)  # #66 spend cap, #86 metering
-            return _agent.run_loop(
+            result = _agent.run_loop(
                 oai, model, messages, kwargs, tools,
                 max_tool_calls=(args.max_tool_calls if args.max_tool_calls is not None
                                 else PROFILE.default_max_tool_calls),
@@ -664,7 +680,24 @@ def _run_agent(args, oai, openai, client, models, model, kwargs) -> Optional[int
                 json_out=args.json,
                 budget=_compact.budget_from_args(args),  # #48 auto-compact parity
                 ledger=ledger,
+                final_emitter=_capture_final if args.json else None,
             )
+            if args.json and result == 0:
+                if len(final_response) != 1:
+                    print("chat: final response was not captured", file=sys.stderr)
+                    return 2
+                # The aggregate must be stamped before serialization; otherwise its
+                # elapsed_seconds and turns fields would still describe an open run.
+                _finish(ledger, t0, quiet=True)
+                json.dump(
+                    _agent_json_envelope(final_response[0], ledger),
+                    sys.stdout,
+                    indent=2,
+                    default=str,
+                    allow_nan=False,
+                )
+                sys.stdout.write("\n")
+            return result
     except openai.OpenAIError as e:
         return _openai.status_to_exit(openai, e, "chat")
     except KeyboardInterrupt:
@@ -674,10 +707,9 @@ def _run_agent(args, oai, openai, client, models, model, kwargs) -> Optional[int
         print("\nchat: aborted", file=sys.stderr)
         return 130
     finally:
-        # After the error handlers so their message lands first, and after `run_loop`
-        # has written its output. If a future ticket gives chat a `to_dict()` envelope
-        # or a session save, this placement becomes wrong -- the stamp has to precede
-        # the snapshot or the blob carries turns=0.
+        # After the error handlers so their message lands first. A successful JSON run
+        # stamps before its envelope above; idempotence makes this a no-op there. Error
+        # and Ctrl+C paths have no envelope, so they still report their partial cost.
         _finish(ledger, t0)
 
 

--- a/tests/test_agent.py
+++ b/tests/test_agent.py
@@ -2719,17 +2719,20 @@ class TestRunLoopSpendGate(unittest.TestCase):
         ledger = _agent.CostLedger(max_spend=0.001)
         ledger.bind_pricing({"input": {"usd": 1.0}, "output": {"usd": 1.0}})
         err = io.StringIO()
+        final = []
         with mock.patch.object(sys, "stdout", io.StringIO()), \
              mock.patch.object(sys, "stderr", err):
             rc = _agent.run_loop(
                 fake, "m", [{"role": "user", "content": "go"}], {},
                 [self._tool()], max_tool_calls=0, yes=True, json_out=False,
                 ledger=ledger,
+                final_emitter=lambda response: final.append(response) or 0,
             )
         self.assertEqual(rc, 0)
         self.assertEqual(len(calls), 2)                      # turn 1 + forced final
         self.assertEqual(calls[-1]["tool_choice"], "none")   # forced, no tools
         self.assertTrue(ledger.over())
+        self.assertEqual(final, [seq[-1]])
         self.assertIn("reached --session-max-spend", err.getvalue())
         self.assertNotIn("chat: reached", err.getvalue())
         self.assertNotIn("reached --max-spend", err.getvalue())

--- a/tests/test_chat.py
+++ b/tests/test_chat.py
@@ -1063,25 +1063,36 @@ class TestChatUsageSurface(unittest.TestCase):
         self.assertEqual(self._out.getvalue().strip(), "final answer")
         self.assertNotIn("wall", self._out.getvalue())
 
-    def test_footer_still_printed_under_json(self):
-        """Chat diverges from code here on purpose -- see `_finish`'s docstring."""
+    def test_json_envelope_totals_every_turn_and_stamps_window(self):
+        """The aggregate replaces the misleading final-turn SDK usage (#88)."""
+        seq = self._tool_seq(1, 2, 4)
+        seq[-1].venice_parameters = {"enable_web_search": "on"}
         with self._stub_tool():
             rc, _f, _c = self._run(
                 _args(message="hi", tools=True, stream=False, json=True),
-                self._tool_seq(1, 2))
+                seq)
         self.assertEqual(rc, 0)
-        self.assertRegex(self._err, r"chat: .*wall")
-        json.loads(self._out.getvalue())  # stdout still parses
-
-    def test_json_stdout_shape_is_unchanged(self):
-        """No envelope, no new key: `--json` stays the raw SDK dump."""
-        with self._stub_tool():
-            self._run(_args(message="hi", tools=True, stream=False, json=True),
-                      self._tool_seq(1, 2))
         doc = json.loads(self._out.getvalue())
-        self.assertIn("choices", doc)
-        self.assertNotIn("final", doc)   # not code.py's envelope
-        self.assertNotIn("venice_usage", doc)
+        self.assertEqual(set(doc), {"final", "usage", "venice_parameters"})
+        self.assertEqual(doc["final"], "final answer")
+        self.assertEqual(doc["venice_parameters"], {"enable_web_search": "on"})
+        self.assertEqual(doc["usage"]["prompt_tokens"], 700)
+        self.assertEqual(doc["usage"]["completion_tokens"], 7)
+        self.assertEqual(doc["usage"]["api_calls_total"], 3)
+        self.assertEqual(doc["usage"]["turns"], 1)
+        self.assertGreaterEqual(doc["usage"]["elapsed_seconds"], 0)
+        self.assertNotRegex(self._err, r"chat: .*wall")
+
+    def test_json_envelope_uses_null_for_absent_venice_parameters(self):
+        with self._stub_tool():
+            rc, _f, _c = self._run(
+                _args(message="hi", tools=True, stream=False, json=True),
+                self._tool_seq(1, 2),
+            )
+        self.assertEqual(rc, 0)
+        doc = json.loads(self._out.getvalue())
+        self.assertIsNone(doc["venice_parameters"])
+        self.assertNotIn("choices", doc)
 
     # --- the cache hit rate on the footer (#100) ---
 
@@ -1096,8 +1107,7 @@ class TestChatUsageSurface(unittest.TestCase):
         self.assertNotIn("0.0% hit", self._err)
 
     def test_footer_reports_a_real_hit_rate(self):
-        # 150 cached of 300 prompt. This footer is the ONLY cache surface chat has:
-        # its `--json` is the raw SDK dump with nowhere to carry a number (#88).
+        # 150 cached of 300 prompt. The human footer and #88's JSON ledger must agree.
         seq = self._tool_seq(1, 2)
         for turn, cached in zip(seq, (50, 100)):
             turn.usage["prompt_tokens_details"] = {"cached_tokens": cached}
@@ -1155,6 +1165,16 @@ class TestChatUsageSurface(unittest.TestCase):
         self.assertEqual(rc, 5)
         self.assertRegex(self._err, r"chat: .*wall")
 
+    def test_json_api_error_emits_no_partial_envelope_and_reports_time(self):
+        import openai
+        rc, _f, _c = self._run(
+            _args(message="hi", tools=True, stream=False, json=True), [],
+            side_effect=openai.OpenAIError("boom"),
+        )
+        self.assertEqual(rc, 5)
+        self.assertEqual(self._out.getvalue(), "")
+        self.assertRegex(self._err, r"chat: .*wall")
+
     def test_ctrlc_reports_time_and_exits_130(self):
         # One paid tool-calling turn, then Ctrl+C mid-loop -- the run whose cost you
         # most want to see. Before #86 this was an uncaught traceback.
@@ -1172,6 +1192,25 @@ class TestChatUsageSurface(unittest.TestCase):
                                    [], side_effect=_create)
         self.assertEqual(rc, 130)
         self.assertIn("chat: aborted", self._err)
+        self.assertRegex(self._err, r"chat: .*wall")
+
+    def test_json_ctrlc_emits_no_partial_envelope_and_reports_time(self):
+        seq = [FakeToolCompletion(
+            tool_calls=[_FnCall("call_0", "venice_chat", '{"message": "hi"}')],
+            usage=self._usage(3))]
+
+        def _create(**kwargs):
+            if seq:
+                return seq.pop(0)
+            raise KeyboardInterrupt
+
+        with self._stub_tool():
+            rc, _f, _c = self._run(
+                _args(message="hi", tools=True, stream=False, json=True), [],
+                side_effect=_create,
+            )
+        self.assertEqual(rc, 130)
+        self.assertEqual(self._out.getvalue(), "")
         self.assertRegex(self._err, r"chat: .*wall")
         self.assertRegex(self._err, r"prompt=300\b")  # the turn you did pay for
 

--- a/tests/test_drive_cli.py
+++ b/tests/test_drive_cli.py
@@ -251,7 +251,10 @@ class TestDriveCharge(_DriveCase):
             d.expect("image: estimated cost $0.0100 is over the auto-approve cap")
             d.expect("Proceed? [y]es / [a]ll (accept rest) / [N]o ")
             d.send("y")
-            d.expect('"content": "TOOL-LOOP-COMPLETE"')
+            d.expect('"final": "TOOL-LOOP-COMPLETE"')
+            d.expect('"prompt_tokens": 22')
+            d.expect('"completion_tokens": 6')
+            d.expect('"turns": 1')
             self.assertEqual(d.wait(), 0)
 
         outputs = list(self.project.glob("venice-image-*.png"))


### PR DESCRIPTION
Closes #88

## Summary
- replace `chat --tools --json`'s misleading final SDK completion with `{final, usage, venice_parameters}`
- finalize and serialize the whole-run ledger while retaining partial-run stderr accounting on errors and Ctrl+C
- preserve plain-chat JSON and all human-output contracts; document the intentional pre-1.0 break

## Review note
- audited `venice review --json`; it already builds its own aggregate findings envelope and does not expose final-turn SDK usage, so no change is needed there

## Validation
- focused chat/agent tests: 358 passed
- `make drive`: 43 passed against the loopback fake API
- full `make test` under declared MCP 2.1 dependencies: 1,844 passed
- `make lint`
- `make scan`
- `make openapi-check`
- `git diff --check`

No live Venice API calls were made.
