### PR TITLE
vision: let capable frontends inspect images natively

### DIFF
--- a/README.md
+++ b/README.md
@@ -858,13 +858,16 @@ guessing, and `venice_model_details` (single `model` arg) which returns one
 model's pricing (cost), `capabilities` (text models — supportsVision etc.),
 `constraints` (image/media — aspect ratios, resolutions, qualities, prompt-length
 limit), and the full `model_spec`, so the agent can budget input and confirm a
-model fits, and `venice_vision`, which sends a local image (`input_path`, as a
-base64 data-URL) or an `image_url` to a vision-capable text model and returns
-what it sees — the agent's eyes, so it can inspect its own generations
-(watermarks, character consistency, glitches) instead of working blind; an
-optional `prompt` directs the question, and when `model` is omitted a
-`supportsVision` model is auto-picked from the catalog. Not spend-gated.
-(`venice code` gets all three too.)
+model fits, and `venice_vision`, which accepts a local image (`input_path`, as a
+base64 data-URL) or an `image_url` — the agent's eyes, so it can inspect its own
+generations (watermarks, character consistency, glitches) instead of working
+blind. `mode=auto` (the default) attaches the image to the active frontend when
+that model advertises `supportsVision`; otherwise it delegates to a separate
+vision model and returns that model's text. `mode=native` or `mode=delegate`
+forces either path. An optional `prompt` directs the question; `model` and
+`max_tokens` configure only delegation or the `auto` fallback. Not spend-gated.
+(`venice code` gets all three too; `venice_vision` is not exposed by
+`mcp-serve`.)
 
 ```sh
 # One command, multiple steps: the model generates an image, then critiques it.
@@ -1538,7 +1541,7 @@ jq '.usage.billed_total' ~/.config/venice/sessions/<id>.json
 | `git` | validated read-only Git (`status`/`diff`/`log`/`show`/…); literal paths go after `--` | no |
 | `project_search` | semantic search over the `.venice` index (if built) — a **snapshot** of the last build; use `grep` for live matches | no |
 | `reindex` | rebuild the `.venice` index so `project_search` reflects this session's edits (re-embeds only changed files); present only when an index exists | yes (paid) |
-| `venice_vision` | describe/inspect a local image or image URL via a vision-capable model | no |
+| `venice_vision` | inspect a local image or URL natively on a capable frontend, otherwise through a delegated vision model (`mode=auto\|native\|delegate`) | no |
 | `write_file` | create/overwrite a file (atomic) | yes |
 | `edit_file` | replace an exact, unique string in a file | yes |
 | `apply_patch` | apply a batch of edits grouped per file, atomically per file (use `occurrence=N` for non-unique strings) | yes |
@@ -1574,7 +1577,9 @@ it unrestricted (unchanged behavior).
 The same active/attached readable-root and secret-path policy applies when
 `venice_vision` or a `--assets` media tool reads a model-supplied local file. Those
 inputs must also match a recognized media signature; confirmation and `--auto` do
-not widen this authority.
+not widen this authority. Native images remain in the conversation history so the
+frontend can inspect them again; a persistent session therefore stores the bounded
+data URL in its existing 0600 envelope.
 
 The free `git` tool validates arguments per operation rather than trusting a
 subcommand name. `branch` and `remote` are listing-only; content diffs require
@@ -2069,6 +2074,9 @@ safety), it should be settable in config." Currently config-backable:
 - `defaults.review.*` — `model`, `base`, `rounds`, `effort`, `context`, `fail_on`,
   `max_diff_chars`, `max_tool_calls`, `subagent_max_tokens`, `exec_timeout`.
   Setting `model` is the usual way to make reviewer/author decorrelation permanent
+- `defaults.vision.*` — `mode` (`auto`, `native`, or `delegate`), delegated
+  fallback `model`, and delegated `max_tokens`. The per-image `prompt` remains a
+  tool-call input rather than a standing preference
 - `defaults.chat.*`, `defaults.code.*`, `defaults.index.*`,
   `defaults.search.*` — see each command's section above
 
@@ -2093,6 +2101,10 @@ way, as do the generation knobs `defaults.image.{model,format,variants}`,
 `defaults.{sfx,music,video}.max_wait`. An explicit argument the model puts in
 the tool call still wins over config. `venice mcp-serve` threads the same
 defaults into its wrappers.
+
+`defaults.vision.*` applies to the in-process `venice_vision` tool in chat and
+code. It does not create a vision tool on `venice mcp-serve`, whose remote-host
+capability and image-content contract are tracked in [#222](https://github.com/gobha-me/venice-cli/issues/222).
 
 Not everything crosses over, and the gaps are deliberate: `poll_interval` is
 CLI-only because the tool implementations fix their own polling cadence, and

--- a/src/venice/commands/_agent.py
+++ b/src/venice/commands/_agent.py
@@ -62,9 +62,11 @@ from .models import MODEL_TYPES
 class Tool:
     """One function tool the model may call.
 
-    ``invoke(arguments, *, confirm=False) -> dict`` takes the model-supplied
-    arguments object and returns a JSON-serializable result dict. ``paid`` marks
-    tools whose result can be a ``confirmation_required`` gate.
+    ``invoke(arguments, *, confirm=False)`` takes the model-supplied arguments
+    object and normally returns a JSON-serializable result dict. A contextual
+    in-process tool may receive loop-owned runtime facts and return a private
+    :class:`_ToolOutcome`. ``paid`` marks tools whose result can be a
+    ``confirmation_required`` gate.
 
     ``category`` (e.g. ``image``/``fs``/``exec``) and ``tags`` are the capability
     axis (#50): a runtime label carried by every built tool so callers can filter a
@@ -82,6 +84,32 @@ class Tool:
     paid: bool = False
     category: str = ""
     tags: Tuple[str, ...] = ()
+    contextual: bool = False
+
+
+@dataclass(frozen=True)
+class _ToolRuntime:
+    """Per-loop facts available to a contextual in-process tool.
+
+    Tool schemas never expose this object.  It is minted by :func:`run_loop`, so
+    a model cannot spoof the active frontend id or its catalog capabilities.
+    """
+
+    model: str
+    models: Optional[List[dict]] = None
+
+
+@dataclass(frozen=True)
+class _ToolOutcome:
+    """A model-visible tool result plus messages committed after its batch.
+
+    Most tools keep returning a plain dict.  This private envelope exists for
+    native vision, where the assistant's tool call must receive its ``tool``
+    result before the loop can legally append the multimodal ``user`` message.
+    """
+
+    result: dict
+    followups: Tuple[dict, ...] = ()
 
 
 @dataclass(frozen=True)
@@ -2455,6 +2483,8 @@ _MODEL_DETAILS_SCHEMA = _obj(
     required=["model"],
 )
 
+VISION_MODE_CHOICES = ("auto", "native", "delegate")
+
 _VISION_SCHEMA = _obj(
     {
         "input_path": _p("string", "Path to a local image file to look at."),
@@ -2465,9 +2495,18 @@ _VISION_SCHEMA = _obj(
         ),
         "model": _p(
             "string",
-            "A vision-capable text model id (default: auto-picked from the catalog).",
+            "A delegated vision model id (used by delegate mode or auto fallback).",
         ),
-        "max_tokens": _p("integer"),
+        "max_tokens": _p("integer", "Maximum tokens for a delegated vision reply."),
+        "mode": {
+            "type": "string",
+            "enum": list(VISION_MODE_CHOICES),
+            "description": (
+                "auto uses the active frontend when it advertises supportsVision, "
+                "otherwise delegates; native requires a known vision-capable "
+                "frontend; delegate always uses a separate vision model."
+            ),
+        },
     },
 )
 
@@ -2702,10 +2741,10 @@ _BUILTINS = [
     ToolSpec(
         "venice_vision",
         "vision_tool",
-        "Look at an image (a local input_path OR an image_url) with a vision-capable "
-        "Venice text model and return what it sees as text. Optional prompt directs "
-        "the question (default: a detailed description). Auto-picks a supportsVision "
-        "model when model is omitted (see venice_model_details). Not spend-gated.",
+        "Look at an image (a local input_path OR an image_url). mode=auto (default) "
+        "attaches it to the active frontend when that model advertises supportsVision "
+        "and otherwise delegates to a vision model; mode=native or mode=delegate "
+        "forces either path. Optional prompt directs the question. Not spend-gated.",
         _VISION_SCHEMA,
         False,
         "vision",
@@ -3122,10 +3161,73 @@ def builtin_tools(
     def _make_free(impl, section, impl_name):
         defaults = _config_defaults(section, impl)
 
-        def invoke(arguments, *, confirm: bool = False):
+        def invoke(arguments, *, confirm: bool = False, runtime=None):
             controlled = {}
             if impl_name == "vision_tool":
                 controlled["path_authority"] = media_path_authority
+                values = {**defaults, **_clean(arguments)}
+                mode = values.pop("mode", "auto")
+                if mode not in VISION_MODE_CHOICES:
+                    return {
+                        "status": "error",
+                        "message": (
+                            "vision: mode must be one of "
+                            + ", ".join(VISION_MODE_CHOICES)
+                        ),
+                    }
+
+                frontend = runtime.model if isinstance(runtime, _ToolRuntime) else None
+                models = runtime.models if isinstance(runtime, _ToolRuntime) else None
+                capability = (
+                    _models.supports_capability(models, frontend, "supportsVision")
+                    if frontend else None
+                )
+                native = mode == "native" or (mode == "auto" and capability is True)
+                if mode == "native" and capability is not True:
+                    state = "does not advertise" if capability is False else "has no known"
+                    return {
+                        "status": "error",
+                        "message": (
+                            f"vision: active model {frontend!r} {state} supportsVision; "
+                            "use mode='delegate' or mode='auto'"
+                        ),
+                    }
+
+                if native:
+                    prepared = _mcp.prepare_vision_input(
+                        values.get("input_path"),
+                        image_url=values.get("image_url"),
+                        path_authority=media_path_authority,
+                    )
+                    if prepared.get("status") != "ok":
+                        return prepared
+                    prompt = (
+                        values.get("prompt") or _mcp.DEFAULT_VISION_PROMPT
+                    ).strip()
+                    followup = {
+                        "role": "user",
+                        "content": [
+                            {"type": "text", "text": prompt},
+                            {
+                                "type": "image_url",
+                                "image_url": {"url": prepared["image_url"]},
+                            },
+                        ],
+                    }
+                    return _ToolOutcome(
+                        {
+                            "status": "ok",
+                            "mode": "native",
+                            "model": frontend,
+                            "message": "image attached to the active frontend",
+                        },
+                        (followup,),
+                    )
+
+                result = impl(client, **controlled, **values)
+                if isinstance(result, dict) and result.get("status") == "ok":
+                    result = {**result, "mode": "delegate"}
+                return result
             return impl(client, **controlled, **{**defaults, **_clean(arguments)})
 
         return invoke
@@ -3148,6 +3250,7 @@ def builtin_tools(
             paid=spec.paid,
             category=spec.category,
             tags=spec.tags,
+            contextual=(spec.impl == "vision_tool"),
         )
         for spec in source
     ]
@@ -3390,7 +3493,25 @@ def _invoke_window(acc):
         acc[0] += time.monotonic() - t
 
 
-def _resolve_spend(tool: Tool, arguments: dict, result, gate: dict, *, window=None):
+def _invoke_tool(tool: Tool, arguments: dict, *, confirm: bool, runtime=None):
+    """Invoke one tool, adding loop-owned context only to contextual tools."""
+    kwargs = {"confirm": confirm}
+    if tool.contextual:
+        kwargs["runtime"] = runtime
+    return tool.invoke(arguments, **kwargs)
+
+
+def _visible_tool_result(result) -> dict:
+    return result.result if isinstance(result, _ToolOutcome) else result
+
+
+def _tool_followups(result) -> Tuple[dict, ...]:
+    return result.followups if isinstance(result, _ToolOutcome) else ()
+
+
+def _resolve_spend(
+    tool: Tool, arguments: dict, result, gate: dict, *, window=None, runtime=None
+):
     """Hybrid gate: prompt on a TTY, else feed the block back to the model.
 
     `gate` is the run's mutable auto-accept holder (`{"auto": bool}`); answering
@@ -3416,15 +3537,19 @@ def _resolve_spend(tool: Tool, arguments: dict, result, gate: dict, *, window=No
                 gate["auto"] = True
             try:
                 with _invoke_window(window):  # #82: same call, same row
-                    return tool.invoke(arguments, confirm=True)
+                    return _invoke_tool(
+                        tool, arguments, confirm=True, runtime=runtime
+                    )
             except Exception as e:  # pragma: no cover - impls shouldn't raise
                 return {"status": "error", "message": f"{tool.name} failed: {e}"}
         print(f"{tool.name}: declined by user", file=sys.stderr)
     return result  # non-TTY or declined -> the model sees the gate and adapts
 
 
-def _run_one_call(tc, dispatch: Dict[str, Tool], gate: dict, *, on_tool=None) -> dict:
-    """Run one tool call and return the model-visible result dict.
+def _run_one_call(
+    tc, dispatch: Dict[str, Tool], gate: dict, *, on_tool=None, runtime=None
+):
+    """Run one tool call and return its result dict or private outcome.
 
     `on_tool` (#82) is an optional ``(name, seconds) -> None`` sink for the call's
     EXECUTION time -- `CostLedger.record_tool` when `run_loop` was given a ledger. A
@@ -3459,10 +3584,14 @@ def _run_one_call(tc, dispatch: Dict[str, Tool], gate: dict, *, on_tool=None) ->
     try:
         try:
             with _invoke_window(window):
-                result = tool.invoke(arguments, confirm=bool(gate["auto"]))
+                result = _invoke_tool(
+                    tool, arguments, confirm=bool(gate["auto"]), runtime=runtime
+                )
         except Exception as e:  # pragma: no cover - impls shouldn't raise
             return {"status": "error", "message": f"{tool.name} failed: {e}"}
-        return _resolve_spend(tool, arguments, result, gate, window=window)
+        return _resolve_spend(
+            tool, arguments, result, gate, window=window, runtime=runtime
+        )
     finally:
         # One flush per CALL, after any confirm re-invoke, on every path out of here
         # including the raise above. `tool.name` rather than `tc.function.name`:
@@ -3482,6 +3611,7 @@ def _dispatch_parallel(
     unlimited: bool,
     show: bool,
     on_tool=None,
+    runtime=None,
 ) -> int:
     """Run one assistant turn's tool calls with subagent dispatches executed concurrently.
 
@@ -3538,8 +3668,10 @@ def _dispatch_parallel(
             max_workers=workers, thread_name_prefix="venice-subagent"
         ) as ex:
             futs = {
-                ex.submit(_run_one_call, tool_calls[i], dispatch, gate,
-                          on_tool=on_tool): i
+                ex.submit(
+                    _run_one_call, tool_calls[i], dispatch, gate,
+                    on_tool=on_tool, runtime=runtime,
+                ): i
                 for i in par_idx
             }
             try:
@@ -3551,7 +3683,9 @@ def _dispatch_parallel(
 
     # Serial remainder, in original order (paid tools + the confirm gate stay unchanged).
     for i in ser_idx:
-        results[i] = _run_one_call(tool_calls[i], dispatch, gate, on_tool=on_tool)
+        results[i] = _run_one_call(
+            tool_calls[i], dispatch, gate, on_tool=on_tool, runtime=runtime
+        )
 
     # Commit on the main thread: append in ORIGINAL order, advance by the executed count.
     for i, tc in enumerate(tool_calls):
@@ -3560,9 +3694,13 @@ def _dispatch_parallel(
                 "role": "tool",
                 "tool_call_id": tc.id,
                 "name": tc.function.name,
-                "content": json.dumps(results[i], default=str, allow_nan=False),
+                "content": json.dumps(
+                    _visible_tool_result(results[i]), default=str, allow_nan=False
+                ),
             }
         )
+    for result in results:
+        messages.extend(_tool_followups(result))
     return calls_made + min(slots, n)
 
 
@@ -3599,6 +3737,7 @@ def run_loop(
     steer_drain: Optional[Callable[[], List[str]]] = None,
     parallel: bool = False,
     final_emitter: Optional[Callable[[object], int]] = None,
+    models: Optional[List[dict]] = None,
 ) -> int:
     """Drive the function-calling loop until the model stops (or the cap is hit).
 
@@ -3633,9 +3772,13 @@ def run_loop(
     `final_emitter` is an internal output seam. By default the loop prints the final
     response according to `json_out`; callers that need to build an envelope only
     after their own accounting is finalized can capture the response instead.
+
+    `models` is the current text catalog used only for loop-owned contextual policy
+    such as native vision. It never rides the model-facing tool schema.
     """
     oai_tools = to_openai_tools(tools)
     dispatch = dispatch_map(tools)
+    runtime = _ToolRuntime(model=model, models=models)
     calls_made = 0
     gate = {"auto": bool(yes)}  # mutable so an `a`/`all` confirm flips the run to auto
     # #82: the per-tool timing sink, bound ONCE so both dispatch paths -- and every pool
@@ -3764,8 +3907,10 @@ def run_loop(
                 tool_calls, dispatch, gate, messages,
                 calls_made=calls_made, max_tool_calls=max_tool_calls,
                 unlimited=unlimited, show=show, on_tool=on_tool,
+                runtime=runtime,
             )
         else:
+            followups = []
             for tc in tool_calls:
                 if not unlimited and calls_made >= max_tool_calls:
                     result = {
@@ -3778,16 +3923,24 @@ def run_loop(
                         f"· {tc.function.name} {_short_args(tc.function.arguments)}".rstrip(),
                         enabled=show,
                     )
-                    result = _run_one_call(tc, dispatch, gate, on_tool=on_tool)
+                    result = _run_one_call(
+                        tc, dispatch, gate, on_tool=on_tool, runtime=runtime
+                    )
                     calls_made += 1
                 messages.append(
                     {
                         "role": "tool",
                         "tool_call_id": tc.id,
                         "name": tc.function.name,
-                        "content": json.dumps(result, default=str, allow_nan=False),
+                        "content": json.dumps(
+                            _visible_tool_result(result),
+                            default=str,
+                            allow_nan=False,
+                        ),
                     }
                 )
+                followups.extend(_tool_followups(result))
+            messages.extend(followups)
 
         if cache_event is not None and cache_event.action == "stop":
             # The assistant tool-call message must receive one result per call before

--- a/src/venice/commands/_mcp.py
+++ b/src/venice/commands/_mcp.py
@@ -722,25 +722,18 @@ def _vision_default(models: List[dict]) -> Optional[str]:
     return None
 
 
-def vision_tool(
-    client,
+def prepare_vision_input(
     input_path: Optional[str] = None,
     *,
     image_url: Optional[str] = None,
-    prompt: Optional[str] = None,
-    model: Optional[str] = None,
-    max_tokens: Optional[int] = None,
     path_authority=None,
 ) -> dict:
-    """Describe/inspect an image via a multimodal /chat/completions call.
+    """Validate one vision source and return its request-ready image URL.
 
-    The image is a local `input_path` (sent as a base64 data: URL) or an
-    `image_url` passed through verbatim -- exactly one of the two. The model
-    must be vision-capable: an explicit non-vision `model` is rejected
-    client-side (the API would reject the image content anyway); when `model`
-    is omitted the default-trait text model is used if it advertises
-    supportsVision, else the first catalog model that does. Cheap relative to
-    media generation, so it is not spend-gated. Needs the `[openai]` extra.
+    Local paths cross the same authority, size, and signature boundary as the
+    delegated vision path, then become a bounded data URL.  Keeping this step
+    separate lets the agent loop attach the exact same authorized image to its
+    active frontend model without buying a second completion.
     """
     if bool(input_path) == bool(image_url):
         return _err("vision: exactly one of input_path or image_url is required")
@@ -753,11 +746,44 @@ def vision_tool(
         if isinstance(resolved, dict):
             return resolved
         p, mime = resolved
-        url = _shared.encode_data_url(
+        image_url = _shared.encode_data_url(
             p, default_mime="image/png", detected_mime=mime
         )
-    else:
-        url = image_url
+
+    return {"status": "ok", "image_url": image_url}
+
+
+def vision_tool(
+    client,
+    input_path: Optional[str] = None,
+    *,
+    image_url: Optional[str] = None,
+    prompt: Optional[str] = None,
+    model: Optional[str] = None,
+    max_tokens: Optional[int] = None,
+    mode: Optional[str] = None,
+    path_authority=None,
+) -> dict:
+    """Describe/inspect an image via a delegated multimodal completion.
+
+    The image is a local `input_path` (sent as a base64 data: URL) or an
+    `image_url` passed through verbatim -- exactly one of the two. The model
+    must be vision-capable: an explicit non-vision `model` is rejected
+    client-side (the API would reject the image content anyway); when `model`
+    is omitted the default-trait text model is used if it advertises
+    supportsVision, else the first catalog model that does. Cheap relative to
+    media generation, so it is not spend-gated. Needs the `[openai]` extra.
+
+    ``mode`` is accepted so ``defaults.vision.mode`` participates in the shared
+    tool-default allowlist.  The in-process agent wrapper consumes it before
+    reaching this delegated implementation.
+    """
+    prepared = prepare_vision_input(
+        input_path, image_url=image_url, path_authority=path_authority
+    )
+    if prepared.get("status") != "ok":
+        return prepared
+    url = prepared["image_url"]
 
     openai = _openai.import_openai("vision")  # stderr hint if missing
     if openai is None:

--- a/src/venice/commands/_repl.py
+++ b/src/venice/commands/_repl.py
@@ -411,6 +411,7 @@ def _turn(oai, openai, chat, text, messages, gen_kwargs, state, args) -> bool:
                     ledger=ledger,
                     steer_drain=steer_drain,
                     parallel=bool(getattr(args, "parallel", None)),  # #52
+                    models=state.get("models"),
                 )
         else:
             _t0 = time.monotonic()
@@ -702,6 +703,7 @@ def run(args, oai, openai, client, models, model, initial=None, *,
             cap = session.max_tool_calls
         state = {
             "model": model,
+            "models": models,
             "tools": tools,
             "tools_on": tools_on,
             "yes": bool(getattr(args, "yes", False)),  # /auto and /manual flip this

--- a/src/venice/commands/chat.py
+++ b/src/venice/commands/chat.py
@@ -694,6 +694,7 @@ def _run_agent(args, oai, openai, client, models, model, kwargs) -> Optional[int
                 budget=_compact.budget_from_args(args),  # #48 auto-compact parity
                 ledger=ledger,
                 final_emitter=_capture_final if args.json else None,
+                models=models,
             )
             if args.json and result == 0:
                 if len(final_response) != 1:

--- a/src/venice/commands/code.py
+++ b/src/venice/commands/code.py
@@ -1116,13 +1116,13 @@ def _run_oneshot(args, oai, openai, model, tools, system, gen_kwargs, root, task
                     _agent.run_loop(oai, model, messages, gen_kwargs, tools,
                                     max_tool_calls=max_calls, yes=yes, json_out=False,
                                     budget=budget, ledger=ledger, steer_drain=steer_drain,
-                                    parallel=parallel)
+                                    parallel=parallel, models=models)
                 final_text = buf.getvalue().strip()
             else:
                 _agent.run_loop(oai, model, messages, gen_kwargs, tools,
                                 max_tool_calls=max_calls, yes=yes, json_out=False,
                                 budget=budget, ledger=ledger, steer_drain=steer_drain,
-                                parallel=parallel)
+                                parallel=parallel, models=models)
     except openai.OpenAIError as e:
         _finish(ledger, t0, human, json_out=args.json)
         return _openai.status_to_exit(openai, e, "code")

--- a/src/venice/userconfig.py
+++ b/src/venice/userconfig.py
@@ -511,6 +511,16 @@ _COMMAND_MAP = {
         "subagent_max_tokens": ("subagent_max_tokens", int),
         "exec_timeout": ("exec_timeout", _positive),
     },
+    # Standing policy for the model-facing venice_vision tool. `prompt` remains
+    # per-call content rather than a durable preference.
+    "vision": {
+        "mode": (
+            "mode",
+            _one_of("venice.commands._agent", "VISION_MODE_CHOICES"),
+        ),
+        "model": ("model", str),
+        "max_tokens": ("max_tokens", int),
+    },
     "image": {
         # `--hide-watermark` / `--safe-mode` are tri-state (default None) so these
         # defaults can win; an explicit CLI flag still wins over config.

--- a/tests/test_agent.py
+++ b/tests/test_agent.py
@@ -2997,6 +2997,180 @@ class TestToolSection(unittest.TestCase):
         self.assertEqual(_agent._tool_section("project_search"), "project_search")
 
 
+class TestNativeVisionDispatch(unittest.TestCase):
+    @staticmethod
+    def _models(capability):
+        spec = {"capabilities": {"supportsVision": capability}}
+        return [{"id": "frontend", "model_spec": spec}]
+
+    @staticmethod
+    def _tool(config=None):
+        return next(t for t in _agent.builtin_tools(
+            object(), only={"venice_vision"}, config=config or {},
+            media_path_authority=object(),
+        ) if t.name == "venice_vision")
+
+    def _call(self, arguments, capability, *, config=None):
+        tool = self._tool(config)
+        runtime = _agent._ToolRuntime("frontend", self._models(capability))
+        return _agent._run_one_call(
+            _FnCall("vision-1", "venice_vision", json.dumps(arguments)),
+            {"venice_vision": tool}, {"auto": True}, runtime=runtime,
+        )
+
+    def test_model_facing_schema_exposes_only_the_three_modes(self):
+        props = self._tool().parameters["properties"]
+        self.assertEqual(props["mode"]["enum"], ["auto", "native", "delegate"])
+        self.assertNotIn("runtime", props)
+
+    def test_auto_known_capable_attaches_image_without_delegate(self):
+        with mock.patch.object(
+            _agent._mcp, "prepare_vision_input",
+            return_value={"status": "ok", "image_url": "data:image/png;base64,eA=="},
+        ) as prepare, mock.patch.object(_agent._mcp, "vision_tool") as delegate:
+            outcome = self._call(
+                {"image_url": "https://example.test/shot.png", "prompt": "Inspect"},
+                True,
+            )
+        self.assertIsInstance(outcome, _agent._ToolOutcome)
+        self.assertEqual(outcome.result["mode"], "native")
+        self.assertEqual(outcome.result["model"], "frontend")
+        self.assertEqual(outcome.followups, ({
+            "role": "user",
+            "content": [
+                {"type": "text", "text": "Inspect"},
+                {"type": "image_url", "image_url": {
+                    "url": "data:image/png;base64,eA==",
+                }},
+            ],
+        },))
+        prepare.assert_called_once()
+        delegate.assert_not_called()
+
+    def test_auto_false_or_unknown_capability_delegates(self):
+        for capability in (False, None):
+            with self.subTest(capability=capability), mock.patch.object(
+                _agent._mcp, "vision_tool",
+                return_value={"status": "ok", "content": "delegate saw it", "model": "vl"},
+            ) as delegate, mock.patch.object(
+                _agent._mcp, "prepare_vision_input"
+            ) as prepare:
+                result = self._call(
+                    {"image_url": "https://example.test/shot.png", "model": "vl"},
+                    capability,
+                )
+            self.assertEqual(result["mode"], "delegate")
+            delegate.assert_called_once()
+            prepare.assert_not_called()
+
+    def test_explicit_native_fails_closed_on_false_or_unknown_capability(self):
+        for capability in (False, None):
+            with self.subTest(capability=capability), mock.patch.object(
+                _agent._mcp, "vision_tool"
+            ) as delegate, mock.patch.object(
+                _agent._mcp, "prepare_vision_input"
+            ) as prepare:
+                result = self._call(
+                    {"image_url": "https://example.test/shot.png", "mode": "native"},
+                    capability,
+                )
+            self.assertEqual(result["status"], "error")
+            self.assertIn("supportsVision", result["message"])
+            delegate.assert_not_called()
+            prepare.assert_not_called()
+
+    def test_explicit_delegate_wins_even_on_capable_frontend(self):
+        with mock.patch.object(
+            _agent._mcp, "vision_tool",
+            return_value={"status": "ok", "content": "delegate", "model": "vl"},
+        ) as delegate:
+            result = self._call(
+                {"image_url": "https://example.test/shot.png", "mode": "delegate"},
+                True,
+            )
+        self.assertEqual(result["mode"], "delegate")
+        delegate.assert_called_once()
+
+    def test_config_mode_is_lower_precedence_than_tool_argument(self):
+        config = {"defaults": {"vision": {"mode": "delegate", "model": "vl"}}}
+        with mock.patch.object(
+            _agent._mcp, "prepare_vision_input",
+            return_value={"status": "ok", "image_url": "https://example.test/shot.png"},
+        ), mock.patch.object(_agent._mcp, "vision_tool") as delegate:
+            outcome = self._call(
+                {"image_url": "https://example.test/shot.png", "mode": "native"},
+                True, config=config,
+            )
+        self.assertIsInstance(outcome, _agent._ToolOutcome)
+        delegate.assert_not_called()
+
+    def test_same_tool_uses_each_run_loops_current_frontend(self):
+        call = _FnCall(
+            "vision-1", "venice_vision",
+            json.dumps({"image_url": "https://example.test/shot.png"}),
+        )
+        with mock.patch.object(
+            _agent._mcp, "vision_tool",
+            return_value={"status": "ok", "content": "delegate", "model": "vl"},
+        ), mock.patch.object(
+            _agent._mcp, "prepare_vision_input",
+            return_value={"status": "ok", "image_url": "https://example.test/shot.png"},
+        ):
+            tool = self._tool()
+            delegated = _agent._run_one_call(
+                call, {"venice_vision": tool}, {"auto": True},
+                runtime=_agent._ToolRuntime("text-only", [{
+                    "id": "text-only", "model_spec": {
+                        "capabilities": {"supportsVision": False},
+                    },
+                }]),
+            )
+            native = _agent._run_one_call(
+                call, {"venice_vision": tool}, {"auto": True},
+                runtime=_agent._ToolRuntime("vision-front", [{
+                    "id": "vision-front", "model_spec": {
+                        "capabilities": {"supportsVision": True},
+                    },
+                }]),
+            )
+        self.assertEqual(delegated["mode"], "delegate")
+        self.assertIsInstance(native, _agent._ToolOutcome)
+        self.assertEqual(native.result["model"], "vision-front")
+
+    def test_run_loop_commits_all_tool_results_before_native_followup(self):
+        def vision(arguments, *, confirm=False, runtime=None):
+            self.assertEqual(runtime.model, "frontend")
+            return _agent._ToolOutcome(
+                {"status": "ok", "mode": "native"},
+                ({"role": "user", "content": [{"type": "text", "text": "image"}]},),
+            )
+
+        tools = [
+            _free_tool(),
+            _agent.Tool(
+                "venice_vision", "vision", {"type": "object", "properties": {}},
+                vision, contextual=True,
+            ),
+        ]
+        seq = [FakeToolCompletion(tool_calls=[
+            _FnCall("c1", "venice_vision", "{}"),
+            _FnCall("c2", "t", "{}"),
+        ]), FakeToolCompletion("done")]
+        fake, calls = _fake_oai(seq)
+        messages = [{"role": "user", "content": "go"}]
+        with mock.patch.object(sys, "stdout", io.StringIO()), \
+             mock.patch.object(sys, "stderr", io.StringIO()):
+            _agent.run_loop(
+                fake, "frontend", messages, {}, tools,
+                max_tool_calls=0, yes=True, json_out=False,
+                models=self._models(True),
+            )
+        roles = [m["role"] for m in calls[1]["messages"][-5:-1]]
+        self.assertEqual(roles, ["assistant", "tool", "tool", "user"])
+        self.assertEqual(calls[1]["messages"][-4]["tool_call_id"], "c1")
+        self.assertEqual(calls[1]["messages"][-3]["tool_call_id"], "c2")
+
+
 class TestAsyncJobSchemas(unittest.TestCase):
     """#62: background param on media schemas + the two async job-tool schemas."""
 
@@ -3672,6 +3846,39 @@ class TestParallelDispatch(unittest.TestCase):
         self.assertEqual(sorted(record), ["venice_spawn"] * 3)  # all three ran
         for m, tag in zip(tms, ["A", "B", "C"]):
             self.assertIn(tag, m["content"])
+
+    def test_mixed_batch_commits_native_followup_after_every_tool_result(self):
+        def vision(arguments, *, confirm=False, runtime=None):
+            return _agent._ToolOutcome(
+                {"status": "ok", "mode": "native"},
+                ({"role": "user", "content": [
+                    {"type": "text", "text": "image"},
+                ]},),
+            )
+
+        tools = [
+            _sub_tool(_agent.SPAWN_TOOL_NAME),
+            _agent.Tool(
+                "venice_vision", "vision", {"type": "object", "properties": {}},
+                vision, contextual=True,
+            ),
+        ]
+        turn = FakeToolCompletion(tool_calls=[
+            self._spawn_call("c1", "worker"),
+            _FnCall("c2", "venice_vision", "{}"),
+        ])
+        _messages, calls = self._run(
+            [turn, FakeToolCompletion("done")], tools,
+            max_tool_calls=0, parallel=True,
+        )
+        self.assertEqual(
+            [m["role"] for m in calls[1]["messages"][-5:-1]],
+            ["assistant", "tool", "tool", "user"],
+        )
+        self.assertEqual(
+            [m["tool_call_id"] for m in calls[1]["messages"][-4:-2]],
+            ["c1", "c2"],
+        )
 
     def test_budget_marks_overflow_not_executed_without_running(self):
         record = []

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -738,10 +738,12 @@ class TestExplicitConfigEnrollment(unittest.TestCase):
             by_section.setdefault(spec["section"], set()).update(
                 _optional_dests(parsers[name])
             )
-        # `browser` is compatibility/tool-only while the CLI rail is disabled.
-        self.assertEqual(set(uc._COMMAND_MAP) - set(by_section), {"browser"})
+        # `browser` and `vision` are tool-only sections rather than top-level
+        # command parsers.
+        tool_only = {"browser", "vision"}
+        self.assertEqual(set(uc._COMMAND_MAP) - set(by_section), tool_only)
         for section, rows in uc._COMMAND_MAP.items():
-            if section == "browser":
+            if section in tool_only:
                 continue
             for key, (dest, _coerce) in rows.items():
                 with self.subTest(section=section, key=key):
@@ -2016,6 +2018,36 @@ class TestConfigDefaultsFor(unittest.TestCase):
         fetch = uc.config_defaults_for("browser", _mcp.web_fetch_tool, doc)
         self.assertEqual(fetch, {"timeout": 10, "max_bytes": 5})
         self.assertNotIn("wait_ms", fetch)           # web_fetch takes no wait_ms
+
+    def test_vision_policy_is_allowlisted_coerced_and_signature_gated(self):
+        from venice.commands import _mcp
+        doc = {"defaults": {"vision": {
+            "mode": "native", "model": "qwen-vl", "max_tokens": "64",
+            "prompt": "not a standing preference",
+        }}}
+        sources = {}
+        out = uc.config_defaults_for(
+            "vision", _mcp.vision_tool, doc, sources=sources
+        )
+        self.assertEqual(out, {
+            "mode": "native", "model": "qwen-vl", "max_tokens": 64,
+        })
+        self.assertEqual(sources, {
+            "mode": "defaults.vision.mode",
+            "model": "defaults.vision.model",
+            "max_tokens": "defaults.vision.max_tokens",
+        })
+
+    def test_invalid_vision_mode_is_ignored(self):
+        from venice.commands import _mcp
+        err = io.StringIO()
+        with contextlib.redirect_stderr(err):
+            out = uc.config_defaults_for(
+                "vision", _mcp.vision_tool,
+                {"defaults": {"vision": {"mode": "maybe"}}},
+            )
+        self.assertEqual(out, {})
+        self.assertIn("ignoring invalid config default mode='maybe'", err.getvalue())
 
 
 if __name__ == "__main__":

--- a/tests/test_drive_cli.py
+++ b/tests/test_drive_cli.py
@@ -320,6 +320,55 @@ class TestDriveCharge(_DriveCase):
         self.assertEqual(result["name"], "venice_image")
         self.assertEqual(json.loads(result["content"])["status"], "ok")
 
+    @needs_openai
+    def test_native_vision_reaches_frontend_without_delegate_completion(self):
+        self.api.set_models("text", [{
+            "id": "vision-front",
+            "type": "text",
+            "model_spec": {
+                "traits": ["default"],
+                "capabilities": {
+                    "supportsFunctionCalling": True,
+                    "supportsVision": True,
+                },
+            },
+        }])
+        (self.project / "shot.png").write_bytes(
+            b"\x89PNG\r\n\x1a\n" + b"drive-native-vision"
+        )
+        self.api.reply_tool_call("venice_vision", {
+            "input_path": "shot.png",
+            "prompt": "Inspect the alignment",
+        })
+        self.api.reply("NATIVE-VISION-COMPLETE")
+
+        cp = self.run_cli(
+            "chat", "inspect the screenshot", "--tools", "--tool", "venice_vision",
+            "--json",
+        )
+        self.assertEqual(cp.returncode, 0, cp.stderr)
+        self.assertIn('"final": "NATIVE-VISION-COMPLETE"', cp.stdout)
+
+        self.assertEqual(
+            self.api.paths,
+            ["/models", "/chat/completions", "/chat/completions"],
+        )
+        bodies = self.api.bodies("/chat/completions")
+        self.assertEqual(len(bodies), 2)  # no delegated vision completion
+        assistant, result, attached = bodies[1]["messages"][-3:]
+        self.assertEqual(assistant["role"], "assistant")
+        self.assertEqual(result["role"], "tool")
+        self.assertEqual(json.loads(result["content"])["mode"], "native")
+        self.assertEqual(attached["role"], "user")
+        self.assertEqual(attached["content"][0], {
+            "type": "text", "text": "Inspect the alignment",
+        })
+        self.assertTrue(
+            attached["content"][1]["image_url"]["url"].startswith(
+                "data:image/png;base64,"
+            )
+        )
+
 
 # --------------------------------------------------------------------------
 # C'. the same gates with no pty at all

--- a/tests/test_sessions.py
+++ b/tests/test_sessions.py
@@ -114,6 +114,21 @@ class TestStore(_Base):
             "provider state \u2603",
         )
 
+    def test_native_vision_message_round_trips_for_reinspection(self):
+        content = [
+            {"type": "text", "text": "Inspect the alignment"},
+            {"type": "image_url", "image_url": {
+                "url": "data:image/png;base64,iVBORw0KGgo=",
+            }},
+        ]
+        sess = self._mk(messages=[
+            {"role": "user", "content": "look at the screenshot"},
+            {"role": "user", "content": content},
+        ])
+        S.save(sess)
+        got = S.load(sess.id, "chat")
+        self.assertEqual(got.messages[1]["content"], content)
+
     def test_envelope_has_version_and_no_key(self):
         sess = self._mk()
         path = S.save(sess)


### PR DESCRIPTION
Closes #72.

## Summary
- add auto, native, and delegate modes to venice_vision, with auto preferring the active frontend only when supportsVision is positively advertised
- preserve the existing delegated completion for text-only or unknown frontends, while explicit native fails closed on false or unknown capability metadata
- append native multimodal user messages only after every result in the assistant tool-call batch, preserving serial and parallel tool pairing/order
- add defaults.vision mode/model/max_tokens policy, persistent-session round trips, and chat/code runtime catalog wiring
- document the bounded 0600 session storage behavior and defer mcp-serve ImageContent/host-capability work to #222

## Validation
- VENICE_API_KEY=test-fake-key make lint — passed
- VENICE_API_KEY=test-fake-key make scan — passed
- VENICE_API_KEY=test-fake-key make drive — 46 passed
- focused native vision/config/session/drive gate — 64 passed
- affected agent, MCP tool, config, session, chat, code, REPL, and drive modules — 890 passed after the REPL catalog wiring fix
- full make test discovery — 1,896 tests reached: 1,856 passed, 1 skipped, and 39 errors confined to the two MCP SDK-bound modules because the shared environment has mcp 1.28.1 while pyproject declares mcp>=2,<3; hosted CI installs the declared extra and is authoritative for those modules
- git diff --check — passed
- no live Venice API calls