### PR TITLE
mcp-serve: return declared native vision content

### DIFF
--- a/README.md
+++ b/README.md
@@ -845,8 +845,9 @@ produces a final answer. These run **in-process on the `[openai]` extra alone**
 
 `venice_image`, `venice_tts`, `venice_sfx`, `venice_music`, `venice_upscale`,
 `venice_bg_remove`, and `venice_chat` (a sub-completion / subagent primitive) —
-seven of the capabilities `venice mcp-serve` exposes (which adds `venice_video`
-and `venice_image_edit`) — plus `project_search`,
+seven capabilities also exposed by `venice mcp-serve`. The MCP server additionally
+adds `venice_video`, `venice_image_edit`, and its declared-host form of
+`venice_vision`. The in-process agent set also includes `project_search`,
 a read-only [semantic search](#semantic-search) over the project's local
 `venice index` for locating code by meaning before acting on it (a **snapshot** of
 the last index build — pair it with `reindex`, a paid tool that rebuilds the index
@@ -866,8 +867,8 @@ that model advertises `supportsVision`; otherwise it delegates to a separate
 vision model and returns that model's text. `mode=native` or `mode=delegate`
 forces either path. An optional `prompt` directs the question; `model` and
 `max_tokens` configure only delegation or the `auto` fallback. Not spend-gated.
-(`venice code` gets all three too; `venice_vision` is not exposed by
-`mcp-serve`.)
+(`venice code` gets all three too; `mcp-serve` uses the separate
+[`--host-image-content`](#mcp-server) declaration for native vision.)
 
 ```sh
 # One command, multiple steps: the model generates an image, then critiques it.
@@ -1906,18 +1907,22 @@ look" must never be able to masquerade as "we looked and found nothing".
 stdio, exposing venice's generators as tools that an MCP host (Claude Code, or
 any MCP client) can call directly instead of shelling out to the CLI. Starting
 the server needs the `[mcp]` extra (Python ≥ 3.10); its `venice_chat` tool also
-needs `[openai]`. Install `[all]` when the host should be able to call all nine
+needs `[openai]`. Delegated `venice_vision` calls need `[openai]` too; its local
+native path does not. Install `[all]` when the host should be able to call all ten
 tools:
 
 ```sh
 pip install "venice-cli[mcp]"
-pip install "venice-cli[all]"       # MCP transport + venice_chat
+pip install "venice-cli[all]"       # MCP transport + chat/delegated vision
 
 # Register it with Claude Code:
 claude mcp add venice -- venice mcp-serve
+
+# Affirm that this stdio host passes MCP ImageContent to a vision-capable model:
+claude mcp add venice-vision -- venice mcp-serve --host-image-content
 ```
 
-The server exposes nine tools:
+The server exposes ten tools:
 
 | Tool | Does | Paid? |
 | --- | --- | --- |
@@ -1930,6 +1935,7 @@ The server exposes nine tools:
 | `venice_bg_remove` | remove a background → transparent PNG | yes (dynamic) |
 | `venice_image_edit` | edit/inpaint an image (+ optional mask layers) → image file | yes (dynamic) |
 | `venice_chat` | one-shot chat completion → reply text (needs `[openai]`) | no |
+| `venice_vision` | inspect a local image natively or delegate image analysis | no |
 
 **Spend gating.** MCP is non-interactive, so instead of a `[y/N]` prompt the
 paid tools gate on cost. A tool call whose estimated cost is at or under the
@@ -1941,10 +1947,23 @@ host must re-call with `confirm=true` (or a higher `max_spend`). Nothing is
 spent and no file is written on a gated call. `venice_chat` is cheap and not
 gated.
 
-**Output.** Tools write their result to a file and return its **path** (never
-inline base64). Files land in `VENICE_MCP_OUTPUT_DIR` (default: the current
-working directory), or a per-call `output_dir`. The API key is read the usual
-way (`$VENICE_API_KEY` or the credentials file) and is never echoed.
+**Output.** Generation/editing tools write their result to a file and return its
+**path**. Files land in `VENICE_MCP_OUTPUT_DIR` (default: the current working
+directory), or a per-call `output_dir`. `venice_vision` is the exception: native
+mode returns the authorized local image inline as MCP ImageContent. The API key
+is read the usual way (`$VENICE_API_KEY` or the credentials file) and is never
+echoed.
+
+**Vision host declaration.** The default `venice mcp-serve` startup assumes a
+text-only host. `venice_vision` therefore delegates in `mode=auto`, preserving
+its `model` and `max_tokens` controls. `--host-image-content` is the operator's
+explicit assertion that this stdio host delivers MCP ImageContent to a
+vision-capable frontend: `auto` then returns a validated local `input_path`
+natively, while `mode=native` requires the assertion. Remote `image_url` inputs
+remain delegated; explicit native URL requests fail closed rather than adding a
+server-side downloader. `mode=delegate` always preserves the text-only path. The
+declaration is fixed for the process; restart or re-register the server to change
+it.
 
 **Local media inputs.** Paths supplied to image/video tools by an MCP host are
 confined to the server's startup working directory after resolving symlinks.
@@ -2102,9 +2121,9 @@ way, as do the generation knobs `defaults.image.{model,format,variants}`,
 the tool call still wins over config. `venice mcp-serve` threads the same
 defaults into its wrappers.
 
-`defaults.vision.*` applies to the in-process `venice_vision` tool in chat and
-code. It does not create a vision tool on `venice mcp-serve`, whose remote-host
-capability and image-content contract are tracked in [#222](https://github.com/gobha-me/venice-cli/issues/222).
+`defaults.vision.*` applies to `venice_vision` in chat, code, and `mcp-serve`.
+On the MCP server, explicit tool arguments still beat config, and native output
+still requires the process-level `--host-image-content` declaration.
 
 Not everything crosses over, and the gaps are deliberate: `poll_interval` is
 CLI-only because the tool implementations fix their own polling cadence, and
@@ -2219,7 +2238,7 @@ The player list (`paplay` -> `aplay` -> `ffplay` -> `mpg123` -> `play`
 | `venice index [PATH] [--model M] [--embed-base-url URL --embed-model M [--embed-ca-bundle PATH \| --embed-insecure]] [...]` / `venice search QUERY [-k N] [--json] [--embed-ca-bundle PATH \| --embed-insecure]` | build / query a local semantic index of a project tree (needs `[openai]`) |
 | `venice code [TASK] [--auto\|--manual] [--plan-only] [-i] [--root DIR] [--continue\|--resume ID\|FILE] [--ephemeral] [--json] [...]` | coding agent: plan → accept → edit/run a project (needs `[openai]` + tool-calling model) |
 | `venice review [FOCUS] [--base REF] [--rounds N] [--effort auto\|always\|never] [--fail-on LEVEL] [--json]` | cold-context review of the current diff (model-backed runs need `[openai]`; skipped/empty runs do not); **findings only — no gate, writes nothing** |
-| `venice mcp-serve` | run an MCP server (stdio) exposing venice tools (needs `[mcp]`; `venice_chat` additionally needs `[openai]`) |
+| `venice mcp-serve [--host-image-content]` | run an MCP server (stdio) exposing venice tools (needs `[mcp]`; delegated vision and `venice_chat` additionally need `[openai]`) |
 | `venice config add\|list\|remove\|show` | manage the MCP server registry |
 | `venice config get\|set\|unset KEY [VALUE]` | manage default flag values |
 | `venice completion bash\|zsh` | print a shell tab-completion script (generated from the parser) |

--- a/src/venice/commands/mcp_serve.py
+++ b/src/venice/commands/mcp_serve.py
@@ -2,8 +2,8 @@
 
 Direction A of the MCP epic (#16 / #14): venice is the *callee*. It speaks MCP over
 stdio -- JSON-RPC frames on stdout -- exposing image/sfx/music/tts/upscale/bg-remove/
-chat as MCP tools, so a host (Claude Code, or the #15 host) calls them instead of
-shelling out to the CLI.
+chat/vision as MCP tools, so a host (Claude Code, or the #15 host) calls them
+instead of shelling out to the CLI.
 
 The `mcp` SDK is imported lazily (behind the `[mcp]` extra, Python >=3.10) so the
 base stdlib-only CLI and `venice --help` keep working without it -- the same
@@ -26,11 +26,20 @@ def register(subparsers) -> None:
         help="Run an MCP server (stdio) exposing venice tools.",
         description=(
             "Speaks MCP over stdio: exposes venice image/sfx/music/tts/upscale/"
-            "bg-remove/chat as MCP tools. Needs the [mcp] extra (Python >=3.10): "
+            "bg-remove/chat/vision as MCP tools. Needs the [mcp] extra "
+            "(Python >=3.10): "
             'pip install "venice-cli[mcp]". Attach it with, e.g., '
             "`claude mcp add venice -- venice mcp-serve`. Spend on paid tools is "
             "gated: costs over VENICE_MCP_MAX_SPEND (default $0.10) need confirm=true. "
-            "Output files land in VENICE_MCP_OUTPUT_DIR (default: cwd)."
+            "Generated files land in VENICE_MCP_OUTPUT_DIR (default: cwd)."
+        ),
+    )
+    p.add_argument(
+        "--host-image-content",
+        action="store_true",
+        help=(
+            "declare that this stdio host delivers MCP ImageContent to a "
+            "vision-capable frontend (default: text-only/delegated vision)"
         ),
     )
     p.set_defaults(handler=_run)
@@ -55,7 +64,11 @@ def _run(args) -> int:
     print("venice mcp-serve: starting stdio MCP server (Ctrl-C to stop)",
           file=sys.stderr)
     try:
-        serve(client, doc=doc)
+        serve(
+            client,
+            doc=doc,
+            host_image_content=getattr(args, "host_image_content", False),
+        )
     except KeyboardInterrupt:
         return 130
     return 0

--- a/src/venice/mcp_server.py
+++ b/src/venice/mcp_server.py
@@ -2,17 +2,21 @@
 
 Imported lazily from `commands.mcp_serve._run`, and only after the `[mcp]` extra is
 confirmed present, so the base (stdlib-only) install and Python 3.9 never load it.
-Each registered `venice_*` tool is a thin, typed wrapper that delegates 1:1 to the
-matching `commands._mcp.*_tool` implementation -- the wrapper carries the MCP schema
-and the LLM-facing docstring; the impl carries the (print-free, unit-tested) logic.
+Most registered `venice_*` tools are thin, typed wrappers that delegate 1:1 to the
+matching `commands._mcp.*_tool` implementation. The vision wrapper additionally
+selects MCP-native content, but reuses the same pure input/delegation helpers. The
+wrappers carry MCP schemas and LLM-facing docstrings; the impls carry print-free,
+unit-tested logic.
 
 Do NOT add `from __future__ import annotations` here: MCPServer builds each tool's
 input schema via typing.get_type_hints, so the annotations must stay concrete
 (`typing.Optional[int]`, not stringized `int | None`).
 """
+import json
 import os
 from typing import Annotated, List, Literal, Optional
 
+from mcp import types
 from mcp.server.mcpserver import MCPServer
 from pydantic import Field
 
@@ -29,13 +33,52 @@ def _merged(defaults: dict, host: dict) -> dict:
     return {**defaults, **{k: v for k, v in host.items() if v is not None}}
 
 
-def build_server(client, doc=None, root=None) -> MCPServer:
+def _vision_text_result(result: dict) -> types.CallToolResult:
+    """Convert the existing delegated result envelope to one MCP text block."""
+    return types.CallToolResult(
+        content=[types.TextContent(text=json.dumps(result))],
+        is_error=result.get("status") == "error",
+    )
+
+
+def _native_vision_result(input_path, prompt, path_authority) -> types.CallToolResult:
+    """Return one authorized local image as prompt text plus MCP ImageContent."""
+    prepared = _mcp.prepare_vision_input(
+        input_path, path_authority=path_authority
+    )
+    if prepared.get("status") != "ok":
+        return _vision_text_result(prepared)
+
+    try:
+        header, data = prepared["image_url"].split(",", 1)
+        mime, encoding = header[len("data:"):].split(";", 1)
+        if (
+            not header.startswith("data:")
+            or encoding != "base64"
+            or not mime.startswith("image/")
+            or not data
+        ):
+            raise ValueError
+    except (AttributeError, ValueError):
+        return _vision_text_result({
+            "status": "error",
+            "message": "vision: authorized image could not be encoded",
+        })
+    return types.CallToolResult(content=[
+        types.TextContent(text=(prompt or _mcp.DEFAULT_VISION_PROMPT).strip()),
+        types.ImageContent(data=data, mime_type=mime),
+    ])
+
+
+def build_server(client, doc=None, root=None, host_image_content=False) -> MCPServer:
     """Build an MCPServer exposing venice tools, all bound to `client`.
 
     `doc` is a userconfig document (issue #58): `defaults.<section>.*` values are
     layered UNDER each host-supplied tool arg, so an explicit arg still wins
     (precedence: host arg > config default > tool hardcoded default) -- the same
     contract `venice chat`/`code` already honor. `doc=None` loads the config file.
+    `host_image_content` is an operator declaration fixed at server startup; an
+    absent declaration never permits an ImageContent result.
     """
     server = MCPServer("venice")
     path_authority = _shared.MediaPathAuthority(
@@ -53,6 +96,7 @@ def build_server(client, doc=None, root=None) -> MCPServer:
         "video": userconfig.config_defaults_for("video", _mcp.video_tool, doc),
         "image_edit": userconfig.config_defaults_for("image_edit", _mcp.image_edit_tool, doc),
         "chat": userconfig.config_defaults_for("chat", _mcp.chat_tool, doc),
+        "vision": userconfig.config_defaults_for("vision", _mcp.vision_tool, doc),
     }
     _retired_upscale_config = _upscale.retired_config_keys(doc)
 
@@ -257,6 +301,65 @@ def build_server(client, doc=None, root=None) -> MCPServer:
         )
 
     @server.tool()
+    def venice_vision(
+        input_path: Optional[str] = None,
+        image_url: Optional[str] = None,
+        prompt: Optional[str] = None,
+        model: Optional[str] = None,
+        max_tokens: Optional[int] = None,
+        mode: Optional[Literal["auto", "native", "delegate"]] = None,
+    ) -> types.CallToolResult:
+        """Inspect one image natively or through a delegated Venice vision model.
+
+        Exactly one of input_path or image_url is required. mode=auto returns a
+        validated local image as MCP ImageContent only when the operator started
+        this stdio server with --host-image-content; otherwise it delegates and
+        returns text. mode=native requires both that declaration and input_path.
+        mode=delegate always delegates. model and max_tokens configure only the
+        delegated path. Omitted args use defaults.vision.*, then mode=auto.
+        """
+        args = _merged(_defaults["vision"], dict(
+            input_path=input_path, image_url=image_url, prompt=prompt,
+            model=model, max_tokens=max_tokens, mode=mode,
+        ))
+        selected = args.pop("mode", None) or "auto"
+
+        if selected == "native":
+            if not host_image_content:
+                return _vision_text_result({
+                    "status": "error",
+                    "message": (
+                        "vision: native mode requires mcp-serve "
+                        "--host-image-content"
+                    ),
+                })
+            if args.get("image_url"):
+                return _vision_text_result({
+                    "status": "error",
+                    "message": (
+                        "vision: native MCP image content accepts only input_path; "
+                        "use mode=delegate for image_url"
+                    ),
+                })
+            return _native_vision_result(
+                args.get("input_path"), args.get("prompt"), path_authority
+            )
+
+        if (
+            selected == "auto"
+            and host_image_content
+            and args.get("input_path")
+        ):
+            return _native_vision_result(
+                args.get("input_path"), args.get("prompt"), path_authority
+            )
+
+        return _vision_text_result(_mcp.vision_tool(
+            client,
+            **{**args, "path_authority": path_authority},
+        ))
+
+    @server.tool()
     def venice_video(
         prompt: str,
         model: Optional[str] = None,
@@ -351,6 +454,8 @@ def build_server(client, doc=None, root=None) -> MCPServer:
     return server
 
 
-def serve(client, doc=None) -> None:
+def serve(client, doc=None, host_image_content=False) -> None:
     """Build the server and run it over stdio (blocks until the transport closes)."""
-    build_server(client, doc=doc).run(transport="stdio")
+    build_server(
+        client, doc=doc, host_image_content=host_image_content
+    ).run(transport="stdio")

--- a/tests/test_mcp_serve.py
+++ b/tests/test_mcp_serve.py
@@ -6,6 +6,7 @@ absent on Python 3.9, where the extra's environment marker excludes it).
 """
 import argparse
 import asyncio
+import base64
 import importlib.util
 import inspect
 import io
@@ -21,7 +22,7 @@ _HAS_MCP = importlib.util.find_spec("mcp") is not None
 EXPECTED_TOOLS = {
     "venice_image", "venice_tts", "venice_sfx", "venice_music",
     "venice_upscale", "venice_bg_remove", "venice_chat",
-    "venice_video", "venice_image_edit",
+    "venice_video", "venice_image_edit", "venice_vision",
 }
 
 
@@ -37,9 +38,39 @@ class TestMissingExtra(unittest.TestCase):
         self.assertIn('venice-cli[mcp]', err.getvalue())
 
 
+class TestCommandWiring(unittest.TestCase):
+    def test_parser_defaults_to_text_only_and_accepts_declaration(self):
+        from venice import cli
+
+        parser = cli.build_parser()
+        self.assertFalse(parser.parse_args(["mcp-serve"]).host_image_content)
+        self.assertTrue(
+            parser.parse_args([
+                "mcp-serve", "--host-image-content"
+            ]).host_image_content
+        )
+
+    def test_run_forwards_the_startup_declaration(self):
+        from venice.commands import mcp_serve
+        from venice import mcp_server
+
+        client = object()
+        doc = {"defaults": {}}
+        with mock.patch.object(mcp_serve._mcp, "import_mcp", return_value=object()), \
+             mock.patch.object(mcp_serve, "build_client_from_auth", return_value=client), \
+             mock.patch.object(mcp_serve.userconfig, "load_config", return_value=doc), \
+             mock.patch.object(mcp_server, "serve") as serve, \
+             mock.patch.object(sys, "stderr", io.StringIO()):
+            rc = mcp_serve._run(argparse.Namespace(host_image_content=True))
+        self.assertEqual(rc, 0)
+        serve.assert_called_once_with(
+            client, doc=doc, host_image_content=True
+        )
+
+
 @unittest.skipUnless(_HAS_MCP, "mcp SDK not installed (expected on Python 3.9)")
 class TestServerWiring(unittest.TestCase):
-    def test_build_server_exposes_exactly_nine_tools(self):
+    def test_build_server_exposes_exactly_ten_tools(self):
         from venice.mcp_server import build_server
 
         class FakeClient:
@@ -86,6 +117,205 @@ class TestServerWiring(unittest.TestCase):
             {"status": "ok", "content": "pong"},
         )
         impl.assert_called_once()
+
+    def test_native_vision_returns_prompt_then_exact_image_content(self):
+        from mcp import Client
+
+        from venice.commands import _mcp, _openai
+        from venice.mcp_server import build_server
+
+        class FakeClient:
+            api_key = "fake"
+            base_url = "https://api.venice.ai/api/v1"
+
+        png = b"\x89PNG\r\n\x1a\nexact-pixels"
+        with tempfile.TemporaryDirectory() as root:
+            Path(root, "frame.png").write_bytes(png)
+            server = build_server(
+                FakeClient(), doc={}, root=root, host_image_content=True
+            )
+
+            async def exercise():
+                async with Client(server) as client:
+                    return await client.call_tool("venice_vision", {
+                        "input_path": "frame.png",
+                        "prompt": "Inspect the alignment.",
+                    })
+
+            with mock.patch.object(_mcp, "vision_tool") as delegate, \
+                 mock.patch.object(_openai, "import_openai") as sdk_import:
+                result = asyncio.run(exercise())
+
+        self.assertFalse(result.is_error)
+        self.assertEqual([block.type for block in result.content], ["text", "image"])
+        self.assertEqual(result.content[0].text, "Inspect the alignment.")
+        self.assertEqual(result.content[1].mime_type, "image/png")
+        self.assertEqual(base64.b64decode(result.content[1].data), png)
+        delegate.assert_not_called()
+        sdk_import.assert_not_called()
+
+    def test_auto_without_declaration_delegates_as_text(self):
+        from mcp import Client
+
+        from venice.commands import _mcp
+        from venice.mcp_server import build_server
+
+        class FakeClient:
+            api_key = "fake"
+            base_url = "https://api.venice.ai/api/v1"
+
+        server = build_server(FakeClient(), doc={})
+
+        async def exercise():
+            async with Client(server) as client:
+                return await client.call_tool("venice_vision", {
+                    "input_path": "frame.png",
+                    "prompt": "Read it",
+                    "model": "vision-model",
+                    "max_tokens": 77,
+                })
+
+        delegated = {
+            "status": "ok", "content": "delegated answer", "model": "vision-model"
+        }
+        with mock.patch.object(_mcp, "vision_tool", return_value=delegated) as impl:
+            result = asyncio.run(exercise())
+
+        self.assertFalse(result.is_error)
+        self.assertEqual([block.type for block in result.content], ["text"])
+        self.assertEqual(json.loads(result.content[0].text), delegated)
+        impl.assert_called_once()
+        self.assertEqual(impl.call_args.kwargs["model"], "vision-model")
+        self.assertEqual(impl.call_args.kwargs["max_tokens"], 77)
+
+    def test_native_without_declaration_fails_closed(self):
+        from venice.commands import _mcp
+        from venice.mcp_server import build_server
+
+        class FakeClient:
+            api_key = "fake"
+            base_url = "https://api.venice.ai/api/v1"
+
+        with mock.patch.object(_mcp, "vision_tool") as impl:
+            result = build_server(FakeClient(), doc={})._tool_manager.get_tool(
+                "venice_vision"
+            ).fn(input_path="frame.png", mode="native")
+        self.assertTrue(result.is_error)
+        self.assertIn("--host-image-content", result.content[0].text)
+        impl.assert_not_called()
+
+    def test_explicit_delegate_wins_over_host_declaration(self):
+        from venice.commands import _mcp
+        from venice.mcp_server import build_server
+
+        class FakeClient:
+            api_key = "fake"
+            base_url = "https://api.venice.ai/api/v1"
+
+        delegated = {"status": "ok", "content": "text"}
+        with mock.patch.object(_mcp, "vision_tool", return_value=delegated) as impl:
+            result = build_server(
+                FakeClient(), doc={}, host_image_content=True
+            )._tool_manager.get_tool("venice_vision").fn(
+                input_path="frame.png", mode="delegate"
+            )
+        self.assertEqual(json.loads(result.content[0].text), delegated)
+        impl.assert_called_once()
+
+    def test_native_remote_url_is_rejected_without_fetch_or_delegate(self):
+        from venice.commands import _mcp
+        from venice.mcp_server import build_server
+
+        class FakeClient:
+            api_key = "fake"
+            base_url = "https://api.venice.ai/api/v1"
+
+        with mock.patch.object(_mcp, "vision_tool") as impl:
+            result = build_server(
+                FakeClient(), doc={}, host_image_content=True
+            )._tool_manager.get_tool("venice_vision").fn(
+                image_url="https://example.test/frame.png", mode="native"
+            )
+        self.assertTrue(result.is_error)
+        self.assertIn("only input_path", result.content[0].text)
+        impl.assert_not_called()
+
+    def test_auto_remote_url_delegates_even_for_image_content_host(self):
+        from venice.commands import _mcp
+        from venice.mcp_server import build_server
+
+        class FakeClient:
+            api_key = "fake"
+            base_url = "https://api.venice.ai/api/v1"
+
+        delegated = {"status": "ok", "content": "remote description"}
+        with mock.patch.object(_mcp, "vision_tool", return_value=delegated) as impl:
+            result = build_server(
+                FakeClient(), doc={}, host_image_content=True
+            )._tool_manager.get_tool("venice_vision").fn(
+                image_url="https://example.test/frame.png"
+            )
+        self.assertEqual(json.loads(result.content[0].text), delegated)
+        impl.assert_called_once()
+
+    def test_vision_config_defaults_and_explicit_overrides_reach_delegate(self):
+        from venice.commands import _mcp
+        from venice.mcp_server import build_server
+
+        class FakeClient:
+            api_key = "fake"
+            base_url = "https://api.venice.ai/api/v1"
+
+        doc = {"defaults": {"vision": {
+            "mode": "delegate", "model": "configured", "max_tokens": 44,
+        }}}
+        delegated = {"status": "ok", "content": "description"}
+        tool = build_server(
+            FakeClient(), doc=doc, host_image_content=True
+        )._tool_manager.get_tool("venice_vision").fn
+        with mock.patch.object(_mcp, "vision_tool", return_value=delegated) as impl:
+            tool(input_path="frame.png")
+            tool(
+                input_path="frame.png", mode="delegate",
+                model="explicit", max_tokens=55,
+            )
+        first, second = impl.call_args_list
+        self.assertEqual(first.kwargs["model"], "configured")
+        self.assertEqual(first.kwargs["max_tokens"], 44)
+        self.assertEqual(second.kwargs["model"], "explicit")
+        self.assertEqual(second.kwargs["max_tokens"], 55)
+
+    def test_native_vision_reuses_local_media_authority_failures(self):
+        from venice.commands import _shared
+        from venice.mcp_server import build_server
+
+        class FakeClient:
+            api_key = "fake"
+            base_url = "https://api.venice.ai/api/v1"
+
+        cases = {
+            "empty.png": b"",
+            "text.png": b"not an image",
+        }
+        with tempfile.TemporaryDirectory() as root, tempfile.TemporaryDirectory() as out:
+            for name, data in cases.items():
+                Path(root, name).write_bytes(data)
+            outside = Path(out, "outside.png")
+            outside.write_bytes(b"\x89PNG\r\n\x1a\nbody")
+            Path(root, "escape.png").symlink_to(outside)
+            Path(root, "large.png").write_bytes(b"\x89PNG\r\n\x1a\nbody")
+            tool = build_server(
+                FakeClient(), doc={}, root=root, host_image_content=True
+            )._tool_manager.get_tool("venice_vision").fn
+            results = [tool(input_path=name) for name in cases]
+            results.append(tool(input_path="missing.png"))
+            results.append(tool(input_path=outside.as_posix()))
+            results.append(tool(input_path="escape.png"))
+            with mock.patch.object(_shared, "MAX_IMAGE_BYTES", 8):
+                results.append(tool(input_path="large.png"))
+        for result in results:
+            self.assertTrue(result.is_error)
+            self.assertEqual([block.type for block in result.content], ["text"])
 
     def test_server_captures_startup_root_for_media_authority(self):
         from venice.mcp_server import build_server
@@ -163,6 +393,26 @@ class TestServerWiring(unittest.TestCase):
             "quality", "disable_prompt_optimization_thinking", "enhance_prompt"
         ):
             self.assertIn(name, edit_props)
+
+    def test_vision_schema_exposes_only_the_declared_public_inputs(self):
+        from venice.mcp_server import build_server
+
+        class FakeClient:
+            api_key = "fake"
+            base_url = "https://api.venice.ai/api/v1"
+
+        tool = build_server(FakeClient(), doc={})._tool_manager.get_tool(
+            "venice_vision"
+        )
+        props = tool.parameters["properties"]
+        self.assertEqual(
+            set(props),
+            {"input_path", "image_url", "prompt", "model", "max_tokens", "mode"},
+        )
+        self.assertEqual(
+            props["mode"]["anyOf"][0]["enum"],
+            ["auto", "native", "delegate"],
+        )
 
     def test_retired_upscale_config_returns_error_without_delegating(self):
         from venice.mcp_server import build_server

--- a/tests/test_mcp_serve.py
+++ b/tests/test_mcp_serve.py
@@ -50,6 +50,7 @@ class TestCommandWiring(unittest.TestCase):
             ]).host_image_content
         )
 
+    @unittest.skipUnless(_HAS_MCP, "mcp SDK not installed (expected on Python 3.9)")
     def test_run_forwards_the_startup_declaration(self):
         from venice.commands import mcp_serve
         from venice import mcp_server


### PR DESCRIPTION
Closes #222.

## Summary
- add `venice mcp-serve --host-image-content` as an explicit, process-scoped declaration that the stdio host can deliver MCP ImageContent to a vision-capable frontend
- expose `venice_vision` as the tenth MCP tool, with fail-closed native mode and delegated text fallback preserving `mode`, `model`, `max_tokens`, and `defaults.vision.*`
- return native local images as ordered TextContent + ImageContent only after the existing project-root, protected-path, regular-file, size, and signature checks
- keep remote `image_url` inputs delegated and leave HTTP/auth/per-client negotiation to #31

## Validation
- `VENICE_API_KEY=test-fake-key make lint` — passed
- `VENICE_API_KEY=test-fake-key make scan` — passed
- affected MCP/config/CLI tests — 254 passed
- full `VENICE_API_KEY=test-fake-key make test` — 1,907 passed, 1 skipped
- `VENICE_API_KEY=test-fake-key make drive` — 46 passed
- `make openapi-check` — passed (18 implemented operations)
- `make build` / strict twine checks — passed
- dependency-free base-wheel smoke — passed
- `git diff --check` — passed
- no live Venice API calls
