### PR TITLE
Add authenticated remote MCP transport

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,9 @@
+.git
+.github
+.venv*
+__pycache__
+*.py[cod]
+build
+dist
+deploy
+tests

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -88,3 +88,48 @@ jobs:
           name: dist
           path: dist
       - uses: pypa/gh-action-pypi-publish@release/v1
+
+  ghcr:
+    needs: build
+    if: github.event_name == 'release'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          ref: ${{ github.sha }}
+
+      - uses: docker/setup-qemu-action@v3
+
+      - uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ github.token }}
+
+      - name: Publish exact release image
+        id: image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: |
+            ghcr.io/${{ github.repository }}:${{ github.event.release.tag_name }}
+            ghcr.io/${{ github.repository }}:sha-${{ github.sha }}
+            ghcr.io/${{ github.repository }}:latest
+          labels: |
+            org.opencontainers.image.created=${{ github.event.release.created_at }}
+            org.opencontainers.image.revision=${{ github.sha }}
+            org.opencontainers.image.source=${{ github.server_url }}/${{ github.repository }}
+            org.opencontainers.image.version=${{ github.event.release.tag_name }}
+
+      - name: Record immutable image digest
+        env:
+          DIGEST: ${{ steps.image.outputs.digest }}
+        run: echo "Published ghcr.io/${GITHUB_REPOSITORY}@${DIGEST}" >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -148,3 +148,62 @@ jobs:
           "$SMOKE_VENV/bin/venice" --version
           "$SMOKE_VENV/bin/venice" --help >/dev/null
           "$SMOKE_VENV/bin/venice" completion bash >/dev/null
+
+  container:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v5
+
+      - uses: docker/setup-buildx-action@v3
+
+      - name: Build remote MCP image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          load: true
+          push: false
+          tags: venice-cli:mcp-ci
+
+      - name: Smoke the read-only non-root listener
+        env:
+          VENICE_API_KEY: test-fake-key
+          VENICE_MCP_PUBLIC_URL: https://mcp.example.test/mcp
+          VENICE_MCP_OAUTH_ISSUER: https://auth.example.test
+          VENICE_MCP_OAUTH_JWKS_URL: https://auth.example.test/jwks
+          VENICE_MCP_OAUTH_AUDIENCE: venice-api
+          VENICE_MCP_OAUTH_SCOPES: venice:mcp
+        run: |
+          set -eu
+          cleanup() {
+            docker logs venice-mcp-ci 2>&1 || true
+            docker rm -f venice-mcp-ci >/dev/null 2>&1 || true
+          }
+          trap cleanup EXIT
+          docker run --detach --name venice-mcp-ci \
+            --read-only --tmpfs /tmp:rw,noexec,nosuid,size=64m \
+            --publish 127.0.0.1:18080:8000 \
+            --env VENICE_API_KEY \
+            --env VENICE_MCP_PUBLIC_URL \
+            --env VENICE_MCP_OAUTH_ISSUER \
+            --env VENICE_MCP_OAUTH_JWKS_URL \
+            --env VENICE_MCP_OAUTH_AUDIENCE \
+            --env VENICE_MCP_OAUTH_SCOPES \
+            venice-cli:mcp-ci
+          python - <<'PY'
+          import json
+          import time
+          import urllib.error
+          import urllib.request
+
+          url = "http://127.0.0.1:18080/healthz"
+          for attempt in range(30):
+              try:
+                  with urllib.request.urlopen(url, timeout=2) as response:
+                      assert json.load(response) == {"status": "ok"}
+                  break
+              except (OSError, urllib.error.URLError):
+                  if attempt == 29:
+                      raise
+                  time.sleep(1)
+          PY

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,34 @@
+FROM python:3.14-slim AS builder
+
+ENV PIP_DISABLE_PIP_VERSION_CHECK=1 \
+    PIP_NO_CACHE_DIR=1
+WORKDIR /src
+COPY pyproject.toml README.md LICENSE ./
+COPY src ./src
+RUN python -m venv /opt/venice \
+    && /opt/venice/bin/python -m pip install --upgrade pip \
+    && /opt/venice/bin/python -m pip install ".[all]"
+
+FROM python:3.14-slim
+
+LABEL org.opencontainers.image.source="https://github.com/gobha-me/venice-cli" \
+      org.opencontainers.image.licenses="MIT"
+
+RUN groupadd --system --gid 10001 venice \
+    && useradd --uid 10001 --gid venice --no-create-home \
+       --home-dir /nonexistent --shell /usr/sbin/nologin venice \
+    && install -d -o venice -g venice /srv/venice
+COPY --from=builder /opt/venice /opt/venice
+
+ENV HOME=/tmp/venice-home \
+    PATH=/opt/venice/bin:$PATH \
+    PYTHONDONTWRITEBYTECODE=1 \
+    PYTHONUNBUFFERED=1
+WORKDIR /srv/venice
+USER 10001:10001
+EXPOSE 8000
+
+HEALTHCHECK --interval=30s --timeout=3s --start-period=10s --retries=3 \
+    CMD ["python", "-c", "import urllib.request; urllib.request.urlopen('http://127.0.0.1:8000/healthz', timeout=2).read()"]
+
+ENTRYPOINT ["venice", "mcp-serve", "--http", "--host", "0.0.0.0", "--port", "8000"]

--- a/README.md
+++ b/README.md
@@ -61,6 +61,8 @@ The name at the left is the corresponding lazy-import label in the source.
 - `review`: model-backed `venice review` runs. A diff skipped by `auto` triage,
   an empty diff, or `--effort never` returns before importing the SDK.
 - `vision`: the agent's model-backed `vision` tool.
+- `mcp-serve --http`: the authenticated remote MCP server's `venice_chat` and
+  delegated `venice_vision` tools.
 <!-- openai-extra-inventory:end -->
 
 The `[mcp]` extra is independent: it provides the transport used to start
@@ -1903,13 +1905,16 @@ look" must never be able to masquerade as "we looked and found nothing".
 
 ## MCP server
 
-`venice mcp-serve` runs an [MCP](https://modelcontextprotocol.io) server over
-stdio, exposing venice's generators as tools that an MCP host (Claude Code, or
-any MCP client) can call directly instead of shelling out to the CLI. Starting
-the server needs the `[mcp]` extra (Python ≥ 3.10); its `venice_chat` tool also
-needs `[openai]`. Delegated `venice_vision` calls need `[openai]` too; its local
-native path does not. Install `[all]` when the host should be able to call all ten
-tools:
+`venice mcp-serve` runs an [MCP](https://modelcontextprotocol.io) server either
+locally over stdio or remotely over authenticated Streamable HTTP. Starting the
+server needs the `[mcp]` extra (Python ≥ 3.10); `venice_chat` and delegated
+`venice_vision` also need `[openai]`.
+
+### Local stdio server
+
+The default stdio profile exposes Venice's generators as tools that a local MCP
+host (Claude Code, or any process that can spawn the CLI) can call directly.
+Install `[all]` when the host should be able to call all ten tools:
 
 ```sh
 pip install "venice-cli[mcp]"
@@ -1976,6 +1981,64 @@ Only stdout carries the JSON-RPC protocol; the server's own diagnostics go to
 stderr. Video generation and image editing are exposed over MCP too: the
 `venice_video` and `venice_image_edit` tools cover the same capabilities as the
 `venice video` and `venice image-edit` CLI commands.
+
+### Authenticated remote server
+
+`venice mcp-serve --http` exposes a deliberately smaller, path-independent
+profile over Streamable HTTP:
+
+- `venice_chat` — one delegated completion;
+- `venice_vision` — delegated analysis of a required remote `image_url`.
+
+The eight tools that consume or return server-local files are absent. HTTP mode
+never turns a pod path into a useful-looking result, and it rejects
+`--host-image-content`; authenticated, bounded remote media resources are tracked
+separately. The local stdio profile remains the ten-tool surface documented above.
+
+HTTP mode is always an OAuth 2.1 resource server. It validates asymmetric JWT
+access tokens locally from an external authorization server's HTTPS JWKS; Venice
+does not provide a login page, issue tokens, or embed an authorization server.
+Tokens must have a `kid`, use RS256, ES256, or EdDSA, and carry the configured
+issuer, audience, expiry, subject, client identity (`client_id` or `azp`), and all
+required scopes. A missing or invalid token is rejected before MCP parses or
+invokes a tool.
+
+```sh
+export VENICE_MCP_PUBLIC_URL=https://mcp.example.com/mcp
+export VENICE_MCP_OAUTH_ISSUER=https://auth.example.com
+export VENICE_MCP_OAUTH_JWKS_URL=https://auth.example.com/.well-known/jwks.json
+export VENICE_MCP_OAUTH_AUDIENCE=https://mcp.example.com
+export VENICE_MCP_OAUTH_SCOPES='venice:mcp'
+
+venice mcp-serve --http --host 0.0.0.0 --port 8000
+```
+
+The first four values and at least one scope are required. Their equivalent CLI
+flags are `--public-url`, `--oauth-issuer`, `--oauth-jwks-url`,
+`--oauth-audience`, and repeatable `--oauth-scope`; explicit flags override the
+environment. The public URL must be HTTPS and end exactly in `/mcp`. These
+security-critical settings do not fall back to `~/.config/venice/config`.
+
+DNS-rebinding protection accepts only the exact Host from the public URL. A
+request with an Origin header is rejected unless that exact HTTPS origin was
+added with repeatable `--allowed-origin` or the whitespace-separated
+`VENICE_MCP_ALLOWED_ORIGINS`. This is an inbound origin check, not a wildcard
+CORS switch. `GET /healthz` is intentionally unauthenticated and returns only
+`{"status":"ok"}` for container probes.
+
+Configure the external authorization server to issue access tokens for the
+chosen audience and scopes, then register its OAuth client in the remote MCP host.
+Claude custom connectors accept a pre-registered OAuth client ID and secret in
+Advanced settings. Authentication limits who may invoke the tools; it does not add
+a pre-call billing quote to `venice_chat` or delegated vision.
+
+The published container is `ghcr.io/gobha-me/venice-cli`. Releases publish an
+immutable version tag and `sha-<full-commit>` tag plus the moving `latest` tag.
+Prefer the version tag or its registry digest in deployments. A hardened
+Deployment, Service, and TLS Ingress template is in
+`deploy/kubernetes/remote-mcp.yaml`; replace its example domain, OAuth values,
+image version, TLS issuer/secret, and separately provision the referenced
+`venice-mcp-api-key` Secret. Do not commit the API key to the manifest.
 
 The reverse direction — venice as an MCP **client**, calling *other* servers'
 tools inside `venice chat` — is [`venice chat --mcp`](#external-mcp-tools---mcp).

--- a/deploy/kubernetes/remote-mcp.yaml
+++ b/deploy/kubernetes/remote-mcp.yaml
@@ -1,0 +1,113 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: venice-mcp
+data:
+  VENICE_MCP_PUBLIC_URL: https://mcp.example.com/mcp
+  VENICE_MCP_OAUTH_ISSUER: https://auth.example.com
+  VENICE_MCP_OAUTH_JWKS_URL: https://auth.example.com/.well-known/jwks.json
+  VENICE_MCP_OAUTH_AUDIENCE: https://mcp.example.com
+  VENICE_MCP_OAUTH_SCOPES: venice:mcp
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: venice-mcp
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: venice-mcp
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: venice-mcp
+    spec:
+      automountServiceAccountToken: false
+      securityContext:
+        runAsNonRoot: true
+        seccompProfile:
+          type: RuntimeDefault
+      containers:
+        - name: venice-mcp
+          # Replace VERSION with a release tag or, preferably, pin its published digest.
+          image: ghcr.io/gobha-me/venice-cli:VERSION
+          imagePullPolicy: IfNotPresent
+          envFrom:
+            - configMapRef:
+                name: venice-mcp
+          env:
+            - name: VENICE_API_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: venice-mcp-api-key
+                  key: VENICE_API_KEY
+          ports:
+            - name: http
+              containerPort: 8000
+          readinessProbe:
+            httpGet:
+              path: /healthz
+              port: http
+            initialDelaySeconds: 2
+            periodSeconds: 10
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: http
+            initialDelaySeconds: 10
+            periodSeconds: 30
+          resources:
+            requests:
+              cpu: 100m
+              memory: 128Mi
+            limits:
+              cpu: 500m
+              memory: 512Mi
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            capabilities:
+              drop: ["ALL"]
+          volumeMounts:
+            - name: tmp
+              mountPath: /tmp
+      volumes:
+        - name: tmp
+          emptyDir:
+            sizeLimit: 64Mi
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: venice-mcp
+spec:
+  selector:
+    app.kubernetes.io/name: venice-mcp
+  ports:
+    - name: http
+      port: 80
+      targetPort: http
+---
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: venice-mcp
+  annotations:
+    cert-manager.io/cluster-issuer: letsencrypt-production
+spec:
+  ingressClassName: traefik
+  tls:
+    - hosts: [mcp.example.com]
+      secretName: venice-mcp-tls
+  rules:
+    - host: mcp.example.com
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: venice-mcp
+                port:
+                  name: http

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,7 +56,7 @@ openai = ["openai>=1.40"]
 # Keep the major bound explicit: SDK 2.x renamed FastMCP to MCPServer and moved
 # protocol-model attributes to snake_case, so a future major must be reviewed
 # deliberately rather than becoming an ambient resolver break like #95.
-mcp = ["mcp>=2,<3; python_version>='3.10'"]
+mcp = ["mcp>=2.1.1,<3; python_version>='3.10'"]
 # Test-only: `pexpect` drives the real CLI on a pty in tests/test_drive_cli.py.
 # Deliberately NOT in `all` -- `all` is a *runtime* install, and the CI `package`
 # job's "a base install pulls in nothing third-party" proof must stay meaningful.
@@ -97,4 +97,7 @@ include = [
   "/LICENSE",
   "/CONTRIBUTING.md",
   "/SECURITY.md",
+  "/Dockerfile",
+  "/.dockerignore",
+  "/deploy",
 ]

--- a/src/venice/commands/mcp_serve.py
+++ b/src/venice/commands/mcp_serve.py
@@ -1,4 +1,4 @@
-"""`venice mcp-serve` -- run an MCP server (stdio) exposing venice tools.
+"""`venice mcp-serve` -- run Venice tools over stdio or authenticated HTTP.
 
 Direction A of the MCP epic (#16 / #14): venice is the *callee*. It speaks MCP over
 stdio -- JSON-RPC frames on stdout -- exposing image/sfx/music/tts/upscale/bg-remove/
@@ -12,21 +12,162 @@ the JSON-RPC transport, so this command's own diagnostics go to stderr only.
 """
 from __future__ import annotations
 
+import argparse
+import os
+import re
 import sys
+import urllib.parse
+from dataclasses import dataclass
 
 from .. import auth
 from .. import userconfig
 from ..client import build_client_from_auth
-from . import _mcp
+from . import _mcp, _openai
+
+
+_SCOPE_RE = re.compile(r"[\x21\x23-\x5b\x5d-\x7e]{1,256}\Z")
+
+
+class RemoteConfigError(ValueError):
+    """The authenticated HTTP listener was not configured safely."""
+
+
+@dataclass(frozen=True)
+class RemoteConfig:
+    public_url: str
+    issuer_url: str
+    jwks_url: str
+    audience: str
+    scopes: tuple[str, ...]
+    allowed_origins: tuple[str, ...]
+
+
+def _port(value: str) -> int:
+    try:
+        port = int(value)
+    except ValueError:
+        raise argparse.ArgumentTypeError("must be an integer") from None
+    if not 1 <= port <= 65535:
+        raise argparse.ArgumentTypeError("must be between 1 and 65535")
+    return port
+
+
+def _setting(args, name: str, env_name: str, environ) -> str:
+    value = getattr(args, name, None)
+    if value is None:
+        value = environ.get(env_name)
+    return str(value).strip() if value is not None else ""
+
+
+def _https_url(value: str, label: str, *, endpoint_path=None) -> str:
+    try:
+        parsed = urllib.parse.urlsplit(value)
+        port = parsed.port
+    except ValueError:
+        raise RemoteConfigError(f"{label} is not a valid URL") from None
+    if (
+        parsed.scheme != "https"
+        or not parsed.hostname
+        or parsed.username is not None
+        or parsed.password is not None
+        or parsed.query
+        or parsed.fragment
+    ):
+        raise RemoteConfigError(
+            f"{label} must be an https URL without credentials, query, or fragment"
+        )
+    if endpoint_path is not None and parsed.path != endpoint_path:
+        raise RemoteConfigError(f"{label} path must be {endpoint_path!r}")
+    # Accessing .port above also rejects malformed/non-numeric ports. Keep the
+    # original spelling otherwise: OAuth issuer comparison is exact.
+    del port
+    return value
+
+
+def _origin(value: str) -> str:
+    try:
+        parsed = urllib.parse.urlsplit(value)
+        parsed.port
+    except ValueError:
+        raise RemoteConfigError("--allowed-origin is not a valid URL") from None
+    if (
+        parsed.scheme != "https"
+        or not parsed.hostname
+        or parsed.username is not None
+        or parsed.password is not None
+        or parsed.path not in ("", "/")
+        or parsed.query
+        or parsed.fragment
+    ):
+        raise RemoteConfigError(
+            "--allowed-origin values must be https origins without a path, "
+            "credentials, query, or fragment"
+        )
+    return f"{parsed.scheme}://{parsed.netloc}"
+
+
+def resolve_remote_config(args, environ=None) -> RemoteConfig:
+    """Resolve the fail-closed OAuth resource-server settings for HTTP mode."""
+    environ = os.environ if environ is None else environ
+    fields = {
+        "public_url": _setting(args, "public_url", "VENICE_MCP_PUBLIC_URL", environ),
+        "issuer_url": _setting(args, "oauth_issuer", "VENICE_MCP_OAUTH_ISSUER", environ),
+        "jwks_url": _setting(args, "oauth_jwks_url", "VENICE_MCP_OAUTH_JWKS_URL", environ),
+        "audience": _setting(args, "oauth_audience", "VENICE_MCP_OAUTH_AUDIENCE", environ),
+    }
+    missing = [name for name, value in fields.items() if not value]
+    cli_names = {
+        "public_url": "--public-url",
+        "issuer_url": "--oauth-issuer",
+        "jwks_url": "--oauth-jwks-url",
+        "audience": "--oauth-audience",
+    }
+    if missing:
+        raise RemoteConfigError(
+            "HTTP mode requires " + ", ".join(cli_names[name] for name in missing)
+        )
+
+    cli_scopes = getattr(args, "oauth_scope", None)
+    scopes = cli_scopes if cli_scopes else environ.get("VENICE_MCP_OAUTH_SCOPES", "").split()
+    scopes = tuple(dict.fromkeys(str(scope).strip() for scope in scopes if str(scope).strip()))
+    if not scopes:
+        raise RemoteConfigError(
+            "HTTP mode requires --oauth-scope (or VENICE_MCP_OAUTH_SCOPES)"
+        )
+    if not all(_SCOPE_RE.fullmatch(scope) for scope in scopes):
+        raise RemoteConfigError(
+            "OAuth scopes must be 1-256 character RFC 6749 scope tokens"
+        )
+
+    cli_origins = getattr(args, "allowed_origin", None)
+    origins = (
+        cli_origins
+        if cli_origins
+        else environ.get("VENICE_MCP_ALLOWED_ORIGINS", "").split()
+    )
+    allowed_origins = tuple(
+        dict.fromkeys(_origin(str(value).strip()) for value in origins)
+    )
+    if len(allowed_origins) > 32:
+        raise RemoteConfigError("at most 32 --allowed-origin values are accepted")
+    return RemoteConfig(
+        public_url=_https_url(fields["public_url"], "--public-url", endpoint_path="/mcp"),
+        issuer_url=_https_url(fields["issuer_url"], "--oauth-issuer"),
+        jwks_url=_https_url(fields["jwks_url"], "--oauth-jwks-url"),
+        audience=fields["audience"],
+        scopes=scopes,
+        allowed_origins=allowed_origins,
+    )
 
 
 def register(subparsers) -> None:
     p = subparsers.add_parser(
         "mcp-serve",
-        help="Run an MCP server (stdio) exposing venice tools.",
+        help="Run Venice tools over stdio or authenticated Streamable HTTP.",
         description=(
-            "Speaks MCP over stdio: exposes venice image/sfx/music/tts/upscale/"
-            "bg-remove/chat/vision as MCP tools. Needs the [mcp] extra "
+            "Speaks MCP over stdio with all local tools, or authenticated "
+            "Streamable HTTP with the remote-safe chat/vision profile. Needs "
+            "the [mcp] extra "
             "(Python >=3.10): "
             'pip install "venice-cli[mcp]". Attach it with, e.g., '
             "`claude mcp add venice -- venice mcp-serve`. Spend on paid tools is "
@@ -42,6 +183,24 @@ def register(subparsers) -> None:
             "vision-capable frontend (default: text-only/delegated vision)"
         ),
     )
+    p.add_argument(
+        "--http", action="store_true",
+        help="serve the remote-safe tool profile over authenticated Streamable HTTP",
+    )
+    p.add_argument("--host", help="HTTP bind host (default: 127.0.0.1)")
+    p.add_argument("--port", type=_port, help="HTTP bind port (default: 8000)")
+    p.add_argument("--public-url", help="public HTTPS MCP endpoint (must end in /mcp)")
+    p.add_argument("--oauth-issuer", help="exact HTTPS OAuth issuer URL")
+    p.add_argument("--oauth-jwks-url", help="HTTPS JSON Web Key Set URL")
+    p.add_argument("--oauth-audience", help="required JWT audience")
+    p.add_argument(
+        "--oauth-scope", action="append",
+        help="required OAuth scope; repeat to require more than one",
+    )
+    p.add_argument(
+        "--allowed-origin", action="append",
+        help="allow one exact HTTPS browser Origin; repeat as needed",
+    )
     p.set_defaults(handler=_run)
 
 
@@ -50,25 +209,66 @@ def _run(args) -> int:
     if mcp is None:
         return 2
 
+    remote = getattr(args, "http", False)
+    remote_only = (
+        "host", "port", "public_url", "oauth_issuer", "oauth_jwks_url",
+        "oauth_audience", "oauth_scope", "allowed_origin",
+    )
+    if not remote and any(getattr(args, name, None) is not None for name in remote_only):
+        print(
+            "venice mcp-serve: HTTP listener/OAuth flags require --http",
+            file=sys.stderr,
+        )
+        return 2
+    if remote and getattr(args, "host_image_content", False):
+        print(
+            "venice mcp-serve: --host-image-content is stdio-only; HTTP vision "
+            "accepts remote image URLs and always delegates",
+            file=sys.stderr,
+        )
+        return 2
+    if remote and _openai.import_openai("mcp-serve --http") is None:
+        return 2
     try:
+        remote_config = resolve_remote_config(args) if remote else None
         # Fail fast on auth *before* stdout is handed to the JSON-RPC transport.
         client = build_client_from_auth()
-    except auth.AuthError as e:
+    except (auth.AuthError, RemoteConfigError) as e:
         print(str(e), file=sys.stderr)
         return 2
 
-    from ..mcp_server import serve  # lazy: only import MCPServer after the probe passes
+    # Lazy: only import MCPServer/PyJWT after the optional SDK probe passes.
+    from ..mcp_server import serve, serve_http
 
     doc = userconfig.load_config()  # #58: honor defaults.<section>.* in exposed tools
 
-    print("venice mcp-serve: starting stdio MCP server (Ctrl-C to stop)",
-          file=sys.stderr)
     try:
-        serve(
-            client,
-            doc=doc,
-            host_image_content=getattr(args, "host_image_content", False),
-        )
+        if remote:
+            assert remote_config is not None
+            host = getattr(args, "host", None) or "127.0.0.1"
+            port = getattr(args, "port", None) or 8000
+            print(
+                f"venice mcp-serve: starting authenticated HTTP server on "
+                f"{host}:{port} (public endpoint {remote_config.public_url})",
+                file=sys.stderr,
+            )
+            serve_http(
+                client, doc=doc, host=host, port=port,
+                public_url=remote_config.public_url,
+                issuer_url=remote_config.issuer_url,
+                jwks_url=remote_config.jwks_url,
+                audience=remote_config.audience,
+                scopes=remote_config.scopes,
+                allowed_origins=remote_config.allowed_origins,
+            )
+        else:
+            print("venice mcp-serve: starting stdio MCP server (Ctrl-C to stop)",
+                  file=sys.stderr)
+            serve(
+                client,
+                doc=doc,
+                host_image_content=getattr(args, "host_image_content", False),
+            )
     except KeyboardInterrupt:
         return 130
     return 0

--- a/src/venice/mcp_server.py
+++ b/src/venice/mcp_server.py
@@ -14,14 +14,125 @@ input schema via typing.get_type_hints, so the annotations must stay concrete
 """
 import json
 import os
+import urllib.parse
 from typing import Annotated, List, Literal, Optional
 
+import anyio
+import jwt
+from jwt.exceptions import PyJWTError
 from mcp import types
+from mcp.server.auth.provider import AccessToken, TokenVerifier
+from mcp.server.auth.settings import AuthSettings
 from mcp.server.mcpserver import MCPServer
+from mcp.server.transport_security import TransportSecuritySettings
 from pydantic import Field
+from starlette.requests import Request
+from starlette.responses import JSONResponse
 
 from . import userconfig
 from .commands import _mcp, _shared, upscale as _upscale
+
+
+REMOTE_TOKEN_MAX_BYTES = 16 * 1024
+REMOTE_JWT_ALGORITHMS = ("RS256", "ES256", "EdDSA")
+REMOTE_DATA_URL_MAX_CHARS = 4 * 1024 * 1024
+
+
+def _valid_remote_image_url(value):
+    """Accept only network/data image URLs; never reinterpret text as a pod path."""
+    if not isinstance(value, str) or not value or len(value) > REMOTE_DATA_URL_MAX_CHARS:
+        return False
+    if value.startswith("data:image/"):
+        header, separator, payload = value.partition(",")
+        return bool(separator and payload and header.endswith(";base64"))
+    try:
+        parsed = urllib.parse.urlsplit(value)
+        parsed.port
+    except ValueError:
+        return False
+    return bool(
+        parsed.scheme in ("http", "https")
+        and parsed.hostname
+        and parsed.username is None
+        and parsed.password is None
+        and not parsed.fragment
+    )
+
+
+class JWKSJWTVerifier(TokenVerifier):
+    """Verify bounded asymmetric OAuth access tokens against a cached JWKS."""
+
+    def __init__(self, *, jwks_url, issuer, audience, required_scopes):
+        self.issuer = issuer
+        self.audience = audience
+        self.required_scopes = frozenset(required_scopes)
+        self._jwks = jwt.PyJWKClient(
+            jwks_url,
+            cache_keys=True,
+            max_cached_keys=16,
+            cache_jwk_set=True,
+            lifespan=300,
+            timeout=5,
+        )
+
+    @staticmethod
+    def _scope_set(claims):
+        raw = claims.get("scope")
+        if raw is None:
+            raw = claims.get("scp")
+        if isinstance(raw, str):
+            return frozenset(raw.split())
+        if isinstance(raw, list) and all(isinstance(item, str) for item in raw):
+            return frozenset(raw)
+        return frozenset()
+
+    def _verify(self, token):
+        if not isinstance(token, str) or not token or len(token.encode()) > REMOTE_TOKEN_MAX_BYTES:
+            return None
+        try:
+            header = jwt.get_unverified_header(token)
+            algorithm = header.get("alg")
+            if algorithm not in REMOTE_JWT_ALGORITHMS or not header.get("kid"):
+                return None
+            signing_key = self._jwks.get_signing_key_from_jwt(token)
+            claims = jwt.decode(
+                token,
+                signing_key.key,
+                algorithms=[algorithm],
+                audience=self.audience,
+                issuer=self.issuer,
+                leeway=60,
+                options={"require": ["exp", "iss", "aud", "sub"]},
+            )
+        except (PyJWTError, OSError, ValueError):
+            # Every signature, claim, parse, and JWKS transport failure is the
+            # same invalid credential to the caller. In particular, never log
+            # the token or its untrusted claims here.
+            return None
+
+        subject = claims.get("sub")
+        client_id = claims.get("client_id") or claims.get("azp")
+        scopes = self._scope_set(claims)
+        if (
+            not isinstance(subject, str)
+            or not subject
+            or not isinstance(client_id, str)
+            or not client_id
+            or not self.required_scopes.issubset(scopes)
+        ):
+            return None
+        return AccessToken(
+            token=token,
+            client_id=client_id,
+            scopes=sorted(scopes),
+            expires_at=claims["exp"],
+            resource=self.audience,
+            subject=subject,
+            claims={"iss": self.issuer},
+        )
+
+    async def verify_token(self, token):
+        return await anyio.to_thread.run_sync(self._verify, token)
 
 
 def _merged(defaults: dict, host: dict) -> dict:
@@ -459,3 +570,152 @@ def serve(client, doc=None, host_image_content=False) -> None:
     build_server(
         client, doc=doc, host_image_content=host_image_content
     ).run(transport="stdio")
+
+
+def build_http_server(
+    client,
+    *,
+    public_url,
+    issuer_url,
+    jwks_url,
+    audience,
+    scopes,
+    doc=None,
+    token_verifier=None,
+) -> MCPServer:
+    """Build the authenticated, path-independent remote MCP profile."""
+    if doc is None:
+        doc = userconfig.load_config()
+    verifier = token_verifier or JWKSJWTVerifier(
+        jwks_url=jwks_url,
+        issuer=issuer_url,
+        audience=audience,
+        required_scopes=scopes,
+    )
+    server = MCPServer(
+        "venice",
+        token_verifier=verifier,
+        auth=AuthSettings(
+            issuer_url=issuer_url,
+            resource_server_url=public_url,
+            required_scopes=list(scopes),
+        ),
+    )
+    chat_defaults = userconfig.config_defaults_for("chat", _mcp.chat_tool, doc)
+    vision_defaults = userconfig.config_defaults_for("vision", _mcp.vision_tool, doc)
+    remote_annotations = types.ToolAnnotations(
+        read_only_hint=False,
+        destructive_hint=False,
+        open_world_hint=True,
+    )
+
+    @server.tool(
+        name="venice_chat",
+        title="Venice chat completion",
+        annotations=remote_annotations,
+    )
+    def remote_chat(
+        message: str,
+        model: Optional[str] = None,
+        system: Optional[str] = None,
+        temperature: Optional[float] = None,
+        max_tokens: Optional[int] = None,
+        web_search: Optional[str] = None,
+        character: Optional[str] = None,
+    ) -> dict:
+        """Run one Venice chat completion. This consumes API credits and has no
+        pre-call spend quote. Omitted values use defaults.chat.*, then built-ins."""
+        return _mcp.chat_tool(
+            client,
+            message,
+            **_merged(chat_defaults, dict(
+                model=model,
+                system=system,
+                temperature=temperature,
+                max_tokens=max_tokens,
+                web_search=web_search,
+                character=character,
+            )),
+        )
+
+    @server.tool(
+        name="venice_vision",
+        title="Venice remote image analysis",
+        annotations=remote_annotations,
+    )
+    def remote_vision(
+        image_url: str,
+        prompt: Optional[str] = None,
+        model: Optional[str] = None,
+        max_tokens: Optional[int] = None,
+    ) -> types.CallToolResult:
+        """Inspect one remote HTTP(S) or data image through a delegated Venice
+        vision model. Server-local paths and native host content are unavailable."""
+        if not _valid_remote_image_url(image_url):
+            return _vision_text_result({
+                "status": "error",
+                "message": (
+                    "vision: image_url must be an HTTP(S) URL without credentials "
+                    "or a bounded base64 image data URL"
+                ),
+            })
+        args = _merged(vision_defaults, dict(
+            image_url=image_url,
+            prompt=prompt,
+            model=model,
+            max_tokens=max_tokens,
+        ))
+        # A stored stdio preference must not promote a remote call to native
+        # content. The remote schema has no mode or local path authority.
+        args.pop("mode", None)
+        return _vision_text_result(_mcp.vision_tool(
+            client,
+            input_path=None,
+            mode="delegate",
+            **args,
+        ))
+
+    @server.custom_route("/healthz", methods=["GET"], include_in_schema=False)
+    async def healthz(_request: Request):
+        return JSONResponse({"status": "ok"})
+
+    return server
+
+
+def serve_http(
+    client,
+    *,
+    host,
+    port,
+    public_url,
+    issuer_url,
+    jwks_url,
+    audience,
+    scopes,
+    allowed_origins=(),
+    doc=None,
+) -> None:
+    """Run the authenticated remote profile over stateless Streamable HTTP."""
+    allowed_host = urllib.parse.urlsplit(public_url).netloc
+    security = TransportSecuritySettings(
+        enable_dns_rebinding_protection=True,
+        allowed_hosts=[allowed_host],
+        allowed_origins=list(allowed_origins),
+    )
+    build_http_server(
+        client,
+        doc=doc,
+        public_url=public_url,
+        issuer_url=issuer_url,
+        jwks_url=jwks_url,
+        audience=audience,
+        scopes=scopes,
+    ).run(
+        transport="streamable-http",
+        host=host,
+        port=port,
+        streamable_http_path="/mcp",
+        stateless_http=True,
+        json_response=True,
+        transport_security=security,
+    )

--- a/tests/test_mcp_http.py
+++ b/tests/test_mcp_http.py
@@ -1,0 +1,494 @@
+"""Authenticated Streamable HTTP coverage for issue #31."""
+import argparse
+import asyncio
+import importlib.util
+import io
+import json
+import sys
+import time
+import unittest
+from types import SimpleNamespace
+from unittest import mock
+
+from venice.commands import mcp_serve
+
+
+try:
+    _HAS_MCP2 = importlib.util.find_spec("mcp.server.mcpserver") is not None
+except ModuleNotFoundError:
+    _HAS_MCP2 = False
+
+
+def _args(**overrides):
+    values = dict(
+        http=True,
+        host="127.0.0.1",
+        port=8000,
+        host_image_content=False,
+        public_url="https://mcp.example.test/mcp",
+        oauth_issuer="https://auth.example.test",
+        oauth_jwks_url="https://auth.example.test/.well-known/jwks.json",
+        oauth_audience="https://mcp.example.test",
+        oauth_scope=["venice:mcp"],
+        allowed_origin=None,
+    )
+    values.update(overrides)
+    return argparse.Namespace(**values)
+
+
+class TestRemoteConfig(unittest.TestCase):
+    def test_parser_registers_http_surface_and_bounds_port(self):
+        from venice import cli
+
+        args = cli.build_parser().parse_args([
+            "mcp-serve", "--http", "--port", "8443",
+            "--public-url", "https://mcp.example.test/mcp",
+            "--oauth-issuer", "https://auth.example.test",
+            "--oauth-jwks-url", "https://auth.example.test/jwks",
+            "--oauth-audience", "venice-api",
+            "--oauth-scope", "venice:mcp",
+            "--oauth-scope", "profile",
+        ])
+        self.assertTrue(args.http)
+        self.assertEqual(args.port, 8443)
+        self.assertEqual(args.oauth_scope, ["venice:mcp", "profile"])
+        with self.assertRaises(SystemExit):
+            cli.build_parser().parse_args(["mcp-serve", "--port", "0"])
+
+    def test_cli_values_override_environment(self):
+        cfg = mcp_serve.resolve_remote_config(
+            _args(allowed_origin=["https://claude.example"]),
+            {
+                "VENICE_MCP_PUBLIC_URL": "https://wrong.example/mcp",
+                "VENICE_MCP_OAUTH_SCOPES": "wrong",
+                "VENICE_MCP_ALLOWED_ORIGINS": "https://wrong.example",
+            },
+        )
+        self.assertEqual(cfg.public_url, "https://mcp.example.test/mcp")
+        self.assertEqual(cfg.scopes, ("venice:mcp",))
+        self.assertEqual(cfg.allowed_origins, ("https://claude.example",))
+
+    def test_environment_fallback_is_complete_and_deduplicated(self):
+        cfg = mcp_serve.resolve_remote_config(
+            _args(
+                public_url=None,
+                oauth_issuer=None,
+                oauth_jwks_url=None,
+                oauth_audience=None,
+                oauth_scope=None,
+            ),
+            {
+                "VENICE_MCP_PUBLIC_URL": "https://mcp.example.test/mcp",
+                "VENICE_MCP_OAUTH_ISSUER": "https://auth.example.test",
+                "VENICE_MCP_OAUTH_JWKS_URL": "https://auth.example.test/jwks",
+                "VENICE_MCP_OAUTH_AUDIENCE": "venice-api",
+                "VENICE_MCP_OAUTH_SCOPES": "venice:mcp profile venice:mcp",
+                "VENICE_MCP_ALLOWED_ORIGINS": (
+                    "https://one.example https://two.example"
+                ),
+            },
+        )
+        self.assertEqual(cfg.scopes, ("venice:mcp", "profile"))
+        self.assertEqual(
+            cfg.allowed_origins,
+            ("https://one.example", "https://two.example"),
+        )
+
+    def test_remote_config_rejects_missing_or_unsafe_values(self):
+        cases = (
+            _args(public_url=None),
+            _args(oauth_scope=[]),
+            _args(oauth_scope=["not a scope"]),
+            _args(public_url="http://mcp.example.test/mcp"),
+            _args(public_url="https://mcp.example.test/other"),
+            _args(oauth_issuer="https://user:pass@auth.example.test"),
+            _args(oauth_jwks_url="https://auth.example.test/jwks?key=1"),
+            _args(allowed_origin=["https://browser.example/path"]),
+        )
+        for args in cases:
+            with self.subTest(args=args):
+                with self.assertRaises(mcp_serve.RemoteConfigError):
+                    mcp_serve.resolve_remote_config(args, {})
+
+    def test_http_native_content_combination_fails_before_auth(self):
+        with mock.patch.object(mcp_serve._mcp, "import_mcp", return_value=object()), \
+             mock.patch.object(mcp_serve._openai, "import_openai", return_value=object()), \
+             mock.patch.object(mcp_serve, "build_client_from_auth") as build, \
+             mock.patch.object(sys, "stderr", io.StringIO()):
+            rc = mcp_serve._run(_args(host_image_content=True))
+        self.assertEqual(rc, 2)
+        build.assert_not_called()
+
+    def test_http_flags_without_http_are_rejected(self):
+        args = _args(http=False, public_url=None, oauth_issuer=None,
+                     oauth_jwks_url=None, oauth_audience=None, oauth_scope=None,
+                     host="0.0.0.0")
+        with mock.patch.object(mcp_serve._mcp, "import_mcp", return_value=object()), \
+             mock.patch.object(mcp_serve, "build_client_from_auth") as build, \
+             mock.patch.object(sys, "stderr", io.StringIO()):
+            rc = mcp_serve._run(args)
+        self.assertEqual(rc, 2)
+        build.assert_not_called()
+
+    @unittest.skipUnless(_HAS_MCP2, "MCP SDK 2.x is required")
+    def test_http_run_forwards_only_validated_remote_settings(self):
+        from venice import mcp_server
+
+        client = object()
+        doc = {"defaults": {}}
+        with mock.patch.object(mcp_serve._mcp, "import_mcp", return_value=object()), \
+             mock.patch.object(mcp_serve._openai, "import_openai", return_value=object()), \
+             mock.patch.object(
+                 mcp_serve, "build_client_from_auth", return_value=client
+             ), \
+             mock.patch.object(
+                 mcp_serve.userconfig, "load_config", return_value=doc
+             ), \
+             mock.patch.object(mcp_server, "serve_http") as serve_http, \
+             mock.patch.object(sys, "stderr", io.StringIO()):
+            rc = mcp_serve._run(_args(host="0.0.0.0", port=8080))
+        self.assertEqual(rc, 0)
+        serve_http.assert_called_once_with(
+            client,
+            doc=doc,
+            host="0.0.0.0",
+            port=8080,
+            public_url="https://mcp.example.test/mcp",
+            issuer_url="https://auth.example.test",
+            jwks_url="https://auth.example.test/.well-known/jwks.json",
+            audience="https://mcp.example.test",
+            scopes=("venice:mcp",),
+            allowed_origins=(),
+        )
+
+
+@unittest.skipUnless(_HAS_MCP2, "MCP SDK 2.x is required")
+class TestJWTVerifier(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        from cryptography.hazmat.primitives.asymmetric import rsa
+
+        cls.private_key = rsa.generate_private_key(
+            public_exponent=65537,
+            key_size=2048,
+        )
+        cls.public_key = cls.private_key.public_key()
+
+    def _verifier(self):
+        from venice.mcp_server import JWKSJWTVerifier
+
+        verifier = JWKSJWTVerifier(
+            jwks_url="https://auth.example.test/jwks",
+            issuer="https://auth.example.test",
+            audience="venice-api",
+            required_scopes=["venice:mcp"],
+        )
+        verifier._jwks.get_signing_key_from_jwt = mock.Mock(
+            return_value=SimpleNamespace(key=self.public_key)
+        )
+        return verifier
+
+    def _token(self, **overrides):
+        import jwt
+
+        claims = {
+            "iss": "https://auth.example.test",
+            "aud": "venice-api",
+            "sub": "user-1",
+            "client_id": "claude-client",
+            "scope": "openid venice:mcp",
+            "exp": int(time.time()) + 300,
+        }
+        claims.update(overrides)
+        return jwt.encode(
+            claims,
+            self.private_key,
+            algorithm="RS256",
+            headers={"kid": "key-1"},
+        )
+
+    def test_valid_token_maps_only_bounded_identity_claims(self):
+        verifier = self._verifier()
+        access = asyncio.run(verifier.verify_token(self._token(secret="do-not-copy")))
+        self.assertEqual(access.client_id, "claude-client")
+        self.assertEqual(access.subject, "user-1")
+        self.assertEqual(access.resource, "venice-api")
+        self.assertEqual(access.claims, {"iss": "https://auth.example.test"})
+        self.assertEqual(access.scopes, ["openid", "venice:mcp"])
+
+    def test_azp_and_list_scp_are_supported(self):
+        verifier = self._verifier()
+        token = self._token(client_id=None, azp="claude", scope=None, scp=["venice:mcp"])
+        access = asyncio.run(verifier.verify_token(token))
+        self.assertEqual(access.client_id, "claude")
+
+    def test_bad_claims_and_jwks_fail_closed(self):
+        now = int(time.time())
+        cases = (
+            self._token(iss="https://other.example"),
+            self._token(aud="other-api"),
+            self._token(scope="openid"),
+            self._token(exp=now - 120),
+            self._token(sub=""),
+            self._token(client_id=None),
+        )
+        for token in cases:
+            with self.subTest(token_length=len(token)):
+                self.assertIsNone(asyncio.run(self._verifier().verify_token(token)))
+
+        verifier = self._verifier()
+        verifier._jwks.get_signing_key_from_jwt.side_effect = OSError("offline")
+        marker = self._token()
+        with mock.patch.object(sys, "stdout", io.StringIO()) as out, \
+             mock.patch.object(sys, "stderr", io.StringIO()) as err:
+            self.assertIsNone(asyncio.run(verifier.verify_token(marker)))
+        self.assertNotIn(marker, out.getvalue() + err.getvalue())
+
+    def test_symmetric_missing_key_and_oversized_tokens_are_rejected_pre_jwks(self):
+        import jwt
+
+        verifier = self._verifier()
+        symmetric = jwt.encode(
+            {"exp": int(time.time()) + 300},
+            "test-secret-that-is-at-least-32-bytes-long",
+            algorithm="HS256",
+            headers={"kid": "key-1"},
+        )
+        no_kid = jwt.encode(
+            {"exp": int(time.time()) + 300},
+            self.private_key,
+            algorithm="RS256",
+        )
+        for token in (symmetric, no_kid, "x" * (16 * 1024 + 1)):
+            self.assertIsNone(asyncio.run(verifier.verify_token(token)))
+        verifier._jwks.get_signing_key_from_jwt.assert_not_called()
+
+
+@unittest.skipUnless(_HAS_MCP2, "MCP SDK 2.x is required")
+class TestHTTPServer(unittest.TestCase):
+    class FakeClient:
+        api_key = "fake"
+        base_url = "https://api.venice.ai/api/v1"
+
+    class StaticVerifier:
+        async def verify_token(self, token):
+            from mcp.server.auth.provider import AccessToken
+
+            if token != "good-token":
+                return None
+            return AccessToken(
+                token=token,
+                client_id="claude-client",
+                scopes=["venice:mcp"],
+                subject="user-1",
+            )
+
+    def _server(self):
+        from venice.mcp_server import build_http_server
+
+        return build_http_server(
+            self.FakeClient(),
+            doc={},
+            public_url="https://mcp.example.test/mcp",
+            issuer_url="https://auth.example.test",
+            jwks_url="https://auth.example.test/jwks",
+            audience="venice-api",
+            scopes=["venice:mcp"],
+            token_verifier=self.StaticVerifier(),
+        )
+
+    @staticmethod
+    def _app(server):
+        from mcp.server.transport_security import TransportSecuritySettings
+
+        return server.streamable_http_app(
+            stateless_http=True,
+            json_response=True,
+            host="mcp.example.test",
+            transport_security=TransportSecuritySettings(
+                enable_dns_rebinding_protection=True,
+                allowed_hosts=["mcp.example.test"],
+                allowed_origins=["https://allowed.example"],
+            ),
+        )
+
+    def test_remote_profile_exposes_only_path_independent_tools(self):
+        server = self._server()
+        tools = {tool.name: tool for tool in server._tool_manager.list_tools()}
+        self.assertEqual(set(tools), {"venice_chat", "venice_vision"})
+        vision = tools["venice_vision"].parameters
+        self.assertEqual(
+            set(vision["properties"]),
+            {"image_url", "prompt", "model", "max_tokens"},
+        )
+        self.assertEqual(vision["required"], ["image_url"])
+        for tool in tools.values():
+            self.assertIs(tool.annotations.read_only_hint, False)
+            self.assertIs(tool.annotations.destructive_hint, False)
+            self.assertIs(tool.annotations.open_world_hint, True)
+
+    def test_remote_vision_forces_delegation_even_with_native_config(self):
+        from venice.commands import _mcp
+        from venice.mcp_server import build_http_server
+
+        server = build_http_server(
+            self.FakeClient(),
+            doc={"defaults": {"vision": {"mode": "native"}}},
+            public_url="https://mcp.example.test/mcp",
+            issuer_url="https://auth.example.test",
+            jwks_url="https://auth.example.test/jwks",
+            audience="venice-api",
+            scopes=["venice:mcp"],
+            token_verifier=self.StaticVerifier(),
+        )
+        delegated = {"status": "ok", "content": "seen"}
+        with mock.patch.object(_mcp, "vision_tool", return_value=delegated) as impl:
+            result = server._tool_manager.get_tool("venice_vision").fn(
+                image_url="https://images.example/frame.png"
+            )
+        self.assertEqual(json.loads(result.content[0].text), delegated)
+        self.assertIsNone(impl.call_args.kwargs["input_path"])
+        self.assertEqual(impl.call_args.kwargs["mode"], "delegate")
+
+    def test_remote_vision_rejects_local_or_credentialed_urls(self):
+        from venice.commands import _mcp
+
+        tool = self._server()._tool_manager.get_tool("venice_vision").fn
+        with mock.patch.object(_mcp, "vision_tool") as impl:
+            results = [
+                tool(image_url="frame.png"),
+                tool(image_url="file:///etc/passwd"),
+                tool(image_url="https://user:pass@images.example/frame.png"),
+                tool(image_url="data:text/plain;base64,SGVsbG8="),
+            ]
+        self.assertTrue(all(result.is_error for result in results))
+        impl.assert_not_called()
+
+    def test_metadata_health_and_auth_failures(self):
+        import httpx2
+
+        server = self._server()
+        app = self._app(server)
+
+        async def exercise():
+            transport = httpx2.ASGITransport(app=app)
+            async with server.session_manager.run():
+                async with httpx2.AsyncClient(
+                    transport=transport,
+                    base_url="https://mcp.example.test",
+                ) as client:
+                    health = await client.get("/healthz")
+                    metadata = await client.get(
+                        "/.well-known/oauth-protected-resource/mcp"
+                    )
+                    missing = await client.post("/mcp", json={})
+                    invalid = await client.post(
+                        "/mcp",
+                        json={},
+                        headers={"Authorization": "Bearer bad-token"},
+                    )
+                    wrong_host = await client.post(
+                        "/mcp",
+                        json={},
+                        headers={
+                            "Authorization": "Bearer good-token",
+                            "Host": "wrong.example",
+                        },
+                    )
+                    wrong_origin = await client.post(
+                        "/mcp",
+                        json={},
+                        headers={
+                            "Authorization": "Bearer good-token",
+                            "Origin": "https://denied.example",
+                        },
+                    )
+                    return health, metadata, missing, invalid, wrong_host, wrong_origin
+
+        health, metadata, missing, invalid, wrong_host, wrong_origin = asyncio.run(
+            exercise()
+        )
+        self.assertEqual(health.json(), {"status": "ok"})
+        self.assertEqual(metadata.status_code, 200)
+        self.assertEqual(metadata.json()["resource"], "https://mcp.example.test/mcp")
+        self.assertEqual(missing.status_code, 401)
+        self.assertEqual(invalid.status_code, 401)
+        self.assertEqual(missing.json(), invalid.json())
+        self.assertIn("resource_metadata=", missing.headers["www-authenticate"])
+        self.assertEqual(wrong_host.status_code, 421)
+        self.assertEqual(wrong_origin.status_code, 403)
+
+    def test_authenticated_client_lists_and_calls_chat(self):
+        import httpx2
+        from mcp import Client
+        from mcp.client.streamable_http import streamable_http_client
+        from venice.commands import _mcp
+
+        server = self._server()
+        app = self._app(server)
+
+        async def exercise():
+            url = "https://mcp.example.test/mcp"
+            transport = httpx2.ASGITransport(app=app)
+            headers = {"Authorization": "Bearer good-token"}
+            async with server.session_manager.run():
+                async with (
+                    httpx2.AsyncClient(
+                        transport=transport,
+                        base_url=url,
+                        headers=headers,
+                    ) as http_client,
+                    Client(streamable_http_client(url, http_client=http_client)) as client,
+                ):
+                    listed = await client.list_tools()
+                    result = await client.call_tool(
+                        "venice_chat", {"message": "ping"}
+                    )
+                    return {tool.name for tool in listed.tools}, result
+
+        with mock.patch.object(
+            _mcp,
+            "chat_tool",
+            return_value={"status": "ok", "content": "pong"},
+        ) as impl:
+            names, result = asyncio.run(exercise())
+        self.assertEqual(names, {"venice_chat", "venice_vision"})
+        self.assertEqual(
+            json.loads(result.content[0].text),
+            {"status": "ok", "content": "pong"},
+        )
+        impl.assert_called_once()
+
+    def test_serve_http_pins_transport_settings(self):
+        from venice import mcp_server
+
+        built = mock.Mock()
+        with mock.patch.object(
+            mcp_server, "build_http_server", return_value=built
+        ) as build:
+            mcp_server.serve_http(
+                self.FakeClient(),
+                doc={},
+                host="0.0.0.0",
+                port=8080,
+                public_url="https://mcp.example.test/mcp",
+                issuer_url="https://auth.example.test",
+                jwks_url="https://auth.example.test/jwks",
+                audience="venice-api",
+                scopes=["venice:mcp"],
+                allowed_origins=["https://allowed.example"],
+            )
+        build.assert_called_once()
+        kwargs = built.run.call_args.kwargs
+        self.assertEqual(kwargs["transport"], "streamable-http")
+        self.assertTrue(kwargs["stateless_http"])
+        self.assertTrue(kwargs["json_response"])
+        self.assertEqual(kwargs["streamable_http_path"], "/mcp")
+        self.assertEqual(
+            kwargs["transport_security"].allowed_hosts,
+            ["mcp.example.test"],
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_shared_openai.py
+++ b/tests/test_shared_openai.py
@@ -283,7 +283,7 @@ class TestImportOpenAI(unittest.TestCase):
         self.assertEqual(readme.count(start_marker), 1)
         self.assertEqual(readme.count(end_marker), 1)
         inventory = readme.split(start_marker, 1)[1].split(end_marker, 1)[0]
-        documented = set(re.findall(r"^- `([a-z_]+)`:", inventory, re.MULTILINE))
+        documented = set(re.findall(r"^- `([^`]+)`:", inventory, re.MULTILINE))
         self.assertEqual(documented, labels)
 
         # These wrappers delegate to one of the labelled boundaries rather


### PR DESCRIPTION
## Summary

- add a fail-closed OAuth/JWT-authenticated Streamable HTTP mode at `/mcp`
- expose only remote-safe `venice_chat` and delegated URL-based `venice_vision` tools while preserving the existing ten-tool stdio profile
- add a non-root container, hardened Kubernetes example, container CI smoke, and release-time multi-arch GHCR publishing
- document external identity-provider setup, Host/Origin enforcement, deployment, and the intentionally deferred media boundary

Remote media resources and input delivery are tracked separately in #227.

## Validation

- `VENICE_API_KEY=test-fake-key make test` — 1,924 passed, 1 skipped
- `VENICE_API_KEY=test-fake-key make drive` — 46 passed
- `make lint`
- `make scan`
- `python -m build`
- `twine check --strict dist/*`
- dependency-free wheel smoke in an isolated venv
- non-root, read-only local container health smoke with fake credentials
- YAML parse for both workflows and the Kubernetes manifest

Closes #31
