### PR TITLE
installer: diagnose pip-owned venice command

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,19 +101,19 @@ PYTHONPATH=src python3 -m venice --help
 For an editable install: `pip install -e ".[openai]"`.
 
 Alternatively `./install.sh` puts `venice` on your PATH without pip, by creating
-two symlinks:
+one symlink:
 - `~/.local/bin/venice` -> `<repo>/bin/venice`
-- `~/.local/lib/venice` -> `<repo>/src/venice`
 
 and `~/.config/venice/` (mode 0700) for the credentials file. The installer
 resolves the repo path itself, so the clone can live wherever you like.
 `~/.local/bin` should be on your PATH.
 
 > **Don't mix pip and `./install.sh`.** Both own `~/.local/bin/venice`. If pip
-> got there first, `install.sh` refuses to clobber the real file and exits 1. If
-> `install.sh` got there first, pip silently replaces the symlink — your repo
-> edits stop taking effect with no error. Pick one; `pip uninstall venice-cli`
-> or `./uninstall.sh` to back the other out.
+> got there first, `install.sh` identifies the pip wrapper, refuses to clobber
+> it, and prints the uninstall/editable-install choices. If `install.sh` got
+> there first, pip silently replaces the symlink — your repo edits stop taking
+> effect with no error. Pick one; `pip uninstall venice-cli` or `./uninstall.sh`
+> to back the other out.
 
 ### Shell completion
 

--- a/install.sh
+++ b/install.sh
@@ -33,7 +33,6 @@ REPO="$(CDPATH= cd -P "$(dirname "$SCRIPT")" && pwd)"
 BIN_SRC="$REPO/bin/venice"
 PKG_SRC="$REPO/src/venice"
 BIN_DST="$HOME/.local/bin/venice"
-LIB_DST="$HOME/.local/lib/venice"
 CFG_DIR="$HOME/.config/venice"
 
 [ -f "$BIN_SRC" ] || { echo "missing: $BIN_SRC" >&2; exit 1; }
@@ -41,7 +40,6 @@ CFG_DIR="$HOME/.config/venice"
 [ -x "$BIN_SRC" ] || chmod +x "$BIN_SRC"
 
 mkdir -p "$HOME/.local/bin"
-mkdir -p "$HOME/.local/lib"
 
 if [ ! -d "$CFG_DIR" ]; then
     mkdir -p "$CFG_DIR"
@@ -50,6 +48,25 @@ if [ ! -d "$CFG_DIR" ]; then
 else
     chmod 700 "$CFG_DIR"
 fi
+
+is_pip_console_script() {
+    candidate="$1"
+    [ -f "$candidate" ] || return 1
+    # Modern pip wrappers import the configured entry point directly.  Older
+    # setuptools wrappers resolve the same distribution/entry-point tuple at
+    # runtime.  Inspect fixed markers only: executing the destination, its
+    # shebang interpreter, or ambient pip would not prove who owns this file.
+    if grep -F "from venice.cli import main" "$candidate" >/dev/null 2>&1 \
+       && grep -F "sys.exit(main())" "$candidate" >/dev/null 2>&1; then
+        return 0
+    fi
+    if grep -F "load_entry_point(" "$candidate" >/dev/null 2>&1 \
+       && grep -F "venice-cli" "$candidate" >/dev/null 2>&1 \
+       && grep -F "'console_scripts', 'venice'" "$candidate" >/dev/null 2>&1; then
+        return 0
+    fi
+    return 1
+}
 
 link() {
     src="$1"; dst="$2"
@@ -63,7 +80,13 @@ link() {
         ln -s "$src" "$dst"
         echo "updated  $dst -> $src  (was: $current)"
     elif [ -e "$dst" ]; then
-        echo "REFUSE   $dst exists and is not a symlink -- remove it manually" >&2
+        if is_pip_console_script "$dst"; then
+            echo "REFUSE   $dst looks like the pip-installed venice-cli command" >&2
+            echo "Remove it first: pip uninstall venice-cli" >&2
+            echo "Or use pip for development: pip install -e ." >&2
+        else
+            echo "REFUSE   $dst exists and is not a symlink -- remove it manually" >&2
+        fi
         return 1
     else
         ln -s "$src" "$dst"
@@ -72,7 +95,6 @@ link() {
 }
 
 link "$BIN_SRC" "$BIN_DST"
-link "$PKG_SRC" "$LIB_DST"
 
 # Bash completion (best-effort; source installs only). pip users instead run
 # `source <(venice completion bash)`. Never fatal: a missing dir or unwritable

--- a/tests/test_install_scripts.py
+++ b/tests/test_install_scripts.py
@@ -84,9 +84,9 @@ class InstallScriptTests(unittest.TestCase):
         bin_link = self.home / ".local/bin/venice"
         lib_link = self.home / ".local/lib/venice"
         self.assertTrue(bin_link.is_symlink())
-        self.assertTrue(lib_link.is_symlink())
         self.assertEqual(os.readlink(bin_link), str(ROOT / "bin/venice"))
-        self.assertEqual(os.readlink(lib_link), str(ROOT / "src/venice"))
+        self.assertFalse(lib_link.exists())
+        self.assertFalse(lib_link.parent.exists())
         config_dir = self.home / ".config/venice"
         self.assertEqual(stat.S_IMODE(config_dir.stat().st_mode), 0o700)
         self.assertEqual(
@@ -94,9 +94,21 @@ class InstallScriptTests(unittest.TestCase):
             f"# venice source completion owner: {ROOT}",
         )
 
+        reinstalled = self.run_script("install.sh")
+        self.assertEqual(reinstalled.returncode, 0, reinstalled.stderr)
+        self.assertIn(
+            f"ok       {bin_link} -> {ROOT / 'bin/venice'}",
+            reinstalled.stdout,
+        )
+        self.assertFalse(lib_link.parent.exists())
+
         credentials = config_dir / "credentials"
         credentials.write_text("test-fake-key\n", encoding="utf-8")
         credentials.chmod(0o600)
+
+        # uninstall.sh retains exact-target cleanup for pre-#20 installs.
+        lib_link.parent.mkdir(parents=True)
+        lib_link.symlink_to(ROOT / "src/venice")
 
         uninstalled = self.run_script("uninstall.sh", through_symlink=True)
         self.assertEqual(uninstalled.returncode, 0, uninstalled.stderr)
@@ -158,6 +170,65 @@ class InstallScriptTests(unittest.TestCase):
         self.assertNotEqual(installed.returncode, 0)
         self.assertEqual(bin_dst.read_text(encoding="utf-8"), "user managed\n")
         self.assertIn("exists and is not a symlink", installed.stderr)
+
+    def test_install_identifies_modern_pip_console_script(self):
+        bin_dst = self.home / ".local/bin/venice"
+        bin_dst.parent.mkdir(parents=True)
+        content = (
+            "#!/usr/bin/python3\n"
+            "import sys\n"
+            "from venice.cli import main\n"
+            "if __name__ == '__main__':\n"
+            "    sys.exit(main())\n"
+        )
+        bin_dst.write_text(content, encoding="utf-8")
+
+        installed = self.run_script("install.sh")
+        self.assertNotEqual(installed.returncode, 0)
+        self.assertEqual(bin_dst.read_text(encoding="utf-8"), content)
+        self.assertIn("pip-installed venice-cli command", installed.stderr)
+        self.assertIn("pip uninstall venice-cli", installed.stderr)
+        self.assertIn("pip install -e .", installed.stderr)
+
+    def test_install_identifies_legacy_pip_console_script(self):
+        bin_dst = self.home / ".local/bin/venice"
+        bin_dst.parent.mkdir(parents=True)
+        content = (
+            "#!/usr/bin/python3\n"
+            "from pkg_resources import load_entry_point\n"
+            "load_entry_point('venice-cli==0.14.0', 'console_scripts', 'venice')\n"
+        )
+        bin_dst.write_text(content, encoding="utf-8")
+
+        installed = self.run_script("install.sh")
+        self.assertNotEqual(installed.returncode, 0)
+        self.assertEqual(bin_dst.read_text(encoding="utf-8"), content)
+        self.assertIn("pip-installed venice-cli command", installed.stderr)
+
+    def test_install_does_not_misclassify_partial_wrapper_markers(self):
+        bin_dst = self.home / ".local/bin/venice"
+        bin_dst.parent.mkdir(parents=True)
+        content = "#!/usr/bin/python3\nfrom venice.cli import main\n"
+        bin_dst.write_text(content, encoding="utf-8")
+
+        installed = self.run_script("install.sh")
+        self.assertNotEqual(installed.returncode, 0)
+        self.assertEqual(bin_dst.read_text(encoding="utf-8"), content)
+        self.assertIn("exists and is not a symlink", installed.stderr)
+        self.assertNotIn("pip-installed", installed.stderr)
+
+    def test_install_does_not_inspect_special_file(self):
+        if not hasattr(os, "mkfifo"):
+            self.skipTest("mkfifo is unavailable")
+        bin_dst = self.home / ".local/bin/venice"
+        bin_dst.parent.mkdir(parents=True)
+        os.mkfifo(bin_dst)
+
+        installed = self.run_script("install.sh")
+        self.assertNotEqual(installed.returncode, 0)
+        self.assertTrue(stat.S_ISFIFO(bin_dst.stat().st_mode))
+        self.assertIn("exists and is not a symlink", installed.stderr)
+        self.assertNotIn("pip-installed", installed.stderr)
 
     def test_uninstall_preserves_links_that_point_elsewhere(self):
         bin_dst = self.home / ".local/bin/venice"

--- a/uninstall.sh
+++ b/uninstall.sh
@@ -46,6 +46,8 @@ unlink_if_ours() {
 }
 
 unlink_if_ours "$HOME/.local/bin/venice" "$REPO/bin/venice"
+# install.sh stopped creating this vestigial link in #20.  Keep exact-target
+# cleanup so older source installs can still be removed safely.
 unlink_if_ours "$HOME/.local/lib/venice" "$REPO/src/venice"
 
 # Remove the bash completion install.sh wrote, but only when its checkout-


### PR DESCRIPTION
Closes #20.

## Summary
- identify current and legacy pip console wrappers from fixed Venice entry-point markers without executing the file, its interpreter, or ambient pip
- keep every existing destination fail-closed while replacing the generic refusal with actionable pip uninstall/editable-install guidance only for recognized wrappers
- stop creating the unused `~/.local/lib/venice` link while retaining exact-target legacy cleanup in `uninstall.sh`
- update source-install documentation and isolated regression coverage

## Validation
- `VENICE_API_KEY=test-fake-key PYTHONPATH=src python3 -m unittest -v tests.test_install_scripts` — 10 passed
- `VENICE_API_KEY=test-fake-key make lint` — passed
- `VENICE_API_KEY=test-fake-key make scan` — passed
- `VENICE_API_KEY=test-fake-key make drive` — 45 passed
- every local test module except the two MCP SDK-bound modules passed
- full discovery reached 1,883 tests; the 39 errors are confined to `test_mcp_serve` and `test_mcp_client` because the shared environment has incompatible `mcp 1.28.1` (`mcp.server.mcpserver` and `mcp.Client` are absent). Hosted CI installs the declared `mcp>=2,<3` extra and is authoritative for those modules.
- `git diff --check` — passed
- no live Venice API calls