### PR TITLE
v0.83: add controlled cache probe

### DIFF
--- a/README.md
+++ b/README.md
@@ -1463,6 +1463,31 @@ The run footer names the off-loop share too, but stays short: one or two buckets
 listed (`[incl. $0.0031 compaction]`), and past that it collapses to
 `[incl. $0.0180 off-loop]` and defers to `/usage` for the per-rail breakdown.
 
+To distinguish "the cache stopped working" from "the provider stopped reporting
+it," run a controlled live probe with synthetic content rather than project or user
+data:
+
+```bash
+# Configured chat model plus a cache-advertising model from another family.
+venice cache-probe
+
+# Explicit bounded threshold sweep; six-digit prefixes are never a default.
+venice cache-probe --model kimi-k3 \
+  --prefix-tokens 8192 --prefix-tokens 64000 \
+  --prefix-tokens 112000 --prefix-tokens 120000 --prefix-tokens 128000
+
+# Machine-readable result, with a hard cap for the complete matrix.
+venice cache-probe --model kimi-k3 --repeat 3 --json --yes --max-spend 0.50
+```
+
+The command prints a conservative all-uncached estimate before making any paid
+completion call, then requires confirmation (or `--yes`). `--max-spend` fails
+closed if the catalog price is absent or the complete matrix exceeds the cap.
+Each call reports the raw `prompt_tokens_details` object unchanged; each model/size
+is classified as `warms`, `never warms`, or `field absent`. Repeating
+`--prefix-tokens` makes warming below a threshold and failure above it visible,
+while size-specific prefixes prevent one sweep row from warming another.
+
 ```bash
 # what has compaction cost this session?
 jq '.usage.buckets.compaction' ~/.config/venice/sessions/<id>.json
@@ -2131,6 +2156,7 @@ The player list (`paplay` -> `aplay` -> `ffplay` -> `mpg123` -> `play`
 | `venice secret set/ls/rm NAME` | manage named secrets in `~/.config/venice/secrets.json` (0600); values never printed, `ls` shows lengths only |
 | `venice balance [--verbose\|--json\|--min N]` | current USD + DIEM balance |
 | `venice models [--type T] [--detail] [SLUG]` | browse the catalog |
+| `venice cache-probe [--model M ...] [--prefix-tokens N ...] [--repeat N] [--json] [--max-spend USD]` | controlled live prefix-cache diagnostic with raw usage details and a pre-spend confirmation gate |
 | `venice sfx PROMPT [--duration N] [--max-spend USD] [...]` | generate a sound effect |
 | `venice sfx-status QUEUE_ID` | fetch a backgrounded SFX job |
 | `venice tts TEXT [--voice V] [--format F] [--speed N] [...]` | synthesize speech (sync) |

--- a/contracts/openapi/implementation.json
+++ b/contracts/openapi/implementation.json
@@ -16,6 +16,7 @@
     "GET /models": {
       "consumers": [
         "cli:models",
+        "cli:cache-probe",
         "internal:model_validation",
         "mcp:model_backed_tools",
         "agent:model_backed_tools"
@@ -174,6 +175,7 @@
     },
     "POST /chat/completions": {
       "consumers": [
+        "cli:cache-probe",
         "cli:chat",
         "cli:code",
         "cli:review",
@@ -184,7 +186,7 @@
       "parameters": {
         "implemented": [],
         "intentional_omissions": {
-          "header:Accept-Encoding": "Compression negotiation is owned by the OpenAI SDK transport."
+          "header:Accept-Encoding": "Compression negotiation is transport-owned; SDK consumers handle it and stdlib consumers do not request it."
         }
       },
       "request_bodies": {

--- a/src/venice/commands/__init__.py
+++ b/src/venice/commands/__init__.py
@@ -1,11 +1,12 @@
 """Single import point. Adding a subcommand = one import + one tuple entry."""
-from . import balance, bg_remove, chat, code, completion, config, contact_sheet, embed, image, image_edit, index, login, master, mcp_serve, memory, models, music, review, search, secret, sessions, sfx, tts, upscale, video
+from . import balance, bg_remove, cache_probe, chat, code, completion, config, contact_sheet, embed, image, image_edit, index, login, master, mcp_serve, memory, models, music, review, search, secret, sessions, sfx, tts, upscale, video
 
 
 def register_all(subparsers) -> None:
     login.register(subparsers)
     balance.register(subparsers)
     models.register(subparsers)
+    cache_probe.register(subparsers)
     sfx.register(subparsers)
     sfx.register_status(subparsers)
     music.register(subparsers)

--- a/src/venice/commands/_models.py
+++ b/src/venice/commands/_models.py
@@ -12,10 +12,23 @@ The catalog GET is free, so commands call it before the paid request to validate
 """
 from __future__ import annotations
 
+import re
 import sys
 from typing import List, Optional, Tuple
 
 from ..client import VeniceAPIError
+
+
+def model_family(model_id: str) -> str:
+    """The leading vendor/family token of a model id.
+
+    ``qwen3-4b`` and ``qwen-2.5-coder`` share family ``qwen``.  Keeping the
+    heuristic beside the catalog helpers lets review decorrelation and the
+    cache-probe control selection agree without importing either command.
+    """
+    return re.split(
+        r"[-._0-9]", (model_id or "").strip().lower(), maxsplit=1
+    )[0]
 
 
 def catalog(client, model_type: str) -> Optional[List[dict]]:

--- a/src/venice/commands/_review.py
+++ b/src/venice/commands/_review.py
@@ -56,7 +56,7 @@ import threading
 import time
 from typing import Dict, List, Optional, Tuple
 
-from . import _agent, _code, _exec, _openai
+from . import _agent, _code, _exec, _models, _openai
 from ._exec import (  # shared exec rails (#33): one gate for every git shell-out
     DEFAULT_EXEC_TIMEOUT,
     MAX_OUTPUT_CHARS,
@@ -538,9 +538,7 @@ def _family(model_id: str) -> str:
     `qwen3-4b` and `qwen-2.5-coder` share family `qwen`, so picking a different *id*
     is not by itself decorrelation -- same family, largely the same blind spots.
     """
-    # `maxsplit=` by keyword: 3.13 deprecates passing it positionally, and the
-    # keyword form has been valid since long before the 3.9 floor.
-    return re.split(r"[-._0-9]", (model_id or "").strip().lower(), maxsplit=1)[0]
+    return _models.model_family(model_id)
 
 
 def resolve_reviewer_model(models, requested: Optional[str],

--- a/src/venice/commands/cache_probe.py
+++ b/src/venice/commands/cache_probe.py
@@ -1,0 +1,423 @@
+"""``venice cache-probe`` -- controlled live prefix-cache diagnostics (#97).
+
+The probe deliberately uses the stdlib Venice client rather than the OpenAI SDK:
+the response's raw ``prompt_tokens_details`` object is the deliverable, and a
+diagnostic for an OpenAI-compatible API should not require an optional client SDK.
+
+Every paid request is preceded by a conservative all-uncached estimate and the
+shared confirmation gate.  Tests replace the transport or use the loopback fake
+API; this module never needs a real credential during development.
+"""
+from __future__ import annotations
+
+import argparse
+import contextlib
+import json
+import math
+import sys
+from typing import Iterable, List, Optional, Tuple
+
+from .. import _numeric, auth, billing, userconfig
+from ..client import VeniceAPIError, build_client_from_auth
+from . import _models, _shared
+
+
+DEFAULT_PREFIX_TOKENS = 8192
+DEFAULT_REPEAT = 2
+MAX_PREFIX_TOKENS = 1_000_000
+MAX_REPEAT = 10
+_MESSAGE_OVERHEAD_TOKENS = 256
+_PROBE_QUESTION = "Reply with a single period."
+
+
+def _prefix_tokens(value: str) -> int:
+    try:
+        parsed = int(value)
+    except (TypeError, ValueError):
+        raise argparse.ArgumentTypeError("must be an integer") from None
+    if not 1 <= parsed <= MAX_PREFIX_TOKENS:
+        raise argparse.ArgumentTypeError(
+            f"must be between 1 and {MAX_PREFIX_TOKENS}"
+        )
+    return parsed
+
+
+def _repeat_count(value: str) -> int:
+    try:
+        parsed = int(value)
+    except (TypeError, ValueError):
+        raise argparse.ArgumentTypeError("must be an integer") from None
+    if not 2 <= parsed <= MAX_REPEAT:
+        raise argparse.ArgumentTypeError(f"must be between 2 and {MAX_REPEAT}")
+    return parsed
+
+
+def register(subparsers) -> None:
+    p = subparsers.add_parser(
+        "cache-probe",
+        help="Test whether prefix caching is live for one or more text models.",
+        description=(
+            "Send a deterministic synthetic prefix repeatedly and report the raw "
+            "prompt_tokens_details returned by the API. This makes paid live calls; "
+            "the worst-case estimate is shown before confirmation."
+        ),
+    )
+    p.add_argument(
+        "--model", "-m", action="append", default=None, metavar="ID",
+        help=(
+            "Text model to probe (repeatable). Explicit values replace the default "
+            "chat model plus automatic different-family control."
+        ),
+    )
+    p.add_argument(
+        "--prefix-tokens", action="append", type=_prefix_tokens, default=None,
+        metavar="N", help=(
+            f"Approximate synthetic prefix size (repeatable; default "
+            f"{DEFAULT_PREFIX_TOKENS}). Six-digit threshold probes are opt-in."
+        ),
+    )
+    p.add_argument(
+        "--repeat", type=_repeat_count, default=DEFAULT_REPEAT, metavar="N",
+        help=f"Calls per model and prefix size (default {DEFAULT_REPEAT}, max {MAX_REPEAT}).",
+    )
+    p.add_argument(
+        "--json", action="store_true",
+        help="Print one JSON result containing raw per-call usage details.",
+    )
+    p.add_argument(
+        "--yes", "-y", action="store_true",
+        help="Confirm the complete estimated probe matrix without prompting.",
+    )
+    p.add_argument(
+        "--max-spend", type=_numeric.non_negative_float, default=None, metavar="USD",
+        help="Refuse the complete matrix if its worst-case USD estimate exceeds this cap.",
+    )
+    p.set_defaults(handler=_run)
+
+
+def _ordered_unique(values: Iterable) -> list:
+    out = []
+    seen = set()
+    for value in values:
+        if value not in seen:
+            seen.add(value)
+            out.append(value)
+    return out
+
+
+def _advertises_cache(model: dict) -> bool:
+    spec = model.get("model_spec") if isinstance(model, dict) else None
+    pricing = spec.get("pricing") if isinstance(spec, dict) else None
+    return isinstance(pricing, dict) and "cache_input" in pricing
+
+
+def _control_model(models, primary: str) -> Optional[str]:
+    """First cache-advertising model from a different family, in catalog order."""
+    family = _models.model_family(primary)
+    for model in models or []:
+        mid = model.get("id") if isinstance(model, dict) else None
+        if (
+            isinstance(mid, str)
+            and mid != primary
+            and _models.model_family(mid) != family
+            and _advertises_cache(model)
+        ):
+            return mid
+    return None
+
+
+def _resolve_models(args, models) -> Tuple[Optional[List[str]], Optional[int]]:
+    explicit = _ordered_unique(args.model or [])
+    if explicit:
+        resolved = []
+        for requested in explicit:
+            model, rc = _models.resolve_model(
+                requested, models, label="cache-probe", noun="text model"
+            )
+            if rc is not None:
+                return None, rc
+            resolved.append(model)
+        return resolved, None
+
+    configured = userconfig.resolve_default("chat", "model")
+    primary, rc = _models.resolve_model(
+        configured,
+        models,
+        label="cache-probe",
+        noun="text model",
+        config_key="defaults.chat.model",
+    )
+    if rc is not None:
+        return None, rc
+    control = _control_model(models, primary)
+    if control is None:
+        print(
+            "cache-probe: no cache-advertising different-family control model "
+            "is available; probing only the primary model",
+            file=sys.stderr,
+        )
+        return [primary], None
+    return [primary, control], None
+
+
+def _build_prefix(size: int) -> str:
+    # The size marker is at the start, so different sweep sizes cannot warm one
+    # another.  The remainder is intentionally boring ASCII and carries no user or
+    # project content.  Repeating "x " is approximately one token per requested
+    # unit on common tokenizers; the API's actual prompt_tokens is always reported.
+    return f"CACHE-PROBE-V1 SIZE={size}\n" + ("x " * size)
+
+
+def _prefix_byte_bound(size: int) -> int:
+    """Conservative input-token bound without allocating the synthetic prefix."""
+    marker = f"CACHE-PROBE-V1 SIZE={size}\n"
+    return len(marker.encode("ascii")) + (2 * size) + _MESSAGE_OVERHEAD_TOKENS
+
+
+def _body(model: str, prefix: str) -> dict:
+    return {
+        "model": model,
+        "messages": [
+            {"role": "system", "content": prefix},
+            {"role": "user", "content": _PROBE_QUESTION},
+        ],
+        "temperature": 0,
+        "max_tokens": 1,
+        "stream": False,
+    }
+
+
+def _price(models, model_id: str, key: str) -> Optional[float]:
+    for model in models or []:
+        if not isinstance(model, dict) or model.get("id") != model_id:
+            continue
+        spec = model.get("model_spec")
+        pricing = spec.get("pricing") if isinstance(spec, dict) else None
+        node = pricing.get(key) if isinstance(pricing, dict) else None
+        raw = node.get("usd") if isinstance(node, dict) else None
+        try:
+            return _numeric.non_negative_float(raw) / 1_000_000.0
+        except (TypeError, ValueError):
+            return None
+    return None
+
+
+def _estimate(models, model_ids, sizes: List[int], repeat: int) -> dict:
+    calls = len(model_ids) * len(sizes) * repeat
+    input_upper = sum(
+        _prefix_byte_bound(size) for size in sizes
+    ) * len(model_ids) * repeat
+    output_upper = calls
+    total = 0.0
+    missing = []
+    for model_id in model_ids:
+        input_rate = _price(models, model_id, "input")
+        output_rate = _price(models, model_id, "output")
+        if input_rate is None or output_rate is None:
+            missing.append(model_id)
+            continue
+        for size in sizes:
+            max_input = _prefix_byte_bound(size)
+            model_cost = repeat * (max_input * input_rate + output_rate)
+            total += model_cost
+            if not math.isfinite(model_cost) or not math.isfinite(total):
+                missing.append(model_id)
+                break
+    return {
+        # Keep the unrounded value for --max-spend. Display formatting can round,
+        # but a budget rail must never admit a value just above the cap.
+        "usd_upper_bound": None if missing else total,
+        "calls": calls,
+        "input_tokens_upper_bound": input_upper,
+        "completion_tokens_upper_bound": output_upper,
+        "pricing_complete": not missing,
+        "unpriced_models": missing,
+    }
+
+
+def _print_estimate(estimate: dict) -> None:
+    total = estimate["usd_upper_bound"]
+    detail = (
+        f"{estimate['calls']} calls, up to "
+        f"{estimate['input_tokens_upper_bound']} uncached input tokens + "
+        f"{estimate['completion_tokens_upper_bound']} output tokens"
+    )
+    if total is None:
+        missing = ", ".join(estimate["unpriced_models"])
+        print(
+            f"Estimated maximum cost: (unknown -- missing input/output pricing "
+            f"for {missing}; {detail})",
+            file=sys.stderr,
+        )
+    else:
+        print(
+            f"Estimated maximum cost: {billing.format_usd(total)} ({detail})",
+            file=sys.stderr,
+        )
+
+
+def _numeric_cache_value(details) -> Optional[float]:
+    if not isinstance(details, dict):
+        return None
+    value = details.get("cached_tokens")
+    if isinstance(value, bool) or not isinstance(value, (int, float)):
+        return None
+    try:
+        number = float(value)
+    except (TypeError, ValueError):
+        return None
+    return number if math.isfinite(number) and number >= 0 else None
+
+
+def _verdict(calls: List[dict]) -> str:
+    values = [_numeric_cache_value(call.get("prompt_tokens_details")) for call in calls]
+    if any(value is not None and value > 0 for value in values):
+        return "warms"
+    if values and all(value == 0 for value in values):
+        return "never warms"
+    return "field absent"
+
+
+def _call_row(response, n: int) -> dict:
+    usage = response.get("usage") if isinstance(response, dict) else None
+    usage = usage if isinstance(usage, dict) else {}
+    details = usage.get("prompt_tokens_details")
+    row = {
+        "n": n,
+        "prompt_tokens": usage.get("prompt_tokens"),
+        "completion_tokens": usage.get("completion_tokens"),
+        # Preserve the raw object only when it is an object. null/garbage is the
+        # three-state "field absent" result, never normalized into an empty object.
+        "prompt_tokens_details": details if isinstance(details, dict) else None,
+    }
+    try:
+        json.dumps(row, allow_nan=False)
+    except (TypeError, ValueError):
+        raise ValueError("usage block is not valid strict JSON") from None
+    return row
+
+
+def _print_call(model: str, size: int, row: dict, repeat: int) -> None:
+    raw = json.dumps(
+        row["prompt_tokens_details"], allow_nan=False,
+        separators=(",", ":"),
+    )
+    print(
+        f"model={model} prefix_tokens={size} call={row['n']}/{repeat} "
+        f"prompt_tokens={row['prompt_tokens']} prompt_tokens_details={raw}"
+    )
+
+
+def _summaries(model_ids: List[str], results: List[dict]) -> List[dict]:
+    summaries = []
+    for model_id in model_ids:
+        rows = [result for result in results if result["model"] == model_id]
+        summaries.append({
+            "model": model_id,
+            "warms": [row["prefix_tokens"] for row in rows if row["verdict"] == "warms"],
+            "never_warms": [
+                row["prefix_tokens"] for row in rows
+                if row["verdict"] == "never warms"
+            ],
+            "field_absent": [
+                row["prefix_tokens"] for row in rows
+                if row["verdict"] == "field absent"
+            ],
+        })
+    return summaries
+
+
+def _print_summaries(summaries: List[dict]) -> None:
+    for row in summaries:
+        def sizes(key):
+            return ",".join(str(value) for value in row[key]) or "none"
+
+        print(
+            f"{row['model']}: warms={sizes('warms')} "
+            f"never-warms={sizes('never_warms')} "
+            f"field-absent={sizes('field_absent')}"
+        )
+
+
+def _run(args) -> int:
+    sizes = _ordered_unique(args.prefix_tokens or [DEFAULT_PREFIX_TOKENS])
+    try:
+        client = build_client_from_auth()
+    except auth.AuthError as exc:
+        print(str(exc), file=sys.stderr)
+        return 2
+
+    models = _models.catalog(client, "text")
+    model_ids, rc = _resolve_models(args, models)
+    if rc is not None:
+        return rc
+
+    estimate = _estimate(models, model_ids, sizes, args.repeat)
+    _print_estimate(estimate)
+    if _shared.over_budget(estimate["usd_upper_bound"], args.max_spend):
+        shown = (
+            billing.format_usd(estimate["usd_upper_bound"])
+            if estimate["usd_upper_bound"] is not None else "unknown"
+        )
+        print(
+            f"cache-probe: estimate {shown} cannot be kept within --max-spend "
+            f"{billing.format_usd(args.max_spend)}; aborting",
+            file=sys.stderr,
+        )
+        return 1
+    # ``input`` writes its prompt to stdout. Keep a JSON run's stdout as one valid
+    # document by routing only that interactive prompt to stderr.
+    if args.json:
+        with contextlib.redirect_stdout(sys.stderr):
+            rc = _shared.confirm_or_exit(args.yes)
+    else:
+        rc = _shared.confirm_or_exit(args.yes)
+    if rc is not None:
+        return rc
+
+    results = []
+    try:
+        for model_id in model_ids:
+            for size in sizes:
+                # Keep at most one synthetic prefix resident. A wide threshold
+                # sweep should not multiply its largest allocation by row count.
+                prefix = _build_prefix(size)
+                calls = []
+                for n in range(1, args.repeat + 1):
+                    response = client.post_json(
+                        "/chat/completions", _body(model_id, prefix)
+                    )
+                    row = _call_row(response, n)
+                    calls.append(row)
+                    if not args.json:
+                        _print_call(model_id, size, row, args.repeat)
+                results.append({
+                    "model": model_id,
+                    "prefix_tokens": size,
+                    "calls": calls,
+                    "verdict": _verdict(calls),
+                })
+    except VeniceAPIError as exc:
+        print(f"cache-probe: {exc}", file=sys.stderr)
+        return _shared.status_to_exit(exc)
+    except ValueError as exc:
+        print(f"cache-probe: {exc}", file=sys.stderr)
+        return 2
+    except KeyboardInterrupt:
+        print("\ncache-probe: aborted", file=sys.stderr)
+        return 130
+
+    summaries = _summaries(model_ids, results)
+    if args.json:
+        json.dump({
+            "estimate": estimate,
+            "models": model_ids,
+            "prefix_tokens": sizes,
+            "repeat": args.repeat,
+            "results": results,
+            "summary": summaries,
+        }, sys.stdout, indent=2, allow_nan=False)
+        sys.stdout.write("\n")
+    else:
+        _print_summaries(summaries)
+    return 0

--- a/tests/_venice_fake_server.py
+++ b/tests/_venice_fake_server.py
@@ -159,6 +159,17 @@ class FakeVenice:
         with self._lock:
             self._chat.append({"deltas": list(deltas), "usage": _USAGE})
 
+    def reply_usage(self, prompt_tokens_details, *, prompt_tokens=11) -> None:
+        """Queue one non-streamed reply with an exact raw cache-usage block."""
+        usage = {
+            "prompt_tokens": prompt_tokens,
+            "completion_tokens": 1,
+            "total_tokens": prompt_tokens + 1,
+            "prompt_tokens_details": prompt_tokens_details,
+        }
+        with self._lock:
+            self._chat.append({"deltas": ["."], "usage": usage})
+
     def reply_paused_stream(self, first_delta: str) -> threading.Event:
         """Queue one SSE delta, then hold the connection open until released."""
         release = threading.Event()

--- a/tests/test_cache_probe.py
+++ b/tests/test_cache_probe.py
@@ -1,0 +1,279 @@
+"""Tests for the controlled live cache diagnostic (#97); no real API calls."""
+import argparse
+import io
+import json
+import sys
+import unittest
+from unittest import mock
+
+from venice.client import VeniceAPIError
+from venice.commands import cache_probe
+
+
+def _model(mid, *, default=False, family_cache=True, input_price=1.0,
+           output_price=2.0):
+    pricing = {
+        "input": {"usd": input_price},
+        "output": {"usd": output_price},
+    }
+    if family_cache:
+        pricing["cache_input"] = {"usd": input_price / 10}
+    return {
+        "id": mid,
+        "model_spec": {
+            "traits": ["default"] if default else [],
+            "pricing": pricing,
+        },
+    }
+
+
+MODELS = [
+    _model("qwen3-primary", default=True),
+    _model("qwen-2.5-sibling"),
+    _model("llama-control"),
+]
+
+
+def _args(**overrides):
+    base = dict(
+        model=["qwen3-primary"], prefix_tokens=[8], repeat=2,
+        json=False, yes=True, max_spend=None,
+    )
+    base.update(overrides)
+    return argparse.Namespace(**base)
+
+
+def _response(cached, *, details_extra=None, prompt=12):
+    details = None if cached is None else {"cached_tokens": cached}
+    if details is not None and details_extra:
+        details.update(details_extra)
+    return {
+        "usage": {
+            "prompt_tokens": prompt,
+            "completion_tokens": 1,
+            "prompt_tokens_details": details,
+        }
+    }
+
+
+class FakeClient:
+    def __init__(self, responses=()):
+        self.responses = list(responses)
+        self.posts = []
+
+    def get_json(self, path, params=None):
+        self.get = (path, params)
+        return {"data": MODELS}
+
+    def post_json(self, path, body):
+        self.posts.append((path, body))
+        response = self.responses.pop(0)
+        if isinstance(response, Exception):
+            raise response
+        return response
+
+
+class TestArguments(unittest.TestCase):
+    def parser(self):
+        parser = argparse.ArgumentParser()
+        cache_probe.register(parser.add_subparsers(dest="command"))
+        return parser
+
+    def test_repeatable_models_and_sizes_preserve_order(self):
+        args = self.parser().parse_args([
+            "cache-probe", "-m", "a", "-m", "b",
+            "--prefix-tokens", "8192", "--prefix-tokens", "120000",
+            "--repeat", "3", "--json", "--yes", "--max-spend", "1.25",
+        ])
+        self.assertEqual(args.model, ["a", "b"])
+        self.assertEqual(args.prefix_tokens, [8192, 120000])
+        self.assertEqual(args.repeat, 3)
+        self.assertTrue(args.json)
+        self.assertTrue(args.yes)
+        self.assertEqual(args.max_spend, 1.25)
+
+    def test_defaults_are_small_and_two_calls(self):
+        args = self.parser().parse_args(["cache-probe"])
+        self.assertIsNone(args.model)
+        self.assertIsNone(args.prefix_tokens)
+        self.assertEqual(args.repeat, 2)
+
+    def test_prefix_and_repeat_bounds_fail_at_parse_time(self):
+        for argv in (
+            ["cache-probe", "--prefix-tokens", "0"],
+            ["cache-probe", "--prefix-tokens", "1000001"],
+            ["cache-probe", "--repeat", "1"],
+            ["cache-probe", "--repeat", "11"],
+        ):
+            with self.subTest(argv=argv), self.assertRaises(SystemExit) as ctx:
+                self.parser().parse_args(argv)
+            self.assertEqual(ctx.exception.code, 2)
+
+
+class TestSelectionAndEstimation(unittest.TestCase):
+    def test_auto_selection_uses_configured_primary_and_different_family_control(self):
+        args = _args(model=None)
+        with mock.patch(
+            "venice.commands.cache_probe.userconfig.resolve_default",
+            return_value="qwen3-primary",
+        ):
+            resolved, rc = cache_probe._resolve_models(args, MODELS)
+        self.assertIsNone(rc)
+        self.assertEqual(resolved, ["qwen3-primary", "llama-control"])
+
+    def test_explicit_selection_deduplicates_and_adds_no_control(self):
+        resolved, rc = cache_probe._resolve_models(
+            _args(model=["llama-control", "llama-control"]), MODELS
+        )
+        self.assertIsNone(rc)
+        self.assertEqual(resolved, ["llama-control"])
+
+    def test_no_control_warns_and_keeps_primary(self):
+        err = io.StringIO()
+        with mock.patch(
+            "venice.commands.cache_probe.userconfig.resolve_default",
+            return_value=None,
+        ), mock.patch.object(sys, "stderr", err):
+            resolved, rc = cache_probe._resolve_models(
+                _args(model=None), MODELS[:2]
+            )
+        self.assertIsNone(rc)
+        self.assertEqual(resolved, ["qwen3-primary"])
+        self.assertIn("probing only the primary", err.getvalue())
+
+    def test_estimate_is_all_uncached_and_unknown_pricing_fails_closed(self):
+        known = cache_probe._estimate(MODELS, ["qwen3-primary"], [8], 2)
+        self.assertTrue(known["pricing_complete"])
+        self.assertGreater(known["usd_upper_bound"], 0)
+        self.assertEqual(known["calls"], 2)
+
+        broken = [_model("broken", default=True, output_price=float("nan"))]
+        unknown = cache_probe._estimate(broken, ["broken"], [8], 2)
+        self.assertFalse(unknown["pricing_complete"])
+        self.assertIsNone(unknown["usd_upper_bound"])
+        self.assertTrue(cache_probe._shared.over_budget(None, 1.0))
+
+
+class TestResults(unittest.TestCase):
+    def test_three_state_verdict(self):
+        cases = (
+            ([_response(0), _response(10)], "warms"),
+            ([_response(0), _response(0)], "never warms"),
+            ([_response(0), _response(None)], "field absent"),
+            ([_response(None), _response(None)], "field absent"),
+        )
+        for responses, expected in cases:
+            calls = [cache_probe._call_row(r, i + 1) for i, r in enumerate(responses)]
+            with self.subTest(expected=expected):
+                self.assertEqual(cache_probe._verdict(calls), expected)
+
+    def test_raw_extension_is_preserved(self):
+        response = _response(
+            8, details_extra={"provider_extension": {"write": 4, "name": "raw"}}
+        )
+        row = cache_probe._call_row(response, 1)
+        self.assertEqual(row["prompt_tokens_details"], {
+            "cached_tokens": 8,
+            "provider_extension": {"write": 4, "name": "raw"},
+        })
+
+    def test_non_finite_raw_usage_fails_closed(self):
+        response = _response(float("nan"))
+        with self.assertRaisesRegex(ValueError, "strict JSON"):
+            cache_probe._call_row(response, 1)
+
+    def test_prefix_is_stable_within_size_and_distinct_across_sizes(self):
+        first = cache_probe._build_prefix(8)
+        self.assertEqual(first, cache_probe._build_prefix(8))
+        self.assertNotEqual(first, cache_probe._build_prefix(9))
+        self.assertTrue(first.startswith("CACHE-PROBE-V1 SIZE=8\n"))
+
+
+class TestRun(unittest.TestCase):
+    def run_command(self, args, responses):
+        client = FakeClient(responses)
+        out, err = io.StringIO(), io.StringIO()
+        with mock.patch(
+            "venice.commands.cache_probe.build_client_from_auth", return_value=client
+        ), mock.patch.object(sys, "stdout", out), mock.patch.object(sys, "stderr", err):
+            rc = cache_probe._run(args)
+        return rc, client, out.getvalue(), err.getvalue()
+
+    def test_json_matrix_preserves_order_and_raw_calls(self):
+        args = _args(
+            model=["qwen3-primary", "llama-control"],
+            prefix_tokens=[8, 16, 8], repeat=2, json=True,
+        )
+        responses = []
+        for _model_id in range(2):
+            responses.extend([
+                _response(0), _response(8),
+                _response(0), _response(0),
+            ])
+        rc, client, out, err = self.run_command(args, responses)
+        self.assertEqual(rc, 0, err)
+        doc = json.loads(out)
+        self.assertEqual(doc["models"], ["qwen3-primary", "llama-control"])
+        self.assertEqual(doc["prefix_tokens"], [8, 16])
+        self.assertEqual([row["verdict"] for row in doc["results"]], [
+            "warms", "never warms", "warms", "never warms",
+        ])
+        self.assertEqual(len(client.posts), 8)
+        self.assertEqual(client.posts[0][1], client.posts[1][1])
+        self.assertNotEqual(client.posts[1][1], client.posts[2][1])
+
+    def test_over_cap_aborts_before_any_post(self):
+        rc, client, _out, err = self.run_command(
+            _args(max_spend=0), [_response(0), _response(0)]
+        )
+        self.assertEqual(rc, 1)
+        self.assertEqual(client.posts, [])
+        self.assertIn("cannot be kept within --max-spend", err)
+
+    def test_noninteractive_without_yes_aborts_before_any_post(self):
+        client = FakeClient([_response(0), _response(0)])
+        err = io.StringIO()
+        with mock.patch(
+            "venice.commands.cache_probe.build_client_from_auth", return_value=client
+        ), mock.patch(
+            "venice.commands.cache_probe.sys.stdin.isatty", return_value=False
+        ), mock.patch.object(sys, "stderr", err):
+            rc = cache_probe._run(_args(yes=False))
+        self.assertEqual(rc, 1)
+        self.assertEqual(client.posts, [])
+        self.assertIn("pass --yes", err.getvalue())
+
+    def test_json_interactive_prompt_stays_off_stdout(self):
+        client = FakeClient([_response(0), _response(8)])
+        out, err = io.StringIO(), io.StringIO()
+
+        def confirm(prompt):
+            print(prompt, end="")
+            return "y"
+
+        with mock.patch(
+            "venice.commands.cache_probe.build_client_from_auth", return_value=client
+        ), mock.patch(
+            "venice.commands.cache_probe.sys.stdin.isatty", return_value=True
+        ), mock.patch("builtins.input", side_effect=confirm) as input_mock, \
+             mock.patch.object(sys, "stdout", out), \
+             mock.patch.object(sys, "stderr", err):
+            rc = cache_probe._run(_args(json=True, yes=False))
+        self.assertEqual(rc, 0, err.getvalue())
+        self.assertEqual(input_mock.call_args.args, ("Proceed? [y/N] ",))
+        self.assertNotIn("Proceed?", out.getvalue())
+        self.assertIn("Proceed?", err.getvalue())
+        self.assertEqual(json.loads(out.getvalue())["results"][0]["verdict"], "warms")
+
+    def test_api_error_stops_remaining_paid_calls(self):
+        error = VeniceAPIError(503, "/chat/completions", "unavailable")
+        rc, client, _out, err = self.run_command(
+            _args(repeat=3), [_response(0), error, _response(8)]
+        )
+        self.assertEqual(rc, 5)
+        self.assertEqual(len(client.posts), 2)
+        self.assertIn("cache-probe: HTTP 503", err)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -563,8 +563,8 @@ _CONFIG_SURFACES = {
 # command requires an explicit choice here or in `_CONFIG_SURFACES`; otherwise
 # the inventory test fails instead of silently choosing a policy.
 _NO_CONFIG_COMMANDS = frozenset({
-    "completion", "config", "login", "mcp-serve", "memory", "models",
-    "secret", "sessions",
+    "cache-probe", "completion", "config", "login", "mcp-serve", "memory",
+    "models", "secret", "sessions",
 })
 
 

--- a/tests/test_drive_cli.py
+++ b/tests/test_drive_cli.py
@@ -183,6 +183,52 @@ class TestDriveHttp(_DriveCase):
 
 @needs_pty
 class TestDriveCharge(_DriveCase):
+    def test_cache_probe_confirms_before_two_paid_calls(self):
+        self.api.reply_usage(
+            {"cached_tokens": 0, "cache_creation_input_tokens": 8},
+            prompt_tokens=12,
+        )
+        self.api.reply_usage(
+            {"cached_tokens": 8, "provider_extension": "preserved"},
+            prompt_tokens=12,
+        )
+
+        with self.cli(
+            "cache-probe", "--model", "llama-3.3-70b",
+            "--prefix-tokens", "8",
+        ) as d:
+            d.expect("Estimated maximum cost:")
+            d.expect("Proceed? [y/N] ")
+            # The free catalog lookup happened, but no paid completion can precede
+            # the operator's answer.
+            self.assertEqual(self.api.paths, ["/models"])
+            d.send("y")
+            d.expect(
+                'prompt_tokens_details={"cached_tokens":0,'
+                '"cache_creation_input_tokens":8}'
+            )
+            d.expect(
+                'prompt_tokens_details={"cached_tokens":8,'
+                '"provider_extension":"preserved"}'
+            )
+            d.expect("llama-3.3-70b: warms=8")
+            self.assertEqual(d.wait(), 0)
+
+        self.assertEqual(
+            self.api.paths,
+            ["/models", "/chat/completions", "/chat/completions"],
+        )
+        bodies = self.api.bodies("/chat/completions")
+        self.assertEqual(len(bodies), 2)
+        self.assertEqual(bodies[0], bodies[1])
+        self.assertEqual(bodies[0]["max_tokens"], 1)
+        self.assertFalse(bodies[0]["stream"])
+        self.assertTrue(
+            bodies[0]["messages"][0]["content"].startswith(
+                "CACHE-PROBE-V1 SIZE=8\n"
+            )
+        )
+
     def test_image_confirm_accept_writes_the_file(self):
         with self.cli("image", "a cat", "--name", "drive-test") as d:
             d.expect("Estimated cost: $0.0100 USD (1 image, model=venice-sd35)")

--- a/tests/test_fake_server.py
+++ b/tests/test_fake_server.py
@@ -82,6 +82,18 @@ class TestFakeServerViaClient(_NoProxyCase):
         # The POST body is recorded for later assertions.
         self.assertEqual(self.api.bodies("/image/generate"), [{"prompt": "a cat"}])
 
+    def test_scripted_cache_usage_is_preserved(self):
+        self.api.reply_usage(
+            {"cached_tokens": 8000, "provider_extension": {"state": "warm"}},
+            prompt_tokens=8200,
+        )
+        doc = self.client.post_json("/chat/completions", {"model": "m"})
+        self.assertEqual(doc["usage"]["prompt_tokens"], 8200)
+        self.assertEqual(doc["usage"]["prompt_tokens_details"], {
+            "cached_tokens": 8000,
+            "provider_extension": {"state": "warm"},
+        })
+
     def test_authorization_presence_is_recorded_without_the_value(self):
         self.client.get_json("/models", params={"type": "text"})
         entry = self.api.requests[0]


### PR DESCRIPTION
Closes #97.

## Summary
- add a confirmation-gated cache-probe command with repeatable model and prefix-size matrices
- preserve raw prompt_tokens_details and classify each row as warms, never warms, or field absent
- select a different-family cache-advertising control by default and fail closed under max-spend when pricing is unavailable
- document the live diagnostic and cover it with hermetic unit, fake-server, drive, config, and OpenAPI checks

## Validation
- PATH=/tmp/venice-issue97-venv/bin:$PATH VENICE_API_KEY=test-fake-key make test (1869 tests)
- make drive (45 tests)
- make lint
- make scan
- make openapi-check
- git diff --check

No live Venice API calls were made.