### PR TITLE
browser: restore tools behind enforced egress boundary

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,6 +10,24 @@ permissions:
   contents: read
 
 jobs:
+  browser-egress:
+    runs-on: ubuntu-24.04
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v5
+      - uses: actions/setup-python@v6
+        with:
+          python-version: "3.14"
+          cache: pip
+          cache-dependency-path: pyproject.toml
+      - name: Install project
+        run: pip install -e .
+      - name: Verify real Chromium egress containment
+        env:
+          VENICE_BROWSER_REQUIRED: "1"
+          VENICE_API_KEY: test-fake-key
+        run: python -m unittest -v tests.test_browser_integration
+
   test:
     runs-on: ubuntu-latest
     # The drive suite waits on a child process, so a genuine hang would

--- a/README.md
+++ b/README.md
@@ -944,9 +944,11 @@ Details and safety:
 | `--shell-allow CMD` | allow only these commands for `--shell` (repeatable; adds to config `shell.allow`) |
 | `--shell-deny PATTERN` | refuse commands matching these globs (repeatable; adds to config `shell.deny`) |
 | `--shell-unrestricted` | acknowledge an empty allowlist under `--yes` (required for that combination) |
-| `--browser` | reserved; temporarily exits 2 without network access while the browser rail is security-disabled |
-| `--browser-allow HOST` | retained browser-policy config for compatibility; inert while `--browser` is disabled |
-| `--browser-deny PATTERN` | retained browser-policy config for compatibility; inert while `--browser` is disabled |
+| `--browser` | add pinned `web_fetch` and sandboxed Chromium `browser_capture`; implies `--tools` |
+| `--browser-allow HOST` | restrict destinations to matching host globs (repeatable; adds to `browser.allow`) |
+| `--browser-deny PATTERN` | deny matching hosts or URLs; deny wins (repeatable; adds to `browser.deny`) |
+| `--browser-private-host HOST` | authorize an exact private hostname (also requires a private range) |
+| `--browser-private-range CIDR` | authorize a loopback/RFC1918/IPv6-ULA range (also requires an exact host) |
 | `--memory` | add persistent memory + task tools (durable notes + a checklist); implies `--tools` (see [Memory & tasks](#memory--tasks---memory)) |
 | `--mcp NAME` | attach a registered external MCP server's tools (repeatable) |
 | `--no-mcp` | attach no MCP servers (overrides a configured default) |
@@ -987,16 +989,48 @@ venice config set shell.allow '["git", "gh", "ls", "cat"]'
 
 #### Web & browser tools (`--browser`)
 
-`web_fetch` and `browser_capture` are temporarily unavailable while
-[GHSA-mqjr-2vh8-6fvg](https://github.com/sirkitree/venice/security/advisories/GHSA-mqjr-2vh8-6fvg)
-is contained. In v0.83.2, passing `--browser` exits with status 2 before loading the SDK,
-credentials, or any network client. The direct implementation seams also return an error,
-and the agent does not advertise either tool.
+`--browser` opts into two read-only tools. `web_fetch` retrieves bounded HTTP(S) text or
+HTML. `browser_capture` renders post-JS DOM/text and/or a PNG with a Chromium-family
+browser. The browser runs non-root with its normal sandbox enabled, a disposable profile
+and home,
+an allowlisted environment, and no ambient credentials. Firefox is not used because its
+CLI cannot provide the same observable, proxy-enforced capture contract.
 
-The `--browser-allow`, `--browser-deny`, and `browser.*` config keys remain accepted only
-to preserve existing configuration. They do not enable network access. Restoring this rail
-requires an enforced egress boundary that covers redirects, DNS rebinding, browser
-subresources, and page scripts—not another URL-only filter.
+The network boundary is enforced at connection time. Each destination is resolved once,
+the complete answer set is checked, and the socket connects only to one of those numeric
+addresses. HTTPS retains the original hostname for SNI, certificate verification, and
+`Host`. Redirects are capped at five and rechecked. Chromium receives one loopback policy
+proxy for HTTP, HTTPS, WebSockets, redirects, frames, scripts, styles, images, fonts,
+fetch/XHR, workers, service workers, prefetches, and downloads; there is no direct fallback.
+QUIC and non-proxied WebRTC UDP are disabled. A capture is capped at 60 seconds, 128
+proxy connections, 16 concurrent connections, and 32 MiB total proxied traffic; `web_fetch`
+is capped at 2 MiB and 60 seconds.
+
+Public Internet addresses are allowed by default unless narrowed with `browser.allow` or
+denied with `browser.deny` (deny always wins). Loopback and private networks are denied by
+default. Private access needs two independent operator grants: the exact canonical host in
+`browser.private_hosts` and every resolved address inside `browser.private_ranges`.
+Ranges may only be loopback, RFC1918, or IPv6 ULA. Link-local, metadata, multicast,
+reserved, unspecified, and IPv4-mapped IPv6 destinations remain hard-blocked and cannot be
+reopened. The model schemas contain none of these authority fields.
+
+```sh
+venice chat --browser --browser-allow docs.example.com "Read the installation page"
+
+# Deliberate local development access: both grants are required.
+venice code --browser \
+  --browser-private-host 127.0.0.1 \
+  --browser-private-range 127.0.0.1/32 \
+  "Check the app at http://127.0.0.1:3000"
+
+venice config set browser.private_hosts '["dev.internal"]'
+venice config set browser.private_ranges '["10.20.0.0/16"]'
+```
+
+Threat model: pages, redirects, DNS answers, and model-supplied URLs are untrusted. The
+operator controls reachability; a model may use only the already-bound policy. This is a
+network and process-containment boundary, not a promise that page content is trustworthy.
+Do not run `browser_capture` as root, disable the Chromium sandbox, or reuse its profile.
 
 #### Web search (`--web-search`)
 
@@ -1007,8 +1041,7 @@ for (an API's docs, a library's usage, an error message).
 `venice_web_search(query)` makes **one** Venice web-search completion (server-side
 `enable_web_search` + `enable_web_citations`, the same feature behind `venice chat
 --web-search`) and returns a short **answer** plus the **cited URLs**. To then read a cited
-page in full, open it outside Venice: the direct `web_fetch` follow-up rail is temporarily
-disabled as described above.
+page in full, opt into `--browser` and use the pinned `web_fetch` follow-up rail.
 
 ```sh
 # discover: search returns an answer and its cited URLs
@@ -1512,7 +1545,7 @@ jq '.usage.billed_total' ~/.config/venice/sessions/<id>.json
 | `run` | run a shell command (`/bin/sh -c`) at the **active** root | yes |
 | `attach_root` | register another directory as a project root (for work spanning repos) and, by default, switch the active root into it so relative paths and `run`/`git` follow — writes outside the writable roots fail loudly | no |
 | `venice_image` / `venice_image_edit` / `venice_sfx` / `venice_music` / `venice_tts` / `venice_upscale` / `venice_bg_remove` / `venice_video` | generate/edit images, audio & video into the project — **opt-in with `--assets`** | yes |
-| `web_fetch` / `browser_capture` | temporarily unavailable for security; not advertised to the agent (see [Web & browser tools](#web--browser-tools---browser)) | no |
+| `web_fetch` / `browser_capture` | bounded pinned fetch / sandboxed Chromium render — **opt-in with `--browser`** (see [Web & browser tools](#web--browser-tools---browser)) | no |
 | `memory_write` / `memory_read` / `memory_search` / `memory_list` | durable notes the agent recalls across turns/sessions (two tiers: project + global) — **opt-in with `--memory`** (see [Memory & tasks](#memory--tasks---memory)) | no |
 | `task_add` / `task_update` / `task_list` | a project-only checklist the agent tracks (`pending`/`in_progress`/`done`) — **opt-in with `--memory`** | no |
 | `venice_scout` | delegate a read-only investigation to a disposable subagent with a fresh context; returns a structured report so exploration doesn't pollute the main context — **opt-in with `--scout`** (see [Scout subagent](#scout-subagent---scout)) | no |
@@ -1564,7 +1597,7 @@ external diff helpers. Use the confirmed `run` tool for other Git forms.
 | `--max-tool-calls N` | cap tool invocations before forcing a final answer (default 25) |
 | `--exec-timeout SECS` | timeout for `run`/`git` (default 120) |
 | `--shell-allow CMD` / `--shell-deny PATTERN` | scope the `run` tool with the shared allow/deny policy (repeatable; adds to config `shell.*`) |
-| `--browser` / `--browser-allow HOST` / `--browser-deny PATTERN` | compatibility flags for the security-disabled browser rail; `--browser` exits 2 without network access (see [Web & browser tools](#web--browser-tools---browser)) |
+| `--browser` / browser policy flags | expose pinned fetch and sandboxed Chromium tools; public by default, allow/deny globs optional, private access requires both `--browser-private-host` and `--browser-private-range` (see [Web & browser tools](#web--browser-tools---browser)) |
 | `--assets` | also expose the in-process asset-generation tools (image / image-edit / sfx / music / tts / upscale / bg-remove / video) so the agent can create images, audio & video in the project; paid — each confirms per call unless `--auto` |
 | `--scout` | expose `venice_scout`: delegate a read-only investigation to a disposable subagent with a fresh context; keeps exploration out of the main context (see [Scout subagent](#scout-subagent---scout)) |
 | `--spawn` | expose `venice_spawn`: delegate a bounded **write/paid** task to a disposable **worker** subagent with a fresh context and a role-scoped subset of your tools; edit churn stays quarantined and it returns a structured report to merge (see [Worker subagent](#worker-subagent---spawn)) |

--- a/src/venice/_egress.py
+++ b/src/venice/_egress.py
@@ -12,6 +12,7 @@ boundary.  Redirects are revalidated and bounded by :class:`GuardedRedirectHandl
 """
 from __future__ import annotations
 
+import fnmatch
 import http.client
 import ipaddress
 import socket
@@ -19,6 +20,7 @@ import ssl
 import urllib.error
 import urllib.parse
 import urllib.request
+from dataclasses import dataclass
 from typing import List, Optional, Tuple
 
 MAX_REDIRECTS = 5
@@ -26,6 +28,188 @@ MAX_REDIRECTS = 5
 
 class EgressPolicyError(OSError):
     """A URL or resolved destination is outside the public HTTPS policy."""
+
+
+_PRIVATE_AUTHORITY = (
+    ipaddress.ip_network("10.0.0.0/8"),
+    ipaddress.ip_network("172.16.0.0/12"),
+    ipaddress.ip_network("192.168.0.0/16"),
+    ipaddress.ip_network("127.0.0.0/8"),
+    ipaddress.ip_network("fc00::/7"),
+    ipaddress.ip_network("::1/128"),
+)
+_METADATA_HOSTS = frozenset({
+    "metadata.google.internal", "metadata.azure.internal",
+})
+_METADATA_ADDRESSES = frozenset({
+    ipaddress.ip_address("169.254.169.254"),
+    ipaddress.ip_address("169.254.170.2"),
+    ipaddress.ip_address("100.100.100.200"),
+    ipaddress.ip_address("168.63.129.16"),
+    ipaddress.ip_address("fd00:ec2::254"),
+})
+
+
+def _canonical_host(host: str) -> str:
+    value = str(host or "").rstrip(".").lower()
+    if not value:
+        raise EgressPolicyError("URL has no host")
+    try:
+        return value.encode("idna").decode("ascii")
+    except UnicodeError:
+        raise EgressPolicyError("URL host is not valid IDNA") from None
+
+
+def _address(value: str):
+    try:
+        address = ipaddress.ip_address(value.split("%", 1)[0])
+    except ValueError:
+        raise EgressPolicyError("resolver returned an invalid IP address") from None
+    if getattr(address, "ipv4_mapped", None) is not None:
+        raise EgressPolicyError("IPv4-mapped IPv6 destinations are blocked")
+    return address
+
+
+def _hard_blocked(address) -> bool:
+    return (
+        address in _METADATA_ADDRESSES
+        or address.is_link_local
+        or address.is_multicast
+        or address.is_reserved
+        or address.is_unspecified
+    )
+
+
+def _private_authority_network(value: str):
+    try:
+        network = ipaddress.ip_network(str(value), strict=True)
+    except ValueError:
+        raise EgressPolicyError(f"invalid private browser range: {value!r}") from None
+    if not any(
+        network.version == parent.version and network.subnet_of(parent)
+        for parent in _PRIVATE_AUTHORITY
+    ):
+        raise EgressPolicyError(
+            f"private browser range is outside loopback, RFC1918, or IPv6 ULA: {network}"
+        )
+    return network
+
+
+@dataclass(frozen=True)
+class DestinationPolicy:
+    """Immutable operator-owned network authority for an untrusted URL."""
+
+    allow: Tuple[str, ...] = ()
+    deny: Tuple[str, ...] = ()
+    private_hosts: Tuple[str, ...] = ()
+    private_ranges: Tuple[object, ...] = ()
+
+    @classmethod
+    def create(
+        cls, *, allow=(), deny=(), private_hosts=(), private_ranges=()
+    ) -> "DestinationPolicy":
+        hosts = tuple(_canonical_host(host) for host in (private_hosts or ()))
+        ranges = tuple(_private_authority_network(value) for value in (private_ranges or ()))
+        return cls(
+            tuple(str(value) for value in (allow or ())),
+            tuple(str(value) for value in (deny or ())),
+            hosts,
+            ranges,
+        )
+
+    def endpoint(self, url: str, *, schemes=("http", "https")) -> Tuple[str, int, str]:
+        value = str(url or "")
+        if not value or value != value.strip():
+            raise EgressPolicyError("URL is empty or contains surrounding whitespace")
+        if any(ord(ch) < 32 or ord(ch) == 127 for ch in value):
+            raise EgressPolicyError("URL contains control characters")
+        try:
+            parts = urllib.parse.urlsplit(value)
+            port = parts.port
+            raw_host = parts.hostname
+        except ValueError:
+            raise EgressPolicyError(f"invalid URL: {safe_url(value)}") from None
+        scheme = (parts.scheme or "").lower()
+        if scheme not in schemes:
+            raise EgressPolicyError(
+                f"blocked URL scheme {scheme or '(none)'!r}: {safe_url(value)}"
+            )
+        if parts.username is not None or parts.password is not None:
+            raise EgressPolicyError(f"URL userinfo is not allowed: {safe_url(value)}")
+        host = _canonical_host(raw_host or "")
+        if host in _METADATA_HOSTS:
+            raise EgressPolicyError(f"blocked metadata host: {host!r}")
+        for pattern in self.deny:
+            if fnmatch.fnmatch(host, pattern.lower()) or fnmatch.fnmatch(value, pattern):
+                raise EgressPolicyError(f"blocked by browser deny policy: {safe_url(value)}")
+        if self.allow and not any(fnmatch.fnmatch(host, p.lower()) for p in self.allow):
+            raise EgressPolicyError(f"host is not in the browser allowlist: {host!r}")
+        return host, port or (443 if scheme in ("https", "wss") else 80), scheme
+
+    def _authorize_address(self, host: str, value: str):
+        address = _address(value)
+        if _hard_blocked(address):
+            raise EgressPolicyError(f"blocked destination address: {address.compressed}")
+        if address.is_loopback or address.is_private:
+            if host not in self.private_hosts or not any(
+                address.version == network.version and address in network
+                for network in self.private_ranges
+            ):
+                raise EgressPolicyError(
+                    f"blocked private destination address: {address.compressed}"
+                )
+            return address
+        if not address.is_global:
+            raise EgressPolicyError(f"blocked non-public destination: {address.compressed}")
+        return address
+
+    def resolve(self, host: str, port: int) -> List[Tuple[int, int, int, tuple]]:
+        host = _canonical_host(host)
+        try:
+            literal = _address(host)
+        except EgressPolicyError:
+            literal = None
+        if literal is not None:
+            self._authorize_address(host, str(literal))
+            family = socket.AF_INET6 if literal.version == 6 else socket.AF_INET
+            sockaddr = (str(literal), port, 0, 0) if family == socket.AF_INET6 else (str(literal), port)
+            return [(family, socket.SOCK_STREAM, socket.IPPROTO_TCP, sockaddr)]
+        try:
+            answers = socket.getaddrinfo(
+                host, port, family=socket.AF_UNSPEC, type=socket.SOCK_STREAM
+            )
+        except socket.gaierror as exc:
+            raise EgressPolicyError(f"DNS resolution failed for {host!r}: {exc}") from None
+        if not answers:
+            raise EgressPolicyError(f"DNS resolution returned no addresses for {host!r}")
+        validated = []
+        seen = set()
+        for family, socktype, proto, _canonname, sockaddr in answers:
+            if family not in (socket.AF_INET, socket.AF_INET6):
+                raise EgressPolicyError("resolver returned an unsupported address family")
+            self._authorize_address(host, sockaddr[0])
+            key = (family, socktype, proto, sockaddr)
+            if key not in seen:
+                seen.add(key)
+                validated.append(key)
+        return validated
+
+    def connect(self, host: str, port: int, timeout, source_address=None) -> socket.socket:
+        last_error: Optional[OSError] = None
+        for family, socktype, proto, sockaddr in self.resolve(host, port):
+            sock = socket.socket(family, socktype, proto)
+            try:
+                sock.settimeout(timeout)
+                if source_address:
+                    sock.bind(source_address)
+                sock.connect(sockaddr)
+                return sock
+            except OSError as exc:
+                last_error = exc
+                sock.close()
+        if last_error is not None:
+            raise last_error
+        raise EgressPolicyError(f"no usable address for {host!r}")
 
 
 def safe_url(url: str) -> str:
@@ -72,13 +256,7 @@ def validate_https_url(url: str) -> Tuple[str, int]:
 
 
 def _public_ip(value: str):
-    try:
-        address = ipaddress.ip_address(value.split("%", 1)[0])
-    except ValueError:
-        raise EgressPolicyError("resolver returned an invalid IP address") from None
-    mapped = getattr(address, "ipv4_mapped", None)
-    if mapped is not None:
-        address = mapped
+    address = _address(value)
     if (
         not address.is_global
         or address.is_private
@@ -116,6 +294,12 @@ def resolve_public(host: str, port: int) -> List[Tuple[int, int, int, tuple]]:
             seen.add(key)
             validated.append((family, socktype, proto, sockaddr))
     return validated
+
+
+def connect_with_policy(
+    policy: DestinationPolicy, host: str, port: int, timeout, source_address=None
+) -> socket.socket:
+    return policy.connect(host, port, timeout, source_address)
 
 
 def _connect_public(host: str, port: int, timeout, source_address=None) -> socket.socket:
@@ -163,6 +347,92 @@ class PinnedHTTPSHandler(urllib.request.HTTPSHandler):
             return PinnedHTTPSConnection(host, **kwargs)
 
         return self.do_open(connection, req, context=self._context)
+
+
+class PolicyHTTPConnection(http.client.HTTPConnection):
+    def __init__(self, *args, policy: DestinationPolicy, **kwargs):
+        self._policy = policy
+        super().__init__(*args, **kwargs)
+
+    def connect(self) -> None:
+        if self._tunnel_host:
+            raise EgressPolicyError("proxy tunnels are disabled")
+        self.sock = self._policy.connect(
+            self.host, self.port, self.timeout, getattr(self, "source_address", None)
+        )
+
+
+class PolicyHTTPSConnection(http.client.HTTPSConnection):
+    def __init__(self, *args, policy: DestinationPolicy, **kwargs):
+        self._policy = policy
+        super().__init__(*args, **kwargs)
+
+    def connect(self) -> None:
+        if self._tunnel_host:
+            raise EgressPolicyError("proxy tunnels are disabled")
+        raw = self._policy.connect(
+            self.host, self.port, self.timeout, getattr(self, "source_address", None)
+        )
+        try:
+            self.sock = self._context.wrap_socket(raw, server_hostname=self.host)
+        except Exception:
+            raw.close()
+            raise
+
+
+class PolicyHTTPHandler(urllib.request.HTTPHandler):
+    def __init__(self, policy: DestinationPolicy):
+        self.policy = policy
+        super().__init__()
+
+    def http_open(self, req):
+        def connection(host, **kwargs):
+            return PolicyHTTPConnection(host, policy=self.policy, **kwargs)
+        return self.do_open(connection, req)
+
+
+class PolicyHTTPSHandler(urllib.request.HTTPSHandler):
+    def __init__(self, policy: DestinationPolicy, *, context=None):
+        self.policy = policy
+        super().__init__(context=context)
+
+    def https_open(self, req):
+        def connection(host, **kwargs):
+            return PolicyHTTPSConnection(host, policy=self.policy, **kwargs)
+        return self.do_open(connection, req, context=self._context)
+
+
+class PolicyRedirectHandler(urllib.request.HTTPRedirectHandler):
+    max_redirections = MAX_REDIRECTS
+    max_repeats = 2
+
+    def __init__(self, policy: DestinationPolicy):
+        self.policy = policy
+
+    def redirect_request(self, req, fp, code, msg, headers, newurl):
+        try:
+            self.policy.endpoint(newurl)
+        except EgressPolicyError as exc:
+            raise urllib.error.HTTPError(
+                safe_url(newurl), code, f"blocked redirect: {exc}", headers, fp
+            ) from None
+        return super().redirect_request(req, fp, code, msg, headers, newurl)
+
+
+def build_policy_opener(policy: DestinationPolicy) -> urllib.request.OpenerDirector:
+    """Build an HTTP(S)-only opener with no ambient proxy or alternate schemes."""
+    context = ssl.create_default_context()
+    opener = urllib.request.OpenerDirector()
+    for handler in (
+        urllib.request.UnknownHandler(),
+        urllib.request.HTTPDefaultErrorHandler(),
+        PolicyRedirectHandler(policy),
+        PolicyHTTPHandler(policy),
+        PolicyHTTPSHandler(policy, context=context),
+        urllib.request.HTTPErrorProcessor(),
+    ):
+        opener.add_handler(handler)
+    return opener
 
 
 class GuardedRedirectHandler(urllib.request.HTTPRedirectHandler):

--- a/src/venice/commands/_agent.py
+++ b/src/venice/commands/_agent.py
@@ -2867,13 +2867,51 @@ def _tool_section(name: str) -> str:
     return name[len("venice_"):] if name.startswith("venice_") else name
 
 
-def browser_tools(*, allow=(), deny=(), output_dir=None, config=None) -> List[Tool]:
-    """Return no browser tools while the browser rail is security-disabled.
+def _browser_args(arguments) -> dict:
+    controlled = ("allow", "deny", "private_hosts", "private_ranges")
+    return {key: value for key, value in _clean(arguments).items() if key not in controlled}
 
-    Keep this compatibility seam so callers cannot accidentally re-expose the direct
-    tool implementations while GHSA-mqjr-2vh8-6fvg is contained.
-    """
-    return []
+
+def browser_tools(
+    *, allow=(), deny=(), private_hosts=(), private_ranges=(), output_dir=None,
+    config=None,
+) -> List[Tool]:
+    """Build browser tools with all network authority bound by the operator."""
+    fetch_defaults = userconfig.config_defaults_for("browser", _mcp.web_fetch_tool, config)
+    capture_defaults = userconfig.config_defaults_for(
+        "browser", _mcp.browser_capture_tool, config
+    )
+
+    def invoke_fetch(arguments, *, confirm: bool = False):
+        return _mcp.web_fetch_tool(
+            allow=allow, deny=deny, private_hosts=private_hosts,
+            private_ranges=private_ranges,
+            **{**fetch_defaults, **_browser_args(arguments)},
+        )
+
+    def invoke_capture(arguments, *, confirm: bool = False):
+        return _mcp.browser_capture_tool(
+            allow=allow, deny=deny, private_hosts=private_hosts,
+            private_ranges=private_ranges, output_dir=output_dir,
+            **{**capture_defaults, **_browser_args(arguments)},
+        )
+
+    return [
+        Tool(
+            "web_fetch",
+            "Fetch an HTTP(S) URL through a DNS-pinned egress boundary and return "
+            "text or HTML. Redirects are revalidated; operator policy cannot be widened.",
+            _WEB_FETCH_SCHEMA, invoke_fetch, paid=False, category="web",
+            tags=("read", "network"),
+        ),
+        Tool(
+            "browser_capture",
+            "Render an HTTP(S) URL in sandboxed disposable Chromium through an "
+            "enforcing proxy; return DOM/text and/or a screenshot path.",
+            _BROWSER_CAPTURE_SCHEMA, invoke_capture, paid=False, category="web",
+            tags=("read", "network"),
+        ),
+    ]
 
 
 def memory_tools() -> List[Tool]:
@@ -3000,6 +3038,8 @@ def builtin_tools(
     browser: bool = False,
     browser_allow=(),
     browser_deny=(),
+    browser_private_hosts=(),
+    browser_private_ranges=(),
     browser_output_dir: Optional[str] = None,
     memory: bool = False,
     exec_timeout: int = _exec.DEFAULT_EXEC_TIMEOUT,
@@ -3025,8 +3065,7 @@ def builtin_tools(
     rail, not a venice API tool, so it isn't part of the selectable `_BUILTINS`
     set) and is never exposed via `mcp-serve`, which builds its own wrappers.
 
-    `browser` (issue #71) is retained as a compatibility argument but appends no tools
-    while GHSA-mqjr-2vh8-6fvg is contained (see `browser_tools`).
+    `browser` appends the pinned `web_fetch` and sandboxed `browser_capture` rails.
 
     `memory` (issue #49) appends the persistent memory + task rails (`memory_tools`):
     free, local notes (two tiers) + a project task list. Also a rail (added after the
@@ -3152,6 +3191,8 @@ def builtin_tools(
     if browser:
         tools.extend(browser_tools(
             allow=browser_allow, deny=browser_deny,
+            private_hosts=browser_private_hosts,
+            private_ranges=browser_private_ranges,
             output_dir=browser_output_dir, config=config,
         ))
 

--- a/src/venice/commands/_browser.py
+++ b/src/venice/commands/_browser.py
@@ -1,29 +1,290 @@
-"""Fail-closed browser rail containment.
+"""Pinned web fetch and sandboxed Chromium rails for untrusted pages.
 
-The former implementation launched a headless browser after checking only the
-initial URL. Redirects, DNS resolution, subresources, and page-script requests
-then escaped that policy boundary. Until the rail has an enforced egress
-boundary, keep every entry point unavailable and dependency-free.
+Both paths use :class:`venice._egress.DestinationPolicy`. Browser traffic is forced
+through a disposable loopback proxy with no direct fallback, so redirects, frames,
+scripts, CSS, images, fetch/XHR, workers, WebSockets, prefetches, and downloads all
+cross the same resolve-and-pin boundary.
 """
 from __future__ import annotations
 
+import html as _htmlmod
+import os
+import re
+import signal
+import shutil
+import subprocess
+import tempfile
+import urllib.error
+import urllib.parse
+import urllib.request
+from typing import List, Optional, Tuple
 
-UNAVAILABLE_MESSAGE = (
-    "web and browser tools are temporarily disabled for security; "
-    "see GHSA-mqjr-2vh8-6fvg"
+from venice import _egress
+from . import _browser_proxy
+from ._exec import MAX_OUTPUT_CHARS
+
+DEFAULT_WINDOW = (1280, 900)
+DEFAULT_WAIT_MS = 4000
+DEFAULT_TIMEOUT = 30
+MAX_TIMEOUT = 60
+MAX_WAIT_MS = 30_000
+MAX_FETCH_BYTES = 2_000_000
+_UA = "venice-cli/web_fetch (+https://github.com/gobha-me/venice-cli)"
+_CAPTURE_MODES = ("dom", "text", "screenshot", "both")
+_ENV_ALLOW = (
+    "PATH", "HOME", "LANG", "LC_ALL", "TZ", "TMPDIR", "XDG_CACHE_HOME",
+    "XDG_RUNTIME_DIR", "XDG_CONFIG_HOME",
+)
+_BROWSERS: List[Tuple[str, str]] = [
+    ("chromium", "chromium"),
+    ("chromium-browser", "chromium"),
+    ("google-chrome", "chromium"),
+    ("google-chrome-stable", "chromium"),
+    ("chrome", "chromium"),
+    ("brave-browser", "chromium"),
+    ("brave-browser-stable", "chromium"),
+    ("brave", "chromium"),
+]
+_BROWSER_BINARIES = (
+    "/opt/google/chrome/chrome",
+    "/opt/brave.com/brave/brave",
+    "/usr/lib/chromium/chromium",
+    "/usr/lib/chromium-browser/chromium-browser",
 )
 
 
+def find_browser() -> Optional[Tuple[str, str]]:
+    for path in _BROWSER_BINARIES:
+        if os.path.isfile(path) and os.access(path, os.X_OK):
+            return path, "chromium"
+    for name, family in _BROWSERS:
+        path = shutil.which(name)
+        if path:
+            return path, family
+    return None
+
+
+def browser_names() -> str:
+    return ", ".join(name for name, _family in _BROWSERS)
+
+
+def capture_filename(url: str) -> str:
+    try:
+        host = urllib.parse.urlsplit(str(url)).hostname or "page"
+    except ValueError:
+        host = "page"
+    slug = re.sub(r"[^A-Za-z0-9._-]+", "-", host).strip("-") or "page"
+    return f"capture-{slug}.png"
+
+
+def _browser_env(profile=None) -> dict:
+    env = {
+        key: value for key, value in os.environ.items()
+        if key in _ENV_ALLOW or key.startswith("LC_")
+    }
+    env.setdefault("PATH", os.environ.get("PATH", "/usr/bin:/bin"))
+    if profile is not None:
+        env["HOME"] = str(profile)
+        env["XDG_CACHE_HOME"] = os.path.join(str(profile), "cache")
+        env["XDG_CONFIG_HOME"] = os.path.join(str(profile), "config")
+    return env
+
+
+def _policy(*, allow=(), deny=(), private_hosts=(), private_ranges=()):
+    return _egress.DestinationPolicy.create(
+        allow=allow, deny=deny, private_hosts=private_hosts,
+        private_ranges=private_ranges,
+    )
+
+
+def check_url_policy(
+    url, *, allow=(), deny=(), private_hosts=(), private_ranges=()
+) -> Optional[str]:
+    try:
+        policy = _policy(
+            allow=allow, deny=deny, private_hosts=private_hosts,
+            private_ranges=private_ranges,
+        )
+        host, port, _scheme = policy.endpoint(str(url))
+        policy.resolve(host, port)
+    except (_egress.EgressPolicyError, OSError) as exc:
+        return str(exc)
+    return None
+
+
+def _bounded_int(value, default, *, minimum=1, maximum):
+    try:
+        parsed = int(value) if value is not None else default
+    except (TypeError, ValueError):
+        return default
+    return max(minimum, min(parsed, maximum))
+
+
+def _decode(raw: bytes, content_type: str) -> str:
+    charset = "utf-8"
+    match = re.search(r"charset=([\w\-]+)", content_type or "", re.I)
+    if match:
+        charset = match.group(1)
+    try:
+        return raw.decode(charset, errors="replace")
+    except (LookupError, TypeError):
+        return raw.decode("utf-8", errors="replace")
+
+
+_SCRIPT_STYLE = re.compile(r"(?is)<(script|style)\b.*?</\1>")
+_TAGS = re.compile(r"(?s)<[^>]+>")
+_INLINE_WS = re.compile(r"[ \t\r\f\v]+")
+_BLANK_LINES = re.compile(r"\n\s*\n\s*")
+
+
+def html_to_text(text: str) -> str:
+    text = _SCRIPT_STYLE.sub(" ", text)
+    text = _TAGS.sub(" ", text)
+    text = _htmlmod.unescape(text)
+    text = _INLINE_WS.sub(" ", text)
+    return _BLANK_LINES.sub("\n\n", text).strip()
+
+
 def web_fetch(
-    url, *, mode="text", max_bytes=None, timeout=None, allow=(), deny=()
+    url, *, mode="text", max_bytes=None, timeout=None, allow=(), deny=(),
+    private_hosts=(), private_ranges=(),
 ) -> dict:
-    """Fail closed without parsing, resolving, or opening ``url``."""
-    return {"ok": False, "error": UNAVAILABLE_MESSAGE}
+    if mode not in ("text", "html"):
+        return {"ok": False, "error": "unknown mode (use text or html)"}
+    try:
+        policy = _policy(
+            allow=allow, deny=deny, private_hosts=private_hosts,
+            private_ranges=private_ranges,
+        )
+        policy.endpoint(str(url))
+    except _egress.EgressPolicyError as exc:
+        return {"ok": False, "error": str(exc)}
+    cap = _bounded_int(max_bytes, MAX_FETCH_BYTES, maximum=MAX_FETCH_BYTES)
+    seconds = _bounded_int(timeout, DEFAULT_TIMEOUT, maximum=MAX_TIMEOUT)
+    opener = _egress.build_policy_opener(policy)
+    request = urllib.request.Request(str(url), headers={"User-Agent": _UA})
+    try:
+        with opener.open(request, timeout=seconds) as response:
+            raw = response.read(cap + 1)
+            final_url = response.geturl()
+            content_type = response.headers.get("Content-Type", "") or ""
+    except urllib.error.HTTPError as exc:
+        return {"ok": False, "error": f"HTTP {exc.code}: {exc.reason}"}
+    except (urllib.error.URLError, OSError, ValueError) as exc:
+        return {"ok": False, "error": f"fetch failed: {getattr(exc, 'reason', exc)}"}
+    decoded = _decode(raw[:cap], content_type)
+    body = decoded if mode == "html" else html_to_text(decoded)
+    key = "html" if mode == "html" else "text"
+    return {
+        "ok": True,
+        "final_url": _egress.safe_url(final_url),
+        "content_type": content_type,
+        key: body[:MAX_OUTPUT_CHARS],
+        "truncated": len(raw) > cap or len(body) > MAX_OUTPUT_CHARS,
+    }
+
+
+def _chromium_flags(proxy_url: str, profile: str) -> list:
+    return [
+        "--headless=new", "--disable-gpu", "--disable-dev-shm-usage",
+        "--disable-background-networking", "--disable-component-update",
+        "--disable-default-apps", "--disable-extensions", "--disable-sync",
+        "--disable-quic", "--metrics-recording-only", "--no-first-run",
+        "--no-default-browser-check", "--password-store=basic", "--use-mock-keychain",
+        "--force-webrtc-ip-handling-policy=disable_non_proxied_udp",
+        f"--proxy-server={proxy_url}", "--proxy-bypass-list=<-loopback>",
+        f"--user-data-dir={profile}",
+    ]
+
+
+def _run(argv, *, timeout: int, profile=None):
+    try:
+        proc = subprocess.Popen(
+            argv, stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True,
+            env=_browser_env(profile), stdin=subprocess.DEVNULL,
+            cwd=str(profile) if profile is not None else None,
+            start_new_session=(os.name == "posix"),
+        )
+        out, err = proc.communicate(timeout=timeout)
+    except FileNotFoundError:
+        return None, "", "", "no Chromium-family browser available"
+    except subprocess.TimeoutExpired:
+        if os.name == "posix":
+            try:
+                os.killpg(proc.pid, signal.SIGKILL)
+            except ProcessLookupError:
+                pass
+        else:  # pragma: no cover - exercised on Windows CI
+            proc.kill()
+        proc.communicate()
+        return None, "", "", f"browser timed out after {timeout}s"
+    except OSError as exc:
+        return None, "", "", f"browser failed: {exc}"
+    return proc.returncode, out or "", err or "", None
 
 
 def capture(
-    url, *, out_path=None, mode="dom", wait_ms=None, window=None,
-    timeout=None, assert_contains=None, allow=(), deny=(),
+    url, *, out_path=None, mode="dom", wait_ms=None, window=None, timeout=None,
+    assert_contains=None, allow=(), deny=(), private_hosts=(), private_ranges=(),
 ) -> dict:
-    """Fail closed without probing or launching a browser."""
-    return {"ok": False, "error": UNAVAILABLE_MESSAGE}
+    mode = str(mode or "dom")
+    if mode not in _CAPTURE_MODES:
+        return {"ok": False, "error": f"unknown mode {mode!r} (use {'/'.join(_CAPTURE_MODES)})"}
+    if hasattr(os, "geteuid") and os.geteuid() == 0:
+        return {"ok": False, "error": "browser_capture refuses to run Chromium as root"}
+    try:
+        policy = _policy(
+            allow=allow, deny=deny, private_hosts=private_hosts,
+            private_ranges=private_ranges,
+        )
+        host, port, _scheme = policy.endpoint(str(url))
+        policy.resolve(host, port)
+    except (_egress.EgressPolicyError, OSError) as exc:
+        return {"ok": False, "error": str(exc)}
+    found = find_browser()
+    if not found:
+        return {"ok": False, "error": f"no Chromium-family browser available (looked for {browser_names()})"}
+    path, family = found
+    wants_dom = mode in ("dom", "text", "both")
+    wants_shot = mode in ("screenshot", "both")
+    if wants_shot and not out_path:
+        return {"ok": False, "error": "out_path is required for a screenshot"}
+    wait = _bounded_int(wait_ms, DEFAULT_WAIT_MS, minimum=0, maximum=MAX_WAIT_MS)
+    seconds = _bounded_int(timeout, DEFAULT_TIMEOUT, maximum=MAX_TIMEOUT)
+    win = window or DEFAULT_WINDOW
+    try:
+        width, height = int(win[0]), int(win[1])
+        if not (1 <= width <= 7680 and 1 <= height <= 4320):
+            raise ValueError
+    except (TypeError, ValueError, IndexError):
+        return {"ok": False, "error": "window must be a width/height pair within 7680x4320"}
+
+    result = {"ok": True, "browser": os.path.basename(path), "family": family}
+    with tempfile.TemporaryDirectory(prefix="venice-browser-") as profile:
+        with _browser_proxy.policy_proxy(policy) as proxy_url:
+            base = [path, *_chromium_flags(proxy_url, profile),
+                    f"--window-size={width},{height}", f"--virtual-time-budget={wait}"]
+            argv = list(base)
+            if wants_shot:
+                argv.append(f"--screenshot={out_path}")
+            if wants_dom:
+                argv.append("--dump-dom")
+            argv.append(str(url))
+            rc, out, err, error = _run(argv, timeout=seconds, profile=profile)
+            if error:
+                return {"ok": False, "error": error}
+            if wants_shot:
+                if rc != 0 or not os.path.isfile(out_path) or os.path.getsize(out_path) == 0:
+                    return {"ok": False, "error": f"browser produced no screenshot (exit {rc}); stderr: {err[:500].strip()}"}
+                result["screenshot_path"] = str(out_path)
+            if wants_dom:
+                if rc != 0 and not out:
+                    return {"ok": False, "error": f"browser dump-dom failed (exit {rc}); stderr: {err[:500].strip()}"}
+                dom = html_to_text(out) if mode == "text" else out
+                if assert_contains is not None:
+                    needle = str(assert_contains)
+                    result["assert_contains"] = needle
+                    result["contains"] = needle in dom
+                result["truncated"] = len(dom) > MAX_OUTPUT_CHARS
+                result["dom"] = dom[:MAX_OUTPUT_CHARS]
+    return result

--- a/src/venice/commands/_browser_proxy.py
+++ b/src/venice/commands/_browser_proxy.py
@@ -1,0 +1,194 @@
+"""Short-lived loopback proxy enforcing browser destination policy per connection."""
+from __future__ import annotations
+
+import contextlib
+import select
+import socket
+import socketserver
+import threading
+import urllib.parse
+
+from venice import _egress
+
+MAX_HEADER_BYTES = 64 * 1024
+MAX_REQUESTS = 128
+MAX_TRANSFER_BYTES = 32 * 1024 * 1024
+MAX_CONCURRENCY = 16
+IO_TIMEOUT = 30
+
+
+class _Budget:
+    def __init__(self, requests=MAX_REQUESTS, transfer=MAX_TRANSFER_BYTES):
+        self.requests = requests
+        self.transfer = transfer
+        self.lock = threading.Lock()
+
+    def request(self) -> bool:
+        with self.lock:
+            if self.requests <= 0:
+                return False
+            self.requests -= 1
+            return True
+
+    def consume(self, count: int) -> bool:
+        with self.lock:
+            if count > self.transfer:
+                self.transfer = 0
+                return False
+            self.transfer -= count
+            return True
+
+
+def _authority(value: str):
+    value = value.strip()
+    if not value or "@" in value or any(ord(ch) < 33 for ch in value):
+        raise _egress.EgressPolicyError("invalid proxy authority")
+    try:
+        parts = urllib.parse.urlsplit("//" + value)
+        host, port = parts.hostname, parts.port
+    except ValueError:
+        raise _egress.EgressPolicyError("invalid proxy authority") from None
+    if not host or port is None or parts.path or parts.query or parts.fragment:
+        raise _egress.EgressPolicyError("proxy authority requires host and port")
+    return host, port
+
+
+def _read_headers(sock: socket.socket) -> bytes:
+    data = bytearray()
+    while b"\r\n\r\n" not in data:
+        chunk = sock.recv(min(8192, MAX_HEADER_BYTES + 1 - len(data)))
+        if not chunk:
+            break
+        data.extend(chunk)
+        if len(data) > MAX_HEADER_BYTES:
+            raise _egress.EgressPolicyError("proxy request headers are too large")
+    if b"\r\n\r\n" not in data:
+        raise _egress.EgressPolicyError("incomplete proxy request headers")
+    return bytes(data)
+
+
+def _tunnel(left: socket.socket, right: socket.socket, budget: _Budget) -> None:
+    peers = {left: right, right: left}
+    while peers:
+        ready, _, _ = select.select(list(peers), [], [], IO_TIMEOUT)
+        if not ready:
+            return
+        for source in ready:
+            try:
+                chunk = source.recv(64 * 1024)
+            except OSError:
+                return
+            if not chunk:
+                return
+            if not budget.consume(len(chunk)):
+                return
+            try:
+                peers[source].sendall(chunk)
+            except OSError:
+                return
+
+
+class _ProxyHandler(socketserver.BaseRequestHandler):
+    def _reply(self, code: int, reason: str) -> None:
+        try:
+            self.request.sendall(
+                f"HTTP/1.1 {code} {reason}\r\nConnection: close\r\nContent-Length: 0\r\n\r\n".encode("ascii")
+            )
+        except OSError:
+            pass
+
+    def handle(self) -> None:
+        server = self.server
+        if not server.semaphore.acquire(blocking=False):
+            self._reply(503, "Busy")
+            return
+        try:
+            if not server.budget.request():
+                self._reply(429, "Request Limit")
+                return
+            self.request.settimeout(IO_TIMEOUT)
+            raw = _read_headers(self.request)
+            head, rest = raw.split(b"\r\n\r\n", 1)
+            lines = head.split(b"\r\n")
+            try:
+                method_b, target_b, version_b = lines[0].split(b" ", 2)
+                method = method_b.decode("ascii").upper()
+                target = target_b.decode("ascii")
+                version = version_b.decode("ascii")
+            except (ValueError, UnicodeDecodeError):
+                raise _egress.EgressPolicyError("invalid proxy request line") from None
+            if version not in ("HTTP/1.0", "HTTP/1.1"):
+                raise _egress.EgressPolicyError("unsupported proxy protocol")
+
+            if method == "CONNECT":
+                host, port = _authority(target)
+                scheme = "https" if port == 443 else "http"
+                server.policy.endpoint(f"{scheme}://{target}/")
+                upstream = server.policy.connect(host, port, IO_TIMEOUT)
+                with upstream:
+                    self.request.sendall(b"HTTP/1.1 200 Connection Established\r\n\r\n")
+                    if rest:
+                        if not server.budget.consume(len(rest)):
+                            return
+                        upstream.sendall(rest)
+                    _tunnel(self.request, upstream, server.budget)
+                return
+
+            parts = urllib.parse.urlsplit(target)
+            if parts.scheme not in ("http", "ws"):
+                raise _egress.EgressPolicyError("proxy requires absolute HTTP URLs")
+            host, port, _scheme = server.policy.endpoint(
+                target, schemes=("http", "ws")
+            )
+            upstream = server.policy.connect(host, port, IO_TIMEOUT)
+            with upstream:
+                path = urllib.parse.urlunsplit(("", "", parts.path or "/", parts.query, ""))
+                filtered = []
+                for line in lines[1:]:
+                    name = line.split(b":", 1)[0].strip().lower()
+                    if name in (b"proxy-authorization", b"proxy-connection"):
+                        continue
+                    filtered.append(line)
+                outgoing = (
+                    b" ".join((method_b, path.encode("ascii"), version_b))
+                    + b"\r\n"
+                    + b"\r\n".join(filtered)
+                    + b"\r\n\r\n"
+                    + rest
+                )
+                if not server.budget.consume(len(outgoing)):
+                    return
+                upstream.sendall(outgoing)
+                _tunnel(self.request, upstream, server.budget)
+        except _egress.EgressPolicyError:
+            self._reply(403, "Forbidden")
+        except (OSError, UnicodeError, ValueError):
+            self._reply(502, "Bad Gateway")
+        finally:
+            server.semaphore.release()
+
+
+class _ProxyServer(socketserver.ThreadingMixIn, socketserver.TCPServer):
+    allow_reuse_address = False
+    daemon_threads = True
+
+    def __init__(self, policy, *, requests=MAX_REQUESTS, transfer=MAX_TRANSFER_BYTES):
+        self.policy = policy
+        self.budget = _Budget(requests, transfer)
+        self.semaphore = threading.BoundedSemaphore(MAX_CONCURRENCY)
+        super().__init__(("127.0.0.1", 0), _ProxyHandler)
+
+
+@contextlib.contextmanager
+def policy_proxy(policy: _egress.DestinationPolicy):
+    """Yield the enforcing proxy URL and tear it down after the browser exits."""
+    server = _ProxyServer(policy)
+    thread = threading.Thread(target=server.serve_forever, name="venice-browser-proxy")
+    thread.daemon = True
+    thread.start()
+    try:
+        yield f"http://127.0.0.1:{server.server_address[1]}"
+    finally:
+        server.shutdown()
+        server.server_close()
+        thread.join(timeout=5)

--- a/src/venice/commands/_code.py
+++ b/src/venice/commands/_code.py
@@ -808,6 +808,8 @@ def code_tools(
     browser: bool = False,
     browser_allow=(),
     browser_deny=(),
+    browser_private_hosts=(),
+    browser_private_ranges=(),
     memory: bool = False,
 ) -> List[_agent.Tool]:
     """Build the coding tools bound to a realpath-resolved project `root`.
@@ -830,8 +832,7 @@ def code_tools(
     Empty lists leave `run` unrestricted (only the confirm gate), preserving the prior
     behavior of autonomous `venice code` runs.
 
-    `browser` (#71) is retained for call compatibility but appends no tools while
-    GHSA-mqjr-2vh8-6fvg is contained (see `_agent.browser_tools`).
+    `browser` (#71/#127) appends the pinned fetch and sandboxed browser rails.
 
     `memory` (#49) appends the persistent memory + task rails (`_agent.memory_tools`):
     free, local notes (two tiers) + a project task list the agent maintains across
@@ -986,10 +987,10 @@ def code_tools(
         ))
 
     if browser:
-        # Compatibility seam only: browser_tools returns [] while the rail is disabled
-        # for GHSA-mqjr-2vh8-6fvg.
         tools.extend(_agent.browser_tools(
             allow=browser_allow, deny=browser_deny,
+            private_hosts=browser_private_hosts,
+            private_ranges=browser_private_ranges,
             output_dir=os.environ.get("VENICE_MCP_OUTPUT_DIR") or root,
             config=config,
         ))

--- a/src/venice/commands/_mcp.py
+++ b/src/venice/commands/_mcp.py
@@ -1436,19 +1436,62 @@ def task_list_tool(client, *, status=None) -> dict:
 
 def web_fetch_tool(
     url, *, mode: str = "text", max_bytes: Optional[int] = None,
-    timeout: Optional[int] = None, allow=(), deny=(),
+    timeout: Optional[int] = None, allow=(), deny=(), private_hosts=(),
+    private_ranges=(),
 ) -> dict:
-    """Fail closed while the browser rail has no enforced egress boundary."""
-    return _err(f"web_fetch: {_browser.UNAVAILABLE_MESSAGE}")
+    """Fetch through the pinned operator-owned HTTP(S) egress boundary."""
+    if not url or not str(url).strip():
+        return _err("web_fetch: url is required")
+    res = _browser.web_fetch(
+        str(url), mode=(mode or "text"), max_bytes=max_bytes, timeout=timeout,
+        allow=allow, deny=deny, private_hosts=private_hosts,
+        private_ranges=private_ranges,
+    )
+    if not res.get("ok"):
+        return _err(f"web_fetch: {res.get('error', 'failed')}")
+    out = {
+        "status": "ok", "url": str(url), "final_url": res.get("final_url"),
+        "content_type": res.get("content_type"),
+        "truncated": res.get("truncated", False),
+    }
+    for key in ("text", "html"):
+        if key in res:
+            out[key] = res[key]
+    return out
 
 
 def browser_capture_tool(
     url, *, mode: str = "dom", wait_ms: Optional[int] = None, timeout: Optional[int] = None,
     assert_contains: Optional[str] = None, output_dir: Optional[str] = None,
-    allow=(), deny=(),
+    allow=(), deny=(), private_hosts=(), private_ranges=(),
 ) -> dict:
-    """Fail closed while the browser rail has no enforced egress boundary."""
-    return _err(f"browser_capture: {_browser.UNAVAILABLE_MESSAGE}")
+    """Render through sandboxed Chromium and its enforced loopback proxy."""
+    if not url or not str(url).strip():
+        return _err("browser_capture: url is required")
+    selected = mode or "dom"
+    out_path = None
+    if selected in ("screenshot", "both"):
+        out_dir = resolve_output_dir(output_dir)
+        try:
+            out_dir.mkdir(parents=True, exist_ok=True)
+        except OSError as exc:
+            return _err(f"browser_capture: cannot create output dir {out_dir}: {exc}")
+        out_path = str(out_dir / _browser.capture_filename(url))
+    res = _browser.capture(
+        str(url), out_path=out_path, mode=selected, wait_ms=wait_ms,
+        timeout=timeout, assert_contains=assert_contains, allow=allow, deny=deny,
+        private_hosts=private_hosts, private_ranges=private_ranges,
+    )
+    if not res.get("ok"):
+        return _err(f"browser_capture: {res.get('error', 'failed')}")
+    out = {
+        "status": "ok", "url": str(url), "mode": selected,
+        "browser": res.get("browser"), "family": res.get("family"),
+    }
+    for key in ("screenshot_path", "dom", "truncated", "assert_contains", "contains"):
+        if key in res:
+            out[key] = res[key]
+    return out
 
 
 def models_tool(client, *, type: str) -> dict:

--- a/src/venice/commands/chat.py
+++ b/src/venice/commands/chat.py
@@ -22,7 +22,7 @@ from typing import Optional
 from .. import _numeric, auth, userconfig
 from ..client import build_client_from_auth
 from . import (
-    _agent, _browser, _compact, _mcp, _mcp_client, _models, _openai, _persona,
+    _agent, _compact, _mcp, _mcp_client, _models, _openai, _persona,
     _repl, _session,
 )
 
@@ -222,20 +222,29 @@ def register(subparsers) -> None:
     )
     ag.add_argument(
         "--browser", action="store_true", dest="browser", default=None,
-        help="Reserved browser rail flag. Temporarily unavailable for security; "
-        "fails closed before any API or network access.",
+        help="Add DNS-pinned web_fetch and sandboxed browser_capture tools. Implies --tools.",
     )
     ag.add_argument(
         "--browser-allow", action="append", dest="browser_allow", default=None,
         metavar="HOST",
-        help="Retained browser.allow config compatibility option; inert while the "
-        "browser rail is security-disabled.",
+        help="Restrict browser destinations to matching host globs (repeatable).",
     )
     ag.add_argument(
         "--browser-deny", action="append", dest="browser_deny", default=None,
         metavar="PATTERN",
-        help="Retained browser.deny config compatibility option; inert while the "
-        "browser rail is security-disabled.",
+        help="Deny matching browser hosts or URLs; repeatable and deny wins.",
+    )
+    ag.add_argument(
+        "--browser-private-host", action="append", dest="browser_private_host",
+        default=None, metavar="HOST",
+        help="Explicitly authorize this exact private/loopback hostname (repeatable; "
+        "also requires --browser-private-range).",
+    )
+    ag.add_argument(
+        "--browser-private-range", action="append", dest="browser_private_range",
+        default=None, metavar="CIDR",
+        help="Authorize a loopback, RFC1918, or IPv6 ULA CIDR (repeatable; also "
+        "requires --browser-private-host).",
     )
     ag.add_argument(
         "--memory", action="store_true", dest="memory", default=None,
@@ -447,12 +456,9 @@ def _run(args) -> int:
         return 2
     _session.apply_to_args(args, session, "chat")
     userconfig.apply_defaults(args, "chat")
-    if getattr(args, "browser", None):
-        print(f"chat: {_browser.UNAVAILABLE_MESSAGE}", file=sys.stderr)
-        return 2
-    # --shell (#33) and --memory (#49) are tools, so they imply the agent loop. A
-    # requested --browser has already failed above.
-    if (getattr(args, "shell", None) or getattr(args, "memory", None)) \
+    # These are tools, so each opt-in implies the agent loop.
+    if (getattr(args, "shell", None) or getattr(args, "memory", None)
+            or getattr(args, "browser", None)) \
             and not getattr(args, "tools", None):
         args.tools = True
     # A startup persona (--persona or defaults.chat.persona) seeds the same lever
@@ -554,10 +560,15 @@ def _tools_for(args, client, models, model):
             return None, 2
     browser_on = bool(getattr(args, "browser", None))
     browser_allow, browser_deny = (), ()
+    browser_private_hosts, browser_private_ranges = (), ()
     if browser_on:
         bpol = userconfig.browser_policy(doc)  # #71 URL allow/deny policy
         browser_allow = list(bpol["allow"]) + list(getattr(args, "browser_allow", None) or [])
         browser_deny = list(bpol["deny"]) + list(getattr(args, "browser_deny", None) or [])
+        browser_private_hosts = list(bpol["private_hosts"]) + list(
+            getattr(args, "browser_private_host", None) or [])
+        browser_private_ranges = list(bpol["private_ranges"]) + list(
+            getattr(args, "browser_private_range", None) or [])
     try:
         tools = _agent.builtin_tools(
             client,
@@ -572,6 +583,8 @@ def _tools_for(args, client, models, model):
             browser=browser_on,
             browser_allow=browser_allow,
             browser_deny=browser_deny,
+            browser_private_hosts=browser_private_hosts,
+            browser_private_ranges=browser_private_ranges,
             browser_output_dir=str(args.output) if args.output else None,
             memory=bool(getattr(args, "memory", None)),
         )

--- a/src/venice/commands/code.py
+++ b/src/venice/commands/code.py
@@ -41,7 +41,7 @@ from typing import List, Optional
 
 from .. import _numeric, auth, config, userconfig
 from ..client import build_client_from_auth
-from . import (_agent, _browser, _code, _compact, _mailbox, _models, _openai,
+from . import (_agent, _code, _compact, _mailbox, _models, _openai,
                _repl, _review, _session, _steer)
 
 _DEFAULT_MAX_TOOL_CALLS = 25
@@ -261,20 +261,29 @@ def register(subparsers) -> None:
     )
     grp.add_argument(
         "--browser", action="store_true", dest="browser", default=None,
-        help="Reserved browser rail flag. Temporarily unavailable for security; "
-        "fails closed before any API or network access.",
+        help="Add DNS-pinned web_fetch and sandboxed browser_capture tools.",
     )
     grp.add_argument(
         "--browser-allow", action="append", dest="browser_allow", default=None,
         metavar="HOST",
-        help="Retained browser.allow config compatibility option; inert while the "
-        "browser rail is security-disabled.",
+        help="Restrict browser destinations to matching host globs (repeatable).",
     )
     grp.add_argument(
         "--browser-deny", action="append", dest="browser_deny", default=None,
         metavar="PATTERN",
-        help="Retained browser.deny config compatibility option; inert while the "
-        "browser rail is security-disabled.",
+        help="Deny matching browser hosts or URLs; repeatable and deny wins.",
+    )
+    grp.add_argument(
+        "--browser-private-host", action="append", dest="browser_private_host",
+        default=None, metavar="HOST",
+        help="Authorize this exact private/loopback hostname (repeatable; also "
+        "requires --browser-private-range).",
+    )
+    grp.add_argument(
+        "--browser-private-range", action="append", dest="browser_private_range",
+        default=None, metavar="CIDR",
+        help="Authorize a loopback, RFC1918, or IPv6 ULA CIDR (repeatable; also "
+        "requires --browser-private-host).",
     )
     grp.add_argument(
         "--memory", action="store_true", dest="memory", default=None,
@@ -758,10 +767,6 @@ def _run(args) -> int:
     _session.apply_to_args(args, session, "code")
     userconfig.apply_defaults(args, "code")
     userconfig.apply_literals(args, cache_guard="warn")
-    if getattr(args, "browser", None):
-        print(f"code: {_browser.UNAVAILABLE_MESSAGE}", file=sys.stderr)
-        return 2
-
     # Faithful root restore: an explicit --root/$VENICE_CODE_ROOT still wins, else a
     # resumed session re-sandboxes to where it left off (tools + system prompt rebind
     # to this root below), else the cwd.
@@ -821,6 +826,10 @@ def _run(args) -> int:
     bpol = userconfig.browser_policy(doc)  # #71 retained compatibility config
     browser_allow = list(bpol["allow"]) + list(getattr(args, "browser_allow", None) or [])
     browser_deny = list(bpol["deny"]) + list(getattr(args, "browser_deny", None) or [])
+    browser_private_hosts = list(bpol["private_hosts"]) + list(
+        getattr(args, "browser_private_host", None) or [])
+    browser_private_ranges = list(bpol["private_ranges"]) + list(
+        getattr(args, "browser_private_range", None) or [])
     rpol = userconfig.roots_policy(doc)  # #76 extra writable / read-only roots
     allow_root = list(rpol["allow"]) + list(getattr(args, "allow_root", None) or [])
     deny_root = list(rpol["deny"]) + list(getattr(args, "deny_root", None) or [])
@@ -843,6 +852,8 @@ def _run(args) -> int:
         browser=bool(getattr(args, "browser", None)),  # #71
         browser_allow=browser_allow,
         browser_deny=browser_deny,
+        browser_private_hosts=browser_private_hosts,
+        browser_private_ranges=browser_private_ranges,
         memory=bool(getattr(args, "memory", None)),  # #49
     )
     # gen_kwargs is built BEFORE the scout tool (its nested loop needs these per-turn

--- a/src/venice/userconfig.py
+++ b/src/venice/userconfig.py
@@ -199,19 +199,23 @@ def shell_policy(doc: dict) -> dict:
 
 
 def browser_policy(doc: dict) -> dict:
-    """Read the retained top-level ``browser`` allow/deny configuration.
+    """Read operator-owned browser network authority.
 
     Mirrors :func:`shell_policy` (a non-`defaults` top-level section with its own reader);
     ``venice config set browser.deny '["*.internal"]'`` round-trips through the generic
-    dotted-key store with no extra plumbing. Browser tools are security-disabled for
-    GHSA-mqjr-2vh8-6fvg; retaining this reader avoids destructive config migrations.
+    dotted-key store with no extra plumbing. Private access requires both an exact
+    hostname and an address range, keeping the two grants independently auditable.
     """
     section = doc.get("browser")
     if not isinstance(section, dict):
-        return {"allow": [], "deny": []}
+        return {"allow": [], "deny": [], "private_hosts": [], "private_ranges": []}
     return {
         "allow": _as_list(section["allow"]) if section.get("allow") else [],
         "deny": _as_list(section["deny"]) if section.get("deny") else [],
+        "private_hosts": _as_list(section["private_hosts"])
+        if section.get("private_hosts") else [],
+        "private_ranges": _as_list(section["private_ranges"])
+        if section.get("private_ranges") else [],
     }
 
 
@@ -694,9 +698,7 @@ _COMMAND_MAP = {
         "scale": ("scale", _numeric.finite_float),
         "creativity": ("creativity", _numeric.finite_float),
     },
-    # #71 compatibility-only browser defaults. The tools are security-disabled for
-    # GHSA-mqjr-2vh8-6fvg, but these keys remain readable so existing configs survive and
-    # a future egress-isolated replacement does not require a migration.
+    # #71/#127 browser resource defaults; hard caps remain in the implementation.
     "browser": {
         "wait_ms": ("wait_ms", int),
         "timeout": ("timeout", int),

--- a/tests/test_agent.py
+++ b/tests/test_agent.py
@@ -3207,25 +3207,32 @@ class TestShellTool(unittest.TestCase):
 
 
 class TestBrowserTools(unittest.TestCase):
-    """GHSA containment: no agent path can advertise the browser rails."""
+    """Browser rails are opt-in and their authority is operator-bound."""
 
     def test_absent_by_default(self):
         names = {t.name for t in _agent.builtin_tools(object())}
         self.assertNotIn("web_fetch", names)
         self.assertNotIn("browser_capture", names)
 
-    def test_absent_even_when_enabled(self):
+    def test_present_only_when_enabled(self):
         names = {t.name for t in _agent.builtin_tools(object(), browser=True)}
-        self.assertNotIn("web_fetch", names)
-        self.assertNotIn("browser_capture", names)
+        self.assertIn("web_fetch", names)
+        self.assertIn("browser_capture", names)
 
-    def test_does_not_bypass_only_filter(self):
+    def test_rail_is_appended_after_only_filter(self):
         tools = _agent.builtin_tools(object(), only={"venice_chat"}, browser=True)
-        self.assertEqual({t.name for t in tools}, {"venice_chat"})
+        self.assertEqual({t.name for t in tools}, {"venice_chat", "web_fetch", "browser_capture"})
 
-    def test_browser_tools_seam_is_empty(self):
-        self.assertEqual(_agent.browser_tools(
-            allow=["example.com"], deny=["internal"], output_dir="/tmp", config={}), [])
+    def test_model_cannot_replace_operator_policy(self):
+        with mock.patch.object(_agent._mcp, "web_fetch_tool", return_value={"status": "ok"}) as impl:
+            tool = next(t for t in _agent.browser_tools(
+                allow=["example.com"], deny=["internal"],
+                private_hosts=["dev.local"], private_ranges=["10.0.0.0/8"],
+                output_dir="/tmp", config={}) if t.name == "web_fetch")
+            tool.invoke({"url": "https://example.com", "allow": ["evil"],
+                         "private_ranges": ["0.0.0.0/0"]})
+        self.assertEqual(impl.call_args.kwargs["allow"], ["example.com"])
+        self.assertEqual(impl.call_args.kwargs["private_ranges"], ["10.0.0.0/8"])
 
 
 class TestConfigDefaults(unittest.TestCase):

--- a/tests/test_browser.py
+++ b/tests/test_browser.py
@@ -1,50 +1,213 @@
-"""Containment tests for the security-disabled browser rail.
-
-Hermetic: these regressions prove both public entry points fail closed without DNS,
-HTTP, or a browser subprocess while GHSA-mqjr-2vh8-6fvg is contained.
-"""
+"""Hermetic tests for the enforced web/browser egress boundary (#127)."""
+import contextlib
+import http.server
+import os
 import socket
-import subprocess
+import tempfile
+import threading
 import unittest
-import urllib.request
 from unittest import mock
 
-from venice.commands import _browser
+from venice import _egress
+from venice.commands import _browser, _browser_proxy
 
 
-class TestBrowserContainment(unittest.TestCase):
-    def _assert_disabled(self, result):
-        self.assertFalse(result["ok"])
-        self.assertIn("temporarily disabled for security", result["error"])
-        self.assertIn("GHSA-mqjr-2vh8-6fvg", result["error"])
+class _Handler(http.server.BaseHTTPRequestHandler):
+    host_headers = []
 
-    def test_web_fetch_always_fails_closed(self):
-        for url in (
-            "https://example.com/",
-            "http://127.0.0.1/",
-            "http://169.254.169.254/latest/meta-data/",
-            "file:///etc/passwd",
-        ):
-            with self.subTest(url=url):
-                self._assert_disabled(_browser.web_fetch(url))
+    def do_GET(self):
+        type(self).host_headers.append(self.headers.get("Host"))
+        redirects = {
+            "/redirect": "http://127.0.0.2/private?token=secret",
+            "/redirect-private": "http://10.0.0.1/private?token=secret",
+            "/redirect-link-local": "http://169.254.169.254/latest/meta-data/?token=secret",
+            "/redirect-metadata": "http://metadata.google.internal/?token=secret",
+            "/redirect-mapped": "http://[::ffff:127.0.0.2]/private?token=secret",
+        }
+        if self.path in redirects:
+            self.send_response(302)
+            self.send_header("Location", redirects[self.path])
+            self.end_headers()
+            return
+        body = b"<html><script>secret()</script><body>Hello boundary</body></html>"
+        self.send_response(200)
+        self.send_header("Content-Type", "text/html; charset=utf-8")
+        self.send_header("Content-Length", str(len(body)))
+        self.end_headers()
+        self.wfile.write(body)
 
-    def test_capture_always_fails_closed(self):
-        for mode in ("dom", "text", "screenshot", "both"):
-            with self.subTest(mode=mode):
-                self._assert_disabled(_browser.capture(
-                    "https://example.com/", mode=mode, out_path="unused.png"))
+    def log_message(self, _format, *_args):
+        pass
 
-    def test_entry_points_never_touch_network_or_processes(self):
-        with mock.patch.object(urllib.request, "urlopen") as urlopen, \
-                mock.patch.object(urllib.request, "build_opener") as build_opener, \
-                mock.patch.object(socket, "getaddrinfo") as getaddrinfo, \
-                mock.patch.object(subprocess, "run") as run:
-            self._assert_disabled(_browser.web_fetch("https://example.com/"))
-            self._assert_disabled(_browser.capture("https://example.com/"))
-        urlopen.assert_not_called()
-        build_opener.assert_not_called()
-        getaddrinfo.assert_not_called()
-        run.assert_not_called()
+
+@contextlib.contextmanager
+def _origin():
+    server = http.server.ThreadingHTTPServer(("127.0.0.1", 0), _Handler)
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    try:
+        yield server.server_address[1]
+    finally:
+        server.shutdown()
+        server.server_close()
+        thread.join(timeout=5)
+
+
+def _private_policy(**kwargs):
+    values = {
+        "private_hosts": ["127.0.0.1"],
+        "private_ranges": ["127.0.0.1/32"],
+    }
+    values.update(kwargs)
+    return _egress.DestinationPolicy.create(**values)
+
+
+class TestDestinationPolicy(unittest.TestCase):
+    def test_private_access_requires_exact_host_and_range(self):
+        for hosts, ranges in (([], []), (["127.0.0.1"], []), ([], ["127.0.0.1/32"])):
+            policy = _egress.DestinationPolicy.create(
+                private_hosts=hosts, private_ranges=ranges
+            )
+            with self.subTest(hosts=hosts, ranges=ranges), self.assertRaises(
+                _egress.EgressPolicyError
+            ):
+                policy.resolve("127.0.0.1", 80)
+        self.assertEqual(_private_policy().resolve("127.0.0.1", 80)[0][3], ("127.0.0.1", 80))
+
+    def test_private_range_authority_is_narrow(self):
+        for value in ("0.0.0.0/0", "8.8.8.0/24", "169.254.0.0/16", "ff00::/8"):
+            with self.subTest(value=value), self.assertRaises(_egress.EgressPolicyError):
+                _egress.DestinationPolicy.create(private_ranges=[value])
+
+    def test_deny_wins_and_metadata_names_are_hard_blocked(self):
+        policy = _egress.DestinationPolicy.create(
+            allow=["*.example"], deny=["secret.example"],
+            private_hosts=["metadata.google.internal"], private_ranges=["10.0.0.0/8"],
+        )
+        with self.assertRaises(_egress.EgressPolicyError):
+            policy.endpoint("https://secret.example/")
+        with self.assertRaises(_egress.EgressPolicyError):
+            policy.endpoint("http://metadata.google.internal/")
+
+    def test_mixed_dns_answer_fails_closed(self):
+        answer = lambda value: (socket.AF_INET, socket.SOCK_STREAM, 6, "", (value, 443))
+        policy = _egress.DestinationPolicy.create()
+        with mock.patch("venice._egress.socket.getaddrinfo", return_value=[
+            answer("8.8.8.8"), answer("127.0.0.1")
+        ]), self.assertRaises(_egress.EgressPolicyError):
+            policy.resolve("rebind.example", 443)
+
+    def test_mapped_loopback_and_metadata_addresses_are_never_authorized(self):
+        policy = _egress.DestinationPolicy.create(
+            private_hosts=["::ffff:127.0.0.1", "169.254.169.254", "100.100.100.200"],
+            private_ranges=["127.0.0.0/8", "10.0.0.0/8"],
+        )
+        for host in ("::ffff:127.0.0.1", "169.254.169.254", "100.100.100.200"):
+            with self.subTest(host=host), self.assertRaises(_egress.EgressPolicyError):
+                policy.resolve(host, 80)
+
+
+class TestWebFetch(unittest.TestCase):
+    def test_authorized_loopback_fetch_and_size_cap(self):
+        _Handler.host_headers = []
+        with _origin() as port:
+            result = _browser.web_fetch(
+                f"http://127.0.0.1:{port}/", max_bytes=10_000,
+                private_hosts=["127.0.0.1"], private_ranges=["127.0.0.1/32"],
+            )
+        self.assertTrue(result["ok"], result)
+        self.assertEqual(result["text"], "Hello boundary")
+        self.assertFalse(result["truncated"])
+        self.assertEqual(_Handler.host_headers, [f"127.0.0.1:{port}"])
+
+    def test_redirects_to_special_destinations_are_blocked_without_contact(self):
+        with _origin() as port:
+            for path in (
+                "/redirect", "/redirect-private", "/redirect-link-local",
+                "/redirect-metadata", "/redirect-mapped",
+            ):
+                with self.subTest(path=path):
+                    result = _browser.web_fetch(
+                        f"http://127.0.0.1:{port}{path}",
+                        private_hosts=["127.0.0.1"],
+                        private_ranges=["127.0.0.1/32"],
+                    )
+                    self.assertFalse(result["ok"])
+                    self.assertNotIn("secret", result["error"])
+
+    def test_no_ambient_proxy_or_alternate_scheme_handlers(self):
+        opener = _egress.build_policy_opener(_egress.DestinationPolicy.create())
+        names = {type(handler).__name__ for handler in opener.handlers}
+        self.assertNotIn("ProxyHandler", names)
+        self.assertNotIn("FileHandler", names)
+        self.assertNotIn("FTPHandler", names)
+
+
+class TestPolicyProxy(unittest.TestCase):
+    def test_absolute_http_request_reaches_only_authorized_origin(self):
+        with _origin() as port, _browser_proxy.policy_proxy(_private_policy()) as proxy:
+            proxy_port = int(proxy.rsplit(":", 1)[1])
+            with socket.create_connection(("127.0.0.1", proxy_port), timeout=3) as sock:
+                sock.sendall(
+                    f"GET http://127.0.0.1:{port}/ HTTP/1.1\r\n"
+                    f"Host: 127.0.0.1:{port}\r\nConnection: close\r\n\r\n".encode()
+                )
+                response = b""
+                while True:
+                    chunk = sock.recv(8192)
+                    if not chunk:
+                        break
+                    response += chunk
+        self.assertIn(b"200 OK", response)
+        self.assertIn(b"Hello boundary", response)
+
+    def test_connect_to_special_destinations_is_forbidden(self):
+        with _browser_proxy.policy_proxy(_private_policy()) as proxy:
+            proxy_port = int(proxy.rsplit(":", 1)[1])
+            for authority in (
+                "127.0.0.2:443", "10.0.0.1:443", "169.254.169.254:443",
+                "100.100.100.200:443", "[::ffff:127.0.0.2]:443",
+            ):
+                with self.subTest(authority=authority), socket.create_connection(
+                    ("127.0.0.1", proxy_port), timeout=3
+                ) as sock:
+                    sock.sendall(
+                        f"CONNECT {authority} HTTP/1.1\r\nHost: {authority}\r\n\r\n".encode()
+                    )
+                    response = sock.recv(1024)
+                    self.assertIn(b"403 Forbidden", response)
+
+
+class TestChromiumContainment(unittest.TestCase):
+    def test_argv_has_proxy_and_sandbox_without_no_sandbox(self):
+        with tempfile.TemporaryDirectory() as directory, mock.patch.object(
+            _browser, "find_browser", return_value=("/usr/bin/chromium", "chromium")
+        ), mock.patch.object(
+            _browser._egress.DestinationPolicy, "resolve", return_value=[]
+        ), mock.patch.object(
+            _browser._browser_proxy, "policy_proxy", return_value=contextlib.nullcontext("http://127.0.0.1:9999")
+        ), mock.patch.object(
+            _browser, "_run", return_value=(0, "<html>ok</html>", "", None)
+        ) as run:
+            result = _browser.capture("https://example.com/", mode="dom", timeout=3)
+        self.assertTrue(result["ok"], result)
+        argv = run.call_args.args[0]
+        self.assertIn("--proxy-server=http://127.0.0.1:9999", argv)
+        self.assertIn("--proxy-bypass-list=<-loopback>", argv)
+        self.assertIn("--disable-quic", argv)
+        self.assertIn("--force-webrtc-ip-handling-policy=disable_non_proxied_udp", argv)
+        self.assertNotIn("--no-sandbox", argv)
+
+    def test_browser_environment_drops_credentials_and_proxies(self):
+        with mock.patch.dict(os.environ, {
+            "VENICE_API_KEY": "do-not-copy", "HTTPS_PROXY": "http://proxy",
+            "PATH": "/bin",
+        }, clear=True):
+            env = _browser._browser_env("/tmp/disposable-profile")
+        self.assertEqual(env["PATH"], "/bin")
+        self.assertEqual(env["HOME"], "/tmp/disposable-profile")
+        self.assertNotIn("VENICE_API_KEY", env)
+        self.assertNotIn("HTTPS_PROXY", env)
 
 
 if __name__ == "__main__":

--- a/tests/test_browser_integration.py
+++ b/tests/test_browser_integration.py
@@ -1,0 +1,118 @@
+"""Real-Chromium egress containment test; required by the dedicated CI job."""
+import http.server
+import os
+import socket
+import threading
+import unittest
+from unittest import mock
+
+from venice.commands import _browser
+
+
+class _Allowed(http.server.BaseHTTPRequestHandler):
+    blocked_port = 0
+
+    def do_GET(self):
+        if self.path == "/ok":
+            body = b"BOUNDARY_OK"
+        elif self.path == "/redirect":
+            self.send_response(302)
+            self.send_header(
+                "Location", f"http://127.0.0.2:{self.blocked_port}/redirected"
+            )
+            self.end_headers()
+            return
+        else:
+            target = f"http://127.0.0.2:{self.blocked_port}"
+            alternate = str(127 * 256 ** 3 + 2)
+            body = f"""<!doctype html><html><head>
+<link rel=stylesheet href='{target}/style.css'>
+<link rel=prefetch href='{target}/prefetch'>
+<script src='{target}/script.js'></script></head><body>
+<img src='{target}/image.png'><img src='http://{alternate}:{self.blocked_port}/alternate.png'>
+<iframe src='{target}/frame'></iframe><iframe src='/redirect'></iframe>
+<a id=d download href='{target}/download'>download</a><div id=result>waiting</div>
+<script>
+fetch('/ok').then(r => r.text()).then(t => document.querySelector('#result').textContent=t);
+fetch('{target}/fetch').catch(()=>{{}});
+fetch('http://[::ffff:127.0.0.2]/mapped').catch(()=>{{}});
+try {{ let x=new XMLHttpRequest(); x.open('GET','{target}/xhr'); x.send(); }} catch(e) {{}}
+try {{ new Worker('{target}/worker.js'); }} catch(e) {{}}
+try {{ navigator.serviceWorker.register('{target}/sw.js'); }} catch(e) {{}}
+try {{ new WebSocket('ws://127.0.0.2:{self.blocked_port}/socket'); }} catch(e) {{}}
+document.querySelector('#d').click();
+</script></body></html>""".encode()
+        self.send_response(200)
+        self.send_header("Content-Type", "text/html; charset=utf-8")
+        self.send_header("Content-Length", str(len(body)))
+        self.end_headers()
+        self.wfile.write(body)
+
+    def log_message(self, _format, *_args):
+        pass
+
+
+class _Blocked(http.server.BaseHTTPRequestHandler):
+    count = 0
+    lock = threading.Lock()
+
+    def _hit(self):
+        with self.lock:
+            type(self).count += 1
+        self.send_response(204)
+        self.end_headers()
+
+    do_GET = _hit
+
+    def log_message(self, _format, *_args):
+        pass
+
+
+class TestRealBrowserBoundary(unittest.TestCase):
+    def test_all_page_traffic_is_confined_to_policy_proxy(self):
+        required = os.environ.get("VENICE_BROWSER_REQUIRED") == "1"
+        if not required:
+            self.skipTest("real browser containment runs in its dedicated CI job")
+        if not _browser.find_browser():
+            self.fail("dedicated browser job requires a Chromium-family browser")
+        blocked = http.server.ThreadingHTTPServer(("127.0.0.2", 0), _Blocked)
+        _Allowed.blocked_port = blocked.server_address[1]
+        allowed = http.server.ThreadingHTTPServer(("127.0.0.1", 0), _Allowed)
+        _Blocked.count = 0
+        threads = [
+            threading.Thread(target=server.serve_forever, daemon=True)
+            for server in (allowed, blocked)
+        ]
+        for thread in threads:
+            thread.start()
+        try:
+            def resolve(host, port, **_kwargs):
+                if host != "fixture.test":
+                    raise AssertionError(f"unexpected DNS lookup outside proxy policy: {host}")
+                return [(
+                    socket.AF_INET, socket.SOCK_STREAM, socket.IPPROTO_TCP, "",
+                    ("127.0.0.1", port),
+                )]
+
+            with mock.patch("venice._egress.socket.getaddrinfo", side_effect=resolve):
+                result = _browser.capture(
+                    f"http://fixture.test:{allowed.server_address[1]}/",
+                    mode="dom", wait_ms=3000, timeout=45,
+                    assert_contains="BOUNDARY_OK",
+                    allow=["fixture.test"],
+                    private_hosts=["fixture.test"],
+                    private_ranges=["127.0.0.1/32"],
+                )
+        finally:
+            for server in (allowed, blocked):
+                server.shutdown()
+                server.server_close()
+            for thread in threads:
+                thread.join(timeout=5)
+        self.assertTrue(result.get("ok"), result)
+        self.assertTrue(result.get("contains"), result)
+        self.assertEqual(_Blocked.count, 0, "Chromium reached an unauthorized loopback peer")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_browser_integration.py
+++ b/tests/test_browser_integration.py
@@ -15,7 +15,7 @@ class _Allowed(http.server.BaseHTTPRequestHandler):
     def do_GET(self):
         if self.path == "/ok":
             body = b"BOUNDARY_OK"
-        elif self.path == "/redirect":
+        elif self.path in ("/redirect", "/download"):
             self.send_response(302)
             self.send_header(
                 "Location", f"http://127.0.0.2:{self.blocked_port}/redirected"
@@ -31,7 +31,7 @@ class _Allowed(http.server.BaseHTTPRequestHandler):
 <script src='{target}/script.js'></script></head><body>
 <img src='{target}/image.png'><img src='http://{alternate}:{self.blocked_port}/alternate.png'>
 <iframe src='{target}/frame'></iframe><iframe src='/redirect'></iframe>
-<a id=d download href='{target}/download'>download</a><div id=result>waiting</div>
+<iframe src='/download'></iframe><div id=result>waiting</div>
 <script>
 fetch('/ok').then(r => r.text()).then(t => document.querySelector('#result').textContent=t);
 fetch('{target}/fetch').catch(()=>{{}});
@@ -40,7 +40,6 @@ try {{ let x=new XMLHttpRequest(); x.open('GET','{target}/xhr'); x.send(); }} ca
 try {{ new Worker('{target}/worker.js'); }} catch(e) {{}}
 try {{ navigator.serviceWorker.register('{target}/sw.js'); }} catch(e) {{}}
 try {{ new WebSocket('ws://127.0.0.2:{self.blocked_port}/socket'); }} catch(e) {{}}
-document.querySelector('#d').click();
 </script></body></html>""".encode()
         self.send_response(200)
         self.send_header("Content-Type", "text/html; charset=utf-8")

--- a/tests/test_chat.py
+++ b/tests/test_chat.py
@@ -31,8 +31,9 @@ def _args(**ov):
         max_spend=None, yes=None, output=None,
         # --- shell exec tool (#33) ---
         shell=None, shell_allow=None, shell_deny=None, shell_unrestricted=None,
-        # --- browser compatibility flags (#71; security-disabled) ---
+        # --- browser egress rail (#71/#127) ---
         browser=None, browser_allow=None, browser_deny=None,
+        browser_private_host=None, browser_private_range=None,
         # --- external MCP client (#21) ---
         mcp=None, no_mcp=False,
         # --- interactive / REPL (#22) ---
@@ -244,20 +245,14 @@ class TestChat(unittest.TestCase):
             rc = chat._run(args)
         return rc, fake, captured
 
-    def test_browser_flag_fails_before_sdk_auth_or_network(self):
+    def test_browser_flag_implies_agent_tools(self):
         from venice.commands import chat
-        err = io.StringIO()
-        with mock.patch.object(chat._openai, "import_openai") as import_openai, \
-                mock.patch.object(chat, "build_client_from_auth") as build_client, \
-                mock.patch("venice.client.urllib.request.urlopen") as urlopen, \
-                mock.patch.object(sys, "stderr", err):
-            rc = chat._run(_args(message="fetch a page", browser=True, stream=False))
-        self.assertEqual(rc, 2)
-        self.assertIn("temporarily disabled for security", err.getvalue())
-        self.assertIn("GHSA-mqjr-2vh8-6fvg", err.getvalue())
-        import_openai.assert_not_called()
-        build_client.assert_not_called()
-        urlopen.assert_not_called()
+        args = _args(message="fetch a page", browser=True, stream=False)
+        with mock.patch.object(chat, "_run_agent", return_value=0) as agent_loop:
+            rc, _fake, _captured = self._run(args, FakeCompletion("unused"))
+        self.assertEqual(rc, 0)
+        self.assertTrue(args.tools)
+        agent_loop.assert_called_once()
 
     def test_reply_printed_non_stream(self):
         out = io.StringIO()

--- a/tests/test_code.py
+++ b/tests/test_code.py
@@ -563,10 +563,10 @@ class TestCodeFactory(unittest.TestCase):
         self.assertNotIn("web_fetch", names)
         self.assertNotIn("browser_capture", names)
 
-    def test_browser_tools_absent_even_when_enabled(self):
+    def test_browser_tools_present_when_enabled(self):
         names = {t.name for t in _code.code_tools("/tmp", browser=True)}
-        self.assertNotIn("web_fetch", names)
-        self.assertNotIn("browser_capture", names)
+        self.assertIn("web_fetch", names)
+        self.assertIn("browser_capture", names)
 
 
 class TestRoots(unittest.TestCase):

--- a/tests/test_code_command.py
+++ b/tests/test_code_command.py
@@ -52,6 +52,7 @@ def _code_args(**ov):
         review=None, review_model=None, review_rounds=None,   # #80 part 1a
         web_search=None, web_search_model=None,
         browser=None, browser_allow=None, browser_deny=None,
+        browser_private_host=None, browser_private_range=None,
     )
     base.update(ov)
     return argparse.Namespace(**base)
@@ -235,21 +236,19 @@ class TestCodeCommand(unittest.TestCase):
             rc = code._run(args)
         return rc, calls
 
-    def test_browser_flag_fails_before_sdk_auth_or_network(self):
+    def test_browser_policy_is_passed_to_code_tools(self):
         from venice.commands import code
-        err = io.StringIO()
-        with mock.patch.object(code._openai, "import_openai") as import_openai, \
-                mock.patch.object(code, "build_client_from_auth") as build_client, \
-                mock.patch("venice.client.urllib.request.urlopen") as urlopen, \
-                mock.patch.object(sys, "stderr", err):
-            rc = code._run(_code_args(
-                task="fetch a page", root=self.root, browser=True, auto=True))
-        self.assertEqual(rc, 2)
-        self.assertIn("temporarily disabled for security", err.getvalue())
-        self.assertIn("GHSA-mqjr-2vh8-6fvg", err.getvalue())
-        import_openai.assert_not_called()
-        build_client.assert_not_called()
-        urlopen.assert_not_called()
+        args = _code_args(
+            task="fetch a page", root=self.root, browser=True, auto=True,
+            browser_private_host=["dev.local"],
+            browser_private_range=["10.0.0.0/8"],
+        )
+        with mock.patch.object(code._code, "code_tools", return_value=[]) as build, \
+                mock.patch.object(code, "_run_oneshot", return_value=0):
+            rc, _calls = self._run(args, [FakeToolCompletion("plan")])
+        self.assertEqual(rc, 0)
+        self.assertEqual(build.call_args.kwargs["browser_private_hosts"], ["dev.local"])
+        self.assertEqual(build.call_args.kwargs["browser_private_ranges"], ["10.0.0.0/8"])
 
     # --- plan-only ---
     def test_plan_only_prints_and_exits_without_executing(self):

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -508,7 +508,8 @@ _CONFIG_SURFACES = {
         "chat",
         ["chat", "p"],
         {
-            "browser", "browser_allow", "browser_deny", "cont", "ephemeral",
+            "browser", "browser_allow", "browser_deny", "browser_private_host",
+            "browser_private_range", "cont", "ephemeral",
             "interactive", "json", "memory", "no_mcp", "no_thinking",
             "no_venice_system_prompt", "resume", "shell", "shell_allow",
             "shell_deny", "shell_unrestricted", "stream", "strip_thinking",
@@ -541,7 +542,8 @@ _CONFIG_SURFACES = {
         "code",
         ["code", "task"],
         {
-            "allow_root", "browser", "browser_allow", "browser_deny", "cont",
+            "allow_root", "browser", "browser_allow", "browser_deny",
+            "browser_private_host", "browser_private_range", "cont",
             "deny_root", "ephemeral", "interactive", "json", "manual",
             "max_tokens", "memory", "no_plan", "no_verify", "plan_only",
             "resume", "shell_allow", "shell_deny", "temperature",
@@ -607,6 +609,8 @@ _CLI_ONLY_REASONS = {
     "browser": "runtime capability enablement",
     "browser_allow": "runtime network authority",
     "browser_deny": "runtime network authority",
+    "browser_private_host": "runtime private network authority",
+    "browser_private_range": "runtime private network authority",
     "cont": "session identity",
     "deny_root": "runtime path authority",
     "dry_run": "one-run execution mode",
@@ -1905,20 +1909,30 @@ class TestBrowserPolicy(_Base):
     """The top-level `browser` URL allow/deny reader (#71), mirroring shell_policy."""
 
     def test_missing_and_malformed_are_empty(self):
-        self.assertEqual(uc.browser_policy({}), {"allow": [], "deny": []})
-        self.assertEqual(uc.browser_policy({"browser": "nope"}), {"allow": [], "deny": []})
+        empty = {"allow": [], "deny": [], "private_hosts": [], "private_ranges": []}
+        self.assertEqual(uc.browser_policy({}), empty)
+        self.assertEqual(uc.browser_policy({"browser": "nope"}), empty)
 
     def test_reads_lists_and_coerces_scalar(self):
-        doc = {"browser": {"allow": ["example.com"], "deny": "*.internal"}}
+        doc = {"browser": {
+            "allow": ["example.com"], "deny": "*.internal",
+            "private_hosts": "dev.internal",
+            "private_ranges": ["10.20.0.0/16"],
+        }}
         self.assertEqual(
             uc.browser_policy(doc),
-            {"allow": ["example.com"], "deny": ["*.internal"]},
+            {"allow": ["example.com"], "deny": ["*.internal"],
+             "private_hosts": ["dev.internal"],
+             "private_ranges": ["10.20.0.0/16"]},
         )
 
     def test_dotted_key_set_roundtrips(self):
         doc = uc.load_config()
         uc.set_value(doc, "browser.deny", ["*.internal"])
-        self.assertEqual(uc.browser_policy(doc), {"allow": [], "deny": ["*.internal"]})
+        self.assertEqual(uc.browser_policy(doc), {
+            "allow": [], "deny": ["*.internal"],
+            "private_hosts": [], "private_ranges": [],
+        })
 
 
 class TestRootsPolicy(_Base):

--- a/tests/test_mcp_tools.py
+++ b/tests/test_mcp_tools.py
@@ -1697,29 +1697,38 @@ class TestReindexTool(_ToolTest):
 
 
 class TestWebFetchTool(_ToolTest):
-    """The retained MCP implementation seam fails closed without network access."""
+    """The MCP seam delegates to the pinned implementation."""
 
-    def test_always_errors_without_calling_backend(self):
-        with mock.patch.object(_mcp._browser, "web_fetch") as backend, \
+    def test_delegates_policy_and_shapes_success(self):
+        with mock.patch.object(
+                _mcp._browser, "web_fetch",
+                return_value={"ok": True, "text": "hello", "final_url": "https://example.com/", "content_type": "text/plain"},
+        ) as backend, \
                 self.stdout_guard():
-            r = _mcp.web_fetch_tool("https://example.com/")
-        self.assertEqual(r["status"], "error")
-        self.assertIn("temporarily disabled for security", r["message"])
-        backend.assert_not_called()
+            r = _mcp.web_fetch_tool(
+                "https://example.com/", private_hosts=["host"],
+                private_ranges=["10.0.0.0/8"],
+            )
+        self.assertEqual(r["status"], "ok")
+        self.assertEqual(r["text"], "hello")
+        self.assertEqual(backend.call_args.kwargs["private_hosts"], ["host"])
 
 
 class TestBrowserCaptureTool(_ToolTest):
-    """The retained capture implementation seam fails closed without side effects."""
+    """The capture seam delegates and keeps output authority host-owned."""
 
-    def test_always_errors_without_calling_backend_or_writing(self):
-        with mock.patch.object(_mcp._browser, "capture") as backend, \
+    def test_delegates_to_browser_backend(self):
+        with mock.patch.object(
+                _mcp._browser, "capture",
+                return_value={"ok": True, "browser": "chromium", "family": "chromium", "dom": "ok"},
+        ) as backend, \
                 self.stdout_guard():
             r = _mcp.browser_capture_tool(
-                "https://example.com/", mode="screenshot", output_dir=self.td)
-        self.assertEqual(r["status"], "error")
-        self.assertIn("temporarily disabled for security", r["message"])
+                "https://example.com/", mode="dom", output_dir=self.td)
+        self.assertEqual(r["status"], "ok")
+        self.assertEqual(r["dom"], "ok")
         self.assertEqual(list(Path(self.td).iterdir()), [])
-        backend.assert_not_called()
+        backend.assert_called_once()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Closes #127.

## Summary
- generalize the pinned transport into one immutable destination policy shared by `web_fetch` and browser traffic
- force sandboxed, non-root Chromium through a short-lived loopback policy proxy with no direct fallback
- add deny-wins public policy plus dual-key private host/CIDR authority that models cannot widen
- restore chat/code agent wiring, document the threat model, and add a required real-Chromium containment job

## Security boundary
- complete DNS answer sets are validated and sockets connect only to the validated numeric address
- loopback/private/link-local/metadata/multicast/reserved/unspecified/mapped addresses fail closed by default
- TLS keeps the original hostname for SNI/certificate validation and HTTP keeps the original Host
- redirects, proxy connections, bytes, concurrency, render time, environment, profile/home, and process cleanup are bounded
- no `--no-sandbox`; QUIC and non-proxied WebRTC UDP are disabled

## Validation
- `VENICE_API_KEY=test-fake-key PYTHONPATH=src python3 -m unittest -v tests.test_browser tests.test_egress tests.test_mcp_tools.TestWebFetchTool tests.test_mcp_tools.TestBrowserCaptureTool tests.test_agent.TestBrowserTools tests.test_chat.TestChat.test_browser_flag_implies_agent_tools tests.test_code.TestCodeFactory.test_browser_tools_present_when_enabled tests.test_code_command.TestCodeCommand.test_browser_policy_is_passed_to_code_tools`
- affected suite: 732 tests passed
- `make lint`
- `make scan`
- `git diff --check`
- full local discovery reached 1,879 tests; 39 unrelated MCP wiring tests cannot run because the shared environment has an incompatible installed MCP SDK (`mcp.server.mcpserver` and `mcp.Client` are absent). Hosted CI installs the declared extras and is authoritative.
- no live Venice API calls