### PR TITLE
Preserve evidence across context compaction

### DIFF
--- a/README.md
+++ b/README.md
@@ -638,6 +638,8 @@ catalog), `/models` (list the available models, marking the current and the
 default), `/auto` and `/manual` (toggle auto-accepting paid/side-effecting tool
 calls for following turns), `/compact [N]` (summarize older history into one
 message, keeping the last `N` turns verbatim),
+`/context list [CURSOR]` (list archived evidence metadata) and
+`/context read ID [OFFSET]` (read up to 32 KiB of an exact archived message),
 `/cost` (this session's estimated spend so far, with the active model's
 current-run cache hit rate on the same line; `--session-max-spend` adds a
 cap), `/usage` (a token + cost breakdown for the session, keeping the
@@ -676,9 +678,19 @@ older prefix into one synthetic message once the prompt crosses
 the last `--compact-keep-turns` turns (default 10) verbatim. The trigger uses
 the server-reported `usage.prompt_tokens` when a turn provides it (falling
 back to a chars-per-token estimate otherwise), so it fires on the real prompt
-size rather than a guess. Compaction is best-effort — a failed summarization
-call leaves the history untouched — and never orphans a tool result from its
-assistant turn. It's off by default because it costs a summarization call.
+size rather than a guess. `--compact-loss-policy aggressive|evidence` controls
+what happens to the summarized prefix. Chat defaults to `aggressive`, preserving
+the original behavior. Code defaults to `evidence`: every removed user message,
+assistant tool call (including arguments), and tool result is copied exactly into
+the private session envelope before the live history is replaced. The model gets
+a bounded index plus the read-only `venice_context_archive` tool; operators can use
+the `/context` commands above even in a plain REPL. The archive is capped at 512
+entries and 8 MiB. If the next compaction would cross either cap, it is refused
+before the summary API call and both history and archive remain unchanged. Reads
+are paged at 32 KiB and list pages at 50 entries. Compaction is otherwise
+best-effort — a failed or empty summarization leaves both stores untouched — and
+never orphans a tool result from its assistant turn. It's off by default because
+it costs a summarization call.
 
 #### Sessions
 
@@ -687,7 +699,11 @@ each turn to `~/.config/venice/sessions/<id>.json` (mode 0600;
 `$VENICE_SESSIONS_DIR` overrides the location). Unlike a bare `/save` transcript,
 a session travels with its **settings** — model, system prompt, generation
 parameters, `max-tool-calls`, the `venice code` sandbox root, and the running
-token/cost usage — so resuming restores the whole context, not just the messages.
+token/cost usage — plus any bounded exact context archive — so resuming restores
+the whole context, not just the messages. Session envelope v2 adds
+`context_archive` plus the structural count of authoritative leading system
+messages; v1 envelopes remain readable, conservatively preserve their complete
+leading system prefix, and resume with an empty archive.
 The API key is never written to a session.
 
 `venice code` also assigns each session an opaque `prompt_cache_key`, sent as an
@@ -1557,6 +1573,7 @@ jq '.usage.billed_total' ~/.config/venice/sessions/<id>.json
 | `venice_scout` | delegate a read-only investigation to a disposable subagent with a fresh context; returns a structured report so exploration doesn't pollute the main context — **opt-in with `--scout`** (see [Scout subagent](#scout-subagent---scout)) | no |
 | `venice_web_search` | search the web to **discover** documentation you don't have a URL for; returns a short answer + cited URLs (billed, but bounded by the tool-call budget) — **opt-in with `--web-search`** (see [Web search](#web-search---web-search)) | no |
 | `venice_review` | hand the current diff to a **cold-context reviewer** — a disposable subagent with a fresh context, read-only tools and (where the catalog allows) a different model — and get back defects with `file:line` + a repro. Findings only: it approves and certifies nothing — **opt-in with `--review`** (see [Reviewer rail](#reviewer-rail---review)) | no |
+| `venice_context_archive` | list bounded metadata or page through exact messages removed by evidence-preserving compaction; current session only, with no filesystem, network, or process access | no |
 
 **Safety.** Every filesystem path is resolved and confined to the **writable roots** —
 the startup root (default: cwd, or `--root` / `$VENICE_CODE_ROOT`) plus any added with
@@ -1618,6 +1635,7 @@ external diff helpers. Use the confirmed `run` tool for other Git forms.
 | `--review-model MODEL` | model for `--review` (default: a function-calling model from a **different family** than the coding model; falls back to the coding model with a warning); config `defaults.code.review_model` |
 | `--review-rounds N` | passes `venice_review` makes over the same diff (default **1**, max 3); config `defaults.code.review_rounds` |
 | `--auto-compact` | summarize older history once the prompt crosses `--compact-threshold` tokens (default 100 000), keeping the last `--compact-keep-turns` turns (default 10); long runs stay in-context |
+| `--compact-loss-policy aggressive\|evidence` | discard summarized messages or retain their exact JSON in the bounded private session archive; default **evidence** for code and **aggressive** for chat; config `defaults.code.compact_loss_policy` / `defaults.chat.compact_loss_policy` |
 | `--cache-guard off\|warn\|stop` | react when a cache-priced model explicitly reports zero cached tokens after the cold first API call and a 2,000-token prompt; default **warn**, config `defaults.code.cache_guard` |
 | `-i`, `--json`, `--model`, `--system` | interactive REPL · JSON envelope · model · extra system instructions |
 | `--persona NAME` | load `~/.config/venice/personas/NAME.md` as the system prompt at launch (`/persona` in the REPL) |
@@ -1636,7 +1654,8 @@ model and a sane `--max-tool-calls` when running unattended.
 
 Per-flag config defaults live under `defaults.code.*` (e.g. `model`, `root`, `auto`,
 `assets`, `scout`, `spawn`, `spawn_max_spend`, `subagent_max_tokens`, `planner`,
-`max_tool_calls`, `review`, `review_model`, `review_rounds`, `cache_guard`).
+`max_tool_calls`, `review`, `review_model`, `review_rounds`, `cache_guard`,
+`compact_loss_policy`).
 
 #### Scout subagent (`--scout`)
 

--- a/src/venice/commands/_agent.py
+++ b/src/venice/commands/_agent.py
@@ -3779,6 +3779,8 @@ def run_loop(
     oai_tools = to_openai_tools(tools)
     dispatch = dispatch_map(tools)
     runtime = _ToolRuntime(model=model, models=models)
+    if budget is not None and budget.protected_system_messages is None:
+        budget.protected_system_messages = _compact.leading_system_count(messages)
     calls_made = 0
     gate = {"auto": bool(yes)}  # mutable so an `a`/`all` confirm flips the run to auto
     # #82: the per-tool timing sink, bound ONCE so both dispatch paths -- and every pool
@@ -3859,6 +3861,9 @@ def run_loop(
             oai, model, messages, budget, base_kwargs,
             on_compact=lambda b, a: _progress(
                 f"(auto-compacted history: {b} -> {a} messages)", enabled=show,
+            ),
+            on_blocked=lambda reason: print(
+                f"auto-compaction refused: {reason}", file=sys.stderr,
             ),
             ledger=ledger,  # #99: log the event; #101: and bill the summary call
         )
@@ -3959,6 +3964,9 @@ def run_loop(
                 oai, model, messages, budget, base_kwargs,
                 on_compact=lambda b, a: _progress(
                     f"(auto-compacted history: {b} -> {a} messages)", enabled=show,
+                ),
+                on_blocked=lambda reason: print(
+                    f"auto-compaction refused: {reason}", file=sys.stderr,
                 ),
                 ledger=ledger,  # #99
             )

--- a/src/venice/commands/_compact.py
+++ b/src/venice/commands/_compact.py
@@ -50,7 +50,7 @@ import time
 from dataclasses import dataclass
 from typing import List, Optional, Tuple
 
-from . import _openai
+from . import _context_archive, _openai
 
 # Rough chars-per-token for English/code text. Deliberately conservative
 # (overestimate tokens) so the fallback triggers compaction a little early
@@ -64,6 +64,7 @@ SUMMARY_MAX_TOKENS = 1024
 
 DEFAULT_THRESHOLD_TOKENS = 100_000
 DEFAULT_KEEP_TURNS = 10
+LOSS_POLICY_CHOICES = ("aggressive", "evidence")
 
 _SUMMARY_PREFIX = "[Summary of earlier conversation]"
 _INSTRUCT = (
@@ -124,6 +125,9 @@ class Budget:
     threshold_tokens: int = DEFAULT_THRESHOLD_TOKENS
     keep_turns: int = DEFAULT_KEEP_TURNS
     last_prompt_tokens: Optional[int] = None
+    loss_policy: str = "aggressive"
+    archive: Optional[_context_archive.ContextArchive] = None
+    protected_system_messages: Optional[int] = None
 
     def observe(self, usage) -> None:
         """Record prompt tokens from a response's `usage` (dict or SDK obj)."""
@@ -150,7 +154,7 @@ class Budget:
         return estimate_tokens(messages) >= self.threshold_tokens
 
 
-def budget_from_args(args) -> Optional["Budget"]:
+def budget_from_args(args, archive=None) -> Optional["Budget"]:
     """The auto-compact Budget for a parsed-args namespace, or None when it
     isn't opted into (#48).
 
@@ -168,6 +172,8 @@ def budget_from_args(args) -> Optional["Budget"]:
         keep_turns=(
             getattr(args, "compact_keep_turns", None) or DEFAULT_KEEP_TURNS
         ),
+        loss_policy=getattr(args, "compact_loss_policy", None) or "aggressive",
+        archive=archive,
     )
 
 
@@ -212,8 +218,16 @@ def _groups(messages: List[dict]) -> List[List[dict]]:
     return groups
 
 
+def leading_system_count(messages: List[dict]) -> int:
+    """Count the contiguous authoritative/generated system prefix."""
+    count = 0
+    while count < len(messages) and messages[count].get("role") == "system":
+        count += 1
+    return count
+
+
 def split_for_compaction(
-    messages: List[dict], keep_turns: int
+    messages: List[dict], keep_turns: int, protected_system_messages: Optional[int] = None
 ) -> Optional[Tuple[List[dict], List[dict]]]:
     """Split history into (prefix to summarize, tail to keep verbatim).
 
@@ -224,14 +238,21 @@ def split_for_compaction(
     """
     if keep_turns < 1:
         keep_turns = 1
-    sys_end = 0
-    while sys_end < len(messages) and messages[sys_end].get("role") == "system":
-        sys_end += 1
-    tail_groups = _groups(messages[sys_end:])
+    leading_systems = leading_system_count(messages)
+    # None is the conservative compatibility path: every leading system
+    # message is authoritative. Session-aware callers persist the exact count,
+    # which lets later generated summary/index messages be replaced without
+    # classifying authority from forgeable content text.
+    if protected_system_messages is None:
+        sys_end = leading_systems
+    else:
+        sys_end = min(max(0, protected_system_messages), leading_systems)
+    generated_end = leading_systems
+    tail_groups = _groups(messages[generated_end:])
     if len(tail_groups) <= keep_turns:
         return None
     cut = len(tail_groups) - keep_turns
-    prefix: List[dict] = []
+    prefix: List[dict] = list(messages[sys_end:generated_end])
     for g in tail_groups[:cut]:
         prefix.extend(g)
     tail: List[dict] = []
@@ -283,6 +304,9 @@ def compact_messages(
     ledger=None,
     budget: Optional[Budget] = None,
     trigger: str = "auto",
+    loss_policy: str = "aggressive",
+    archive: Optional[_context_archive.ContextArchive] = None,
+    protected_system_messages: Optional[int] = None,
 ) -> bool:
     """Summarize the older prefix in place; keep system + last `keep_turns`.
 
@@ -311,11 +335,27 @@ def compact_messages(
     history it now describes -- i.e. re-firing compaction immediately, a sawtooth #99's
     trace would show and nothing would prevent.
     """
-    split = split_for_compaction(messages, keep_turns)
+    split = split_for_compaction(
+        messages, keep_turns, protected_system_messages=protected_system_messages
+    )
     if split is None:
         return False
     prefix, tail = split
     sys_msgs = messages[: len(messages) - len(prefix) - len(tail)]
+
+    # Evidence mode refuses before spending a summarization call if the exact
+    # removed messages cannot fit. Staging is side-effect-free; commit happens
+    # only after a usable summary exists, alongside the live-history rewrite.
+    staged = []
+    if loss_policy == "evidence":
+        if archive is None:
+            return False
+        archive.last_error = None
+        try:
+            staged = archive.stage(prefix)
+        except _context_archive.ArchiveError as e:
+            archive.last_error = str(e)
+            return False
 
     # #128: compaction is a deliberately fresh summarization conversation. Reusing
     # the parent session's routing identity would mix unrelated prefixes on one cache
@@ -366,7 +406,11 @@ def compact_messages(
     # lie in the artifact that exists to stop one.
     est_before = estimate_tokens(messages)
     msgs_before = len(messages)
-    messages[:] = sys_msgs + [synthetic_message(summary)] + tail
+    replacement = sys_msgs + [synthetic_message(summary)]
+    if loss_policy == "evidence":
+        archive.commit(staged)
+        replacement.append(archive.live_index_message())
+    messages[:] = replacement + tail
     if ledger is not None:
         ledger.record_compaction({
             "trigger": trigger,
@@ -411,7 +455,7 @@ def compact_messages(
 
 def maybe_compact(oai, model: str, messages: List[dict],
                   budget: Optional[Budget], base_kwargs: Optional[dict] = None,
-                  on_compact=None, ledger=None) -> bool:
+                  on_compact=None, on_blocked=None, ledger=None) -> bool:
     """Compact `messages` in place when `budget` says they're over budget.
 
     The shared gate for every compaction site (`run_loop`'s per-turn check, its
@@ -433,7 +477,12 @@ def maybe_compact(oai, model: str, messages: List[dict],
         oai, model, messages,
         keep_turns=budget.keep_turns, base_kwargs=base_kwargs,
         ledger=ledger, budget=budget, trigger="auto",
+        loss_policy=budget.loss_policy, archive=budget.archive,
+        protected_system_messages=budget.protected_system_messages,
     ):
+        if (on_blocked is not None and budget.archive is not None
+                and budget.archive.last_error):
+            on_blocked(budget.archive.last_error)
         return False
     if on_compact is not None:
         on_compact(before, len(messages))

--- a/src/venice/commands/_context_archive.py
+++ b/src/venice/commands/_context_archive.py
@@ -1,0 +1,283 @@
+"""Bounded, lossless local archive for evidence-preserving compaction (#74)."""
+from __future__ import annotations
+
+import copy
+import hashlib
+import json
+from dataclasses import dataclass, field
+from typing import List, Optional
+
+
+MAX_ARCHIVE_BYTES = 8 * 1024 * 1024
+MAX_ARCHIVE_ENTRIES = 512
+MAX_LIST_ENTRIES = 50
+MAX_READ_BYTES = 32 * 1024
+LIVE_INDEX_ENTRIES = 32
+EXCERPT_CHARS = 160
+
+
+class ArchiveError(ValueError):
+    """An archive envelope is malformed or a capacity boundary was crossed."""
+
+
+def _canonical(message: dict) -> str:
+    try:
+        return json.dumps(
+            message, ensure_ascii=False, sort_keys=True, separators=(",", ":"),
+            allow_nan=False,
+        )
+    except (TypeError, ValueError) as e:
+        raise ArchiveError(f"archived message is not finite JSON: {e}") from None
+
+
+def _digest(text: str) -> str:
+    return hashlib.sha256(text.encode("utf-8")).hexdigest()
+
+
+def _excerpt(text: str, *, tail: bool = False) -> str:
+    value = text[-EXCERPT_CHARS:] if tail else text[:EXCERPT_CHARS]
+    return value.replace("\n", "\\n")
+
+
+def _metadata(entry: dict) -> dict:
+    result = {
+        "id": entry["id"],
+        "role": entry["role"],
+        "chars": entry["chars"],
+        "sha256": entry["sha256"],
+        "head": entry["head"],
+        "tail": entry["tail"],
+    }
+    if entry.get("name"):
+        result["name"] = entry["name"]
+    return result
+
+
+def _bounded_utf8_slice(text: str, offset: int) -> str:
+    """Return the longest char-aligned slice no larger than MAX_READ_BYTES."""
+    lo, hi = offset, len(text)
+    while lo < hi:
+        mid = (lo + hi + 1) // 2
+        if len(text[offset:mid].encode("utf-8")) <= MAX_READ_BYTES:
+            lo = mid
+        else:
+            hi = mid - 1
+    return text[offset:lo]
+
+
+@dataclass
+class ContextArchive:
+    """A bounded collection of exact, canonicalized archived messages."""
+
+    entries: List[dict] = field(default_factory=list)
+    last_error: Optional[str] = None
+
+    @classmethod
+    def from_envelope(cls, raw) -> "ContextArchive":
+        if raw is None:
+            return cls()
+        if not isinstance(raw, list):
+            raise ArchiveError("context_archive must be a JSON list")
+        if len(raw) > MAX_ARCHIVE_ENTRIES:
+            raise ArchiveError(
+                f"context_archive exceeds {MAX_ARCHIVE_ENTRIES} entries"
+            )
+        validated = []
+        seen = set()
+        for index, item in enumerate(raw, 1):
+            if not isinstance(item, dict) or not isinstance(item.get("message"), dict):
+                raise ArchiveError(f"context_archive entry {index} is malformed")
+            message = item["message"]
+            if not isinstance(message.get("role"), str):
+                raise ArchiveError(f"context_archive entry {index} has no role")
+            text = _canonical(message)
+            entry_id = item.get("id")
+            expected_id = f"ctx-{index:06d}"
+            if entry_id != expected_id:
+                raise ArchiveError(f"context_archive entry {index} has an invalid id")
+            if entry_id in seen:
+                raise ArchiveError(f"context_archive entry {index} repeats id {entry_id}")
+            seen.add(entry_id)
+            expected = cls._entry(entry_id, message, text)
+            for key in ("sha256", "chars", "role", "head", "tail"):
+                if item.get(key) != expected[key]:
+                    raise ArchiveError(
+                        f"context_archive entry {entry_id} has invalid {key}"
+                    )
+            if item.get("name") != expected.get("name"):
+                raise ArchiveError(
+                    f"context_archive entry {entry_id} has invalid name"
+                )
+            validated.append(expected)
+        total = len(_canonical(validated).encode("utf-8"))
+        if total > MAX_ARCHIVE_BYTES:
+            raise ArchiveError(f"context_archive exceeds {MAX_ARCHIVE_BYTES} bytes")
+        return cls(validated)
+
+    @staticmethod
+    def _entry(entry_id: str, message: dict, text: Optional[str] = None) -> dict:
+        text = _canonical(message) if text is None else text
+        entry = {
+            "id": entry_id,
+            "role": message["role"],
+            "chars": len(text),
+            "sha256": _digest(text),
+            "head": _excerpt(text),
+            "tail": _excerpt(text, tail=True),
+            "message": copy.deepcopy(message),
+        }
+        name = message.get("name")
+        if isinstance(name, str) and name:
+            entry["name"] = name
+        elif message.get("role") == "assistant":
+            calls = message.get("tool_calls")
+            if isinstance(calls, list):
+                names = []
+                for call in calls:
+                    fn = call.get("function") if isinstance(call, dict) else None
+                    if isinstance(fn, dict) and isinstance(fn.get("name"), str):
+                        names.append(fn["name"])
+                if names:
+                    entry["name"] = ",".join(names)
+        return entry
+
+    @property
+    def bytes_used(self) -> int:
+        return len(_canonical(self.entries).encode("utf-8"))
+
+    def stage(self, messages: List[dict]) -> List[dict]:
+        """Build entries and enforce both caps without changing the archive."""
+        staged = []
+        for message in messages:
+            if not isinstance(message, dict) or not isinstance(message.get("role"), str):
+                raise ArchiveError("message selected for archival is malformed")
+            text = _canonical(message)
+            entry_id = f"ctx-{len(self.entries) + len(staged) + 1:06d}"
+            staged.append(self._entry(entry_id, message, text))
+        count = len(self.entries) + len(staged)
+        if count > MAX_ARCHIVE_ENTRIES:
+            raise ArchiveError(
+                f"evidence archive full: compaction needs {count} entries "
+                f"(limit {MAX_ARCHIVE_ENTRIES})"
+            )
+        used = len(_canonical(self.entries + staged).encode("utf-8"))
+        if used > MAX_ARCHIVE_BYTES:
+            raise ArchiveError(
+                f"evidence archive full: compaction needs {used} bytes "
+                f"(limit {MAX_ARCHIVE_BYTES})"
+            )
+        return staged
+
+    def commit(self, staged: List[dict]) -> None:
+        self.entries.extend(staged)
+        self.last_error = None
+
+    def clear(self) -> None:
+        self.entries.clear()
+        self.last_error = None
+
+    def to_envelope(self) -> list:
+        return copy.deepcopy(self.entries)
+
+    def list_page(self, cursor: int = 0, limit: int = MAX_LIST_ENTRIES) -> dict:
+        if not isinstance(cursor, int) or isinstance(cursor, bool) or cursor < 0:
+            raise ArchiveError("cursor must be a non-negative integer")
+        if not isinstance(limit, int) or isinstance(limit, bool) or not 1 <= limit <= MAX_LIST_ENTRIES:
+            raise ArchiveError(f"limit must be between 1 and {MAX_LIST_ENTRIES}")
+        page = self.entries[cursor:cursor + limit]
+        end = cursor + len(page)
+        return {
+            "entries": [_metadata(e) for e in page],
+            "cursor": cursor,
+            "next_cursor": end if end < len(self.entries) else None,
+            "total": len(self.entries),
+            "bytes": self.bytes_used,
+        }
+
+    def read(self, entry_id: str, offset: int = 0) -> dict:
+        if not isinstance(entry_id, str):
+            raise ArchiveError("entry_id must be a string")
+        if not isinstance(offset, int) or isinstance(offset, bool) or offset < 0:
+            raise ArchiveError("offset must be a non-negative integer")
+        entry = next((e for e in self.entries if e["id"] == entry_id), None)
+        if entry is None:
+            raise ArchiveError(f"unknown archive entry {entry_id!r}")
+        text = _canonical(entry["message"])
+        if offset > len(text):
+            raise ArchiveError(f"offset {offset} exceeds entry length {len(text)}")
+        content = _bounded_utf8_slice(text, offset)
+        end = offset + len(content)
+        return {
+            "id": entry_id,
+            "sha256": entry["sha256"],
+            "offset": offset,
+            "content": content,
+            "next_offset": end if end < len(text) else None,
+            "complete": end >= len(text),
+            "chars": len(text),
+        }
+
+    def live_index_message(self) -> dict:
+        newest = self.entries[-LIVE_INDEX_ENTRIES:]
+        lines = [
+            "[Archived context evidence index]",
+            f"{len(self.entries)} exact message(s), {self.bytes_used} byte(s). "
+            "Use venice_context_archive to list metadata or read exact content.",
+        ]
+        older = len(self.entries) - len(newest)
+        if older:
+            lines.append(f"{older} older entry/entries are discoverable with list pagination.")
+        for entry in newest:
+            label = entry["role"]
+            if entry.get("name"):
+                label += f"/{entry['name']}"
+            lines.append(
+                f"{entry['id']} {label} {entry['chars']} chars "
+                f"sha256={entry['sha256']} head={entry['head']!r} tail={entry['tail']!r}"
+            )
+        return {"role": "system", "content": "\n".join(lines)}
+
+
+def archive_tool(archive: ContextArchive):
+    """Build the current-session, read-only archive lookup tool."""
+    from . import _agent
+
+    def invoke(args, *, confirm=False):
+        del confirm
+        try:
+            action = args.get("action")
+            if action == "list":
+                return {"status": "ok", **archive.list_page(
+                    args.get("cursor", 0), args.get("limit", MAX_LIST_ENTRIES)
+                )}
+            if action == "read":
+                return {"status": "ok", **archive.read(
+                    args.get("entry_id"), args.get("offset", 0)
+                )}
+            return {"status": "error", "message": "action must be list or read"}
+        except ArchiveError as e:
+            return {"status": "error", "message": str(e)}
+
+    return _agent.Tool(
+        name="venice_context_archive",
+        description=(
+            "Read evidence archived from earlier context compactions in this session. "
+            "List bounded metadata pages, then read exact canonical message JSON by id."
+        ),
+        parameters={
+            "type": "object",
+            "properties": {
+                "action": {"type": "string", "enum": ["list", "read"]},
+                "entry_id": {"type": "string"},
+                "cursor": {"type": "integer", "minimum": 0},
+                "offset": {"type": "integer", "minimum": 0},
+                "limit": {"type": "integer", "minimum": 1, "maximum": MAX_LIST_ENTRIES},
+            },
+            "required": ["action"],
+            "additionalProperties": False,
+        },
+        invoke=invoke,
+        paid=False,
+        category="context",
+        tags=("read",),
+    )

--- a/src/venice/commands/_repl.py
+++ b/src/venice/commands/_repl.py
@@ -36,7 +36,7 @@ from pathlib import Path
 from typing import List, Optional
 
 from .. import config
-from . import _agent, _compact, _models, _persona, _session, _steer
+from . import _agent, _compact, _context_archive, _models, _persona, _session, _steer
 
 
 _PROMPT = "you> "
@@ -51,6 +51,9 @@ Commands:
   /auto            auto-accept paid/side-effecting tool calls for following turns
   /manual          confirm each paid/side-effecting tool call (undo /auto)
   /compact [N]     summarize older history to shrink the context (keeps last N turns)
+  /context list    list archived evidence metadata (up to 50 entries)
+  /context read ID [OFFSET]
+                   read up to 32 KiB of exact archived message JSON
   /cost            this session's estimated spend so far + cache hit rate (--session-max-spend caps it)
   /usage           token + cost breakdown for this session (cache-read/write split)
   /reset           clear the conversation (keeps the system prompt)
@@ -66,6 +69,7 @@ Anything else is sent to the model as your next message."""
 # only meaningful inside a /paste block, so they stay out of top-level completion.)
 _COMMANDS = (
     "/system", "/persona", "/model", "/models", "/auto", "/manual", "/compact",
+    "/context",
     "/cost", "/usage", "/reset", "/save", "/paste", "/edit", "/help", "/exit",
     "/quit",
 )
@@ -120,12 +124,11 @@ def _seed_messages(args) -> List[dict]:
     return []
 
 
-def _reset_messages(messages: List[dict]) -> None:
-    """Clear history in place, keeping only a leading system message if present."""
-    keep = messages[0] if messages and messages[0].get("role") == "system" else None
+def _reset_messages(messages: List[dict], system: Optional[str] = None) -> None:
+    """Clear history in place, restoring only the authoritative system prompt."""
     messages.clear()
-    if keep is not None:
-        messages.append(keep)
+    if system is not None:
+        messages.append({"role": "system", "content": system})
 
 
 def _set_system(messages: List[dict], text: str) -> None:
@@ -139,6 +142,14 @@ def _current_system(messages: List[dict]) -> Optional[str]:
     if messages and messages[0].get("role") == "system":
         return messages[0].get("content")
     return None
+
+
+def _set_protected_system_messages(state: dict, count: int) -> None:
+    """Keep structural system authority synchronized with auto-compaction."""
+    state["protected_system_messages"] = count
+    budget = state.get("budget")
+    if budget is not None:
+        budget.protected_system_messages = count
 
 
 # --------------------------------------------------------------------------- #
@@ -388,6 +399,9 @@ def _turn(oai, openai, chat, text, messages, gen_kwargs, state, args) -> bool:
         on_compact=lambda b, a: print(
             f"(auto-compacted history: {b} -> {a} messages)", file=sys.stderr,
         ),
+        on_blocked=lambda reason: print(
+            f"(auto-compaction refused: {reason})", file=sys.stderr,
+        ),
         ledger=ledger,  # #99
     )
     # Mid-run steering: a tool-loop turn drains this session's mailbox at each
@@ -455,13 +469,19 @@ def _autosave(state, messages, gen_kwargs) -> None:
     if sess is None:
         return
     sess.model = state.get("model", sess.model)
-    sess.system = _current_system(messages)
+    sess.system = state.get("system")
     sess.gen_kwargs = gen_kwargs
     sess.max_tool_calls = state.get("max_tool_calls", sess.max_tool_calls)
     ledger = state.get("ledger")
     if ledger is not None:
         sess.usage = ledger.to_dict()
     sess.messages = messages
+    archive = state.get("archive")
+    if archive is not None:
+        sess.context_archive = archive.to_envelope()
+    sess.protected_system_messages = state.get(
+        "protected_system_messages", sess.protected_system_messages
+    )
     try:
         _session.save(sess)
     except OSError as e:
@@ -474,6 +494,12 @@ def _autosave(state, messages, gen_kwargs) -> None:
 def _dispatch_slash(line, messages, state, args, models, oai=None, gen_kwargs=None) -> str:
     """Handle a ``/command``. Returns ``"exit"`` to leave the REPL, else
     ``"continue"``. `oai`/`gen_kwargs` are needed only by `/compact` (#48)."""
+    # Direct callers predating #74 may not carry this explicit authority bit.
+    # Infer it once, before any compaction-generated system message can appear.
+    state.setdefault("system", _current_system(messages))
+    state.setdefault(
+        "protected_system_messages", 1 if state["system"] is not None else 0
+    )
     parts = line[1:].split(maxsplit=1)
     cmd = parts[0].lower() if parts else ""
     rest = parts[1].strip() if len(parts) > 1 else ""
@@ -483,14 +509,28 @@ def _dispatch_slash(line, messages, state, args, models, oai=None, gen_kwargs=No
     if cmd == "help":
         print(_HELP, file=sys.stderr)
     elif cmd == "reset":
-        _reset_messages(messages)
+        _reset_messages(messages, state.get("system"))
+        _set_protected_system_messages(
+            state, 1 if state.get("system") is not None else 0
+        )
+        archive = state.get("archive")
+        if archive is not None:
+            archive.clear()
         print("(conversation cleared)", file=sys.stderr)
     elif cmd == "system":
         if rest:
-            _set_system(messages, rest)
+            if state.get("system") is None:
+                messages.insert(0, {"role": "system", "content": rest})
+                state["protected_system_messages"] += 1
+            else:
+                _set_system(messages, rest)
+            state["system"] = rest
+            _set_protected_system_messages(
+                state, state["protected_system_messages"]
+            )
             print("(system prompt set)", file=sys.stderr)
         else:
-            print(f"system: {_current_system(messages) or '(none)'}", file=sys.stderr)
+            print(f"system: {state.get('system') or '(none)'}", file=sys.stderr)
     elif cmd == "persona":
         if rest:
             try:
@@ -498,7 +538,15 @@ def _dispatch_slash(line, messages, state, args, models, oai=None, gen_kwargs=No
             except _persona.PersonaError as e:
                 print(f"/persona: {e}", file=sys.stderr)
             else:
-                _set_system(messages, text)
+                if state.get("system") is None:
+                    messages.insert(0, {"role": "system", "content": text})
+                    state["protected_system_messages"] += 1
+                else:
+                    _set_system(messages, text)
+                state["system"] = text
+                _set_protected_system_messages(
+                    state, state["protected_system_messages"]
+                )
                 print(f"(persona {rest!r} loaded)", file=sys.stderr)
         else:
             # Create the drop-dir lazily so a first-time user has somewhere to
@@ -563,6 +611,8 @@ def _dispatch_slash(line, messages, state, args, models, oai=None, gen_kwargs=No
             # a cache cliff on the next call, so it is traced like the automatic one --
             # `trigger` is what lets the operator tell the two apart afterwards.
             ledger=state.get("ledger"), budget=state.get("budget"), trigger="manual",
+            loss_policy=state["loss_policy"], archive=state.get("archive"),
+            protected_system_messages=state["protected_system_messages"],
         ):
             # #116: no budget reset here any more -- `compact_messages` owns it, so this
             # site cannot forget it and cannot disagree with `maybe_compact` about when
@@ -573,7 +623,30 @@ def _dispatch_slash(line, messages, state, args, models, oai=None, gen_kwargs=No
                 file=sys.stderr,
             )
         else:
-            print("(nothing to compact)", file=sys.stderr)
+            archive = state.get("archive")
+            if archive is not None and archive.last_error:
+                print(f"(/compact refused: {archive.last_error})", file=sys.stderr)
+            else:
+                print("(nothing to compact)", file=sys.stderr)
+    elif cmd == "context":
+        archive = state.get("archive")
+        if archive is None:
+            print("(no evidence archive for this session)", file=sys.stderr)
+        else:
+            words = rest.split()
+            try:
+                if words and words[0] == "list" and len(words) <= 2:
+                    cursor = int(words[1]) if len(words) == 2 else 0
+                    print(json.dumps(archive.list_page(cursor), indent=2), file=sys.stderr)
+                elif words and words[0] == "read" and len(words) in (2, 3):
+                    offset = int(words[2]) if len(words) == 3 else 0
+                    print(json.dumps(archive.read(words[1], offset), indent=2),
+                          file=sys.stderr)
+                else:
+                    print("usage: /context list [CURSOR] | /context read ID [OFFSET]",
+                          file=sys.stderr)
+            except (ValueError, _context_archive.ArchiveError) as e:
+                print(f"/context: {e}", file=sys.stderr)
     elif cmd == "cost":
         # Session spend so far (#66). The REPL ledger is always-on (#75), so this
         # reports the running total; `--session-max-spend` only adds the cap line.
@@ -615,7 +688,8 @@ def _dispatch_slash(line, messages, state, args, models, oai=None, gen_kwargs=No
 def run(args, oai, openai, client, models, model, initial=None, *,
         tools_session=None, gen_kwargs=None, label="venice chat",
         max_tool_calls=8, session=None, ephemeral=False, root=None,
-        system_reseed=False, ledger=None, resolved_models=None) -> int:
+        system_reseed=False, ledger=None, resolved_models=None,
+        context_archive=None) -> int:
     """Drive the interactive REPL until `/exit`, `/quit`, or EOF (Ctrl-D).
 
     `initial` is an already-resolved first message (e.g. `venice chat -i "hi"`);
@@ -656,6 +730,12 @@ def run(args, oai, openai, client, models, model, initial=None, *,
             print(f"chat: {e}", file=sys.stderr)
             return 2
 
+    archive = context_archive
+    if archive is None:
+        archive = _context_archive.ContextArchive.from_envelope(
+            session.context_archive if session is not None else None
+        )
+
     if gen_kwargs is None:
         gen_kwargs = chat._gen_kwargs(args)
     if session is not None:
@@ -676,6 +756,20 @@ def run(args, oai, openai, client, models, model, initial=None, *,
                 file=sys.stderr,
             )
         _set_system(messages, args.system)
+
+    if system_reseed and getattr(args, "system", None):
+        # Code can import a chat/legacy transcript with no protected system
+        # prefix. `_set_system` inserts the fresh root/safety prompt above; it
+        # becomes authoritative immediately and must survive compaction.
+        protected_system_messages = max(
+            1, session.protected_system_messages if session is not None else 0
+        )
+    else:
+        protected_system_messages = (
+            session.protected_system_messages
+            if session is not None
+            else _compact.leading_system_count(messages)
+        )
 
     # `--tools`/`--mcp` (or an injected `tools_session`) turns the REPL into an
     # agent session. Any MCP servers stay attached for the whole session via the
@@ -698,6 +792,9 @@ def run(args, oai, openai, client, models, model, initial=None, *,
                 if rc is not None:
                     return rc      # invalid --tool subset / MCP attach error
                 tools_on = False   # model lacks function calling -> plain chat
+        if (tools_on and getattr(args, "compact_loss_policy", "aggressive") == "evidence"
+                and not any(t.name == "venice_context_archive" for t in tools)):
+            tools.append(_context_archive.archive_tool(archive))
         cap = getattr(args, "max_tool_calls", None)
         if cap is None and session is not None and session.max_tool_calls is not None:
             cap = session.max_tool_calls
@@ -708,10 +805,23 @@ def run(args, oai, openai, client, models, model, initial=None, *,
             "tools_on": tools_on,
             "yes": bool(getattr(args, "yes", False)),  # /auto and /manual flip this
             "max_tool_calls": cap if cap is not None else max_tool_calls,
+            "archive": archive,
+            "loss_policy": getattr(args, "compact_loss_policy", "aggressive"),
+            "system": (
+                args.system
+                if system_reseed and getattr(args, "system", None)
+                else (session.system
+                      if session is not None and session.system is not None
+                      else _current_system(messages))
+            ),
+            "protected_system_messages": protected_system_messages,
         }
         # Auto-compaction (#48) is opt-in: `--auto-compact` or
         # `defaults.<cmd>.auto_compact` (it costs a summarization call).
         state["budget"] = _compact.budget_from_args(args)
+        if state["budget"] is not None:
+            state["budget"].archive = archive
+            state["budget"].protected_system_messages = protected_system_messages
         # Usage + spend ledger: always-on in the REPL so `/usage` and `/cost`
         # work in any session (#75); `--session-max-spend` (#66) only adds a cap.
         #
@@ -741,6 +851,7 @@ def run(args, oai, openai, client, models, model, initial=None, *,
                 gen_kwargs=gen_kwargs, root=root,
                 max_tool_calls=state["max_tool_calls"], messages=messages,
                 resolved_models=resolved_models,
+                context_archive=archive.to_envelope(),
             )
             active.resolved_models = dict(resolved_models or {})
             if root is not None:

--- a/src/venice/commands/_session.py
+++ b/src/venice/commands/_session.py
@@ -28,9 +28,9 @@ from pathlib import Path
 from typing import List, Optional, Tuple
 
 from .. import _numeric, config
-from . import _index
+from . import _context_archive, _index
 
-SESSION_VERSION = 1
+SESSION_VERSION = 2
 
 
 class SessionError(Exception):
@@ -88,6 +88,8 @@ class Session:
     usage: Optional[dict] = None
     resolved_models: dict = field(default_factory=dict)
     messages: list = field(default_factory=list)
+    context_archive: list = field(default_factory=list)
+    protected_system_messages: int = 0
 
     def to_envelope(self) -> dict:
         return {
@@ -105,6 +107,8 @@ class Session:
             "usage": self.usage,
             "resolved_models": self.resolved_models,
             "messages": self.messages,
+            "context_archive": self.context_archive,
+            "protected_system_messages": self.protected_system_messages,
         }
 
     @classmethod
@@ -112,6 +116,20 @@ class Session:
         """Hydrate from an envelope dict, tolerant of missing/foreign keys."""
         now = _now_iso()
         gk = d.get("gen_kwargs")
+        try:
+            archive = _context_archive.ContextArchive.from_envelope(
+                d.get("context_archive")
+            ).to_envelope()
+        except _context_archive.ArchiveError as e:
+            raise SessionError(f"invalid context archive: {e}") from None
+        messages = _validate_messages(d.get("messages") or [])
+        leading = _leading_system_count(messages)
+        protected = d.get("protected_system_messages")
+        if protected is None:  # v1 / early v2: preserve every leading system safely
+            protected = leading
+        if (not isinstance(protected, int) or isinstance(protected, bool)
+                or protected < 0 or protected > leading):
+            raise SessionError("protected_system_messages is invalid")
         return cls(
             id=str(d.get("id") or new_id()),
             command=d.get("command") or "chat",
@@ -128,21 +146,26 @@ class Session:
                 dict(d.get("resolved_models"))
                 if isinstance(d.get("resolved_models"), dict) else {}
             ),
-            messages=_validate_messages(d.get("messages") or []),
+            messages=messages,
+            context_archive=archive,
+            protected_system_messages=protected,
         )
 
 
 def new_session(command: str, *, label: str = "venice chat", model=None,
                 system=None, gen_kwargs=None, root=None, max_tool_calls=None,
-                messages=None, resolved_models=None) -> Session:
+                messages=None, resolved_models=None, context_archive=None) -> Session:
     """Mint a brand-new active session (fresh id + timestamps)."""
     now = _now_iso()
+    saved_messages = list(messages or [])
     return Session(
         id=new_id(), command=command, created=now, updated=now,
         model=model, system=system,
         gen_kwargs=dict(gen_kwargs or {}), root=root, label=label,
         max_tool_calls=max_tool_calls,
-        resolved_models=dict(resolved_models or {}), messages=list(messages or []),
+        resolved_models=dict(resolved_models or {}), messages=saved_messages,
+        context_archive=list(context_archive or []),
+        protected_system_messages=_leading_system_count(saved_messages),
     )
 
 
@@ -161,6 +184,13 @@ def _validate_messages(data) -> list:
     ):
         raise SessionError("transcript must be a JSON list of message objects")
     return data
+
+
+def _leading_system_count(messages: list) -> int:
+    count = 0
+    while count < len(messages) and messages[count].get("role") == "system":
+        count += 1
+    return count
 
 
 def _read_json(path: str):

--- a/src/venice/commands/chat.py
+++ b/src/venice/commands/chat.py
@@ -22,7 +22,7 @@ from typing import Optional
 from .. import _numeric, auth, userconfig
 from ..client import build_client_from_auth
 from . import (
-    _agent, _compact, _mcp, _mcp_client, _models, _openai, _persona,
+    _agent, _compact, _context_archive, _mcp, _mcp_client, _models, _openai, _persona,
     _repl, _session,
 )
 
@@ -121,6 +121,12 @@ def register(subparsers) -> None:
         metavar="N",
         help="Turns kept verbatim when compacting "
         f"(default {_compact.DEFAULT_KEEP_TURNS}); older ones are summarized.",
+    )
+    it.add_argument(
+        "--compact-loss-policy", choices=_compact.LOSS_POLICY_CHOICES, default=None,
+        dest="compact_loss_policy", metavar="POLICY",
+        help="Compaction loss policy: aggressive summarizes and discards older "
+        "messages; evidence archives them exactly (default: aggressive).",
     )
 
     # --- Venice extensions -> venice_parameters ---
@@ -456,6 +462,7 @@ def _run(args) -> int:
         return 2
     _session.apply_to_args(args, session, "chat")
     userconfig.apply_defaults(args, "chat")
+    userconfig.apply_literals(args, compact_loss_policy="aggressive")
     # These are tools, so each opt-in implies the agent loop.
     if (getattr(args, "shell", None) or getattr(args, "memory", None)
             or getattr(args, "browser", None)) \
@@ -685,13 +692,20 @@ def _run_agent(args, oai, openai, client, models, model, kwargs) -> Optional[int
             # gating: `_build_ledger` leaves max_tokens None and both `over()` and
             # `over_tokens()` short-circuit on a None cap. --session-max-spend still caps.
             ledger = _agent.usage_ledger(args, models, model)  # #66 spend cap, #86 metering
+            archive = _context_archive.ContextArchive()
+            if args.compact_loss_policy == "evidence":
+                tools.append(_context_archive.archive_tool(archive))
+            budget = _compact.budget_from_args(args)
+            if budget is not None:
+                budget.archive = archive
+                budget.protected_system_messages = _compact.leading_system_count(messages)
             result = _agent.run_loop(
                 oai, model, messages, kwargs, tools,
                 max_tool_calls=(args.max_tool_calls if args.max_tool_calls is not None
                                 else PROFILE.default_max_tool_calls),
                 yes=bool(args.yes),
                 json_out=args.json,
-                budget=_compact.budget_from_args(args),  # #48 auto-compact parity
+                budget=budget,  # #48/#74
                 ledger=ledger,
                 final_emitter=_capture_final if args.json else None,
                 models=models,

--- a/src/venice/commands/code.py
+++ b/src/venice/commands/code.py
@@ -41,20 +41,23 @@ from typing import List, Optional
 
 from .. import _numeric, auth, config, userconfig
 from ..client import build_client_from_auth
-from . import (_agent, _code, _compact, _mailbox, _models, _openai,
+from . import (_agent, _code, _compact, _context_archive, _mailbox, _models, _openai,
                _repl, _review, _session, _steer)
 
 _DEFAULT_MAX_TOOL_CALLS = 25
 
 
-def _budget_for(args) -> Optional[_compact.Budget]:
+def _budget_for(args, archive=None) -> Optional[_compact.Budget]:
     """The auto-compact budget for a run, or None when it isn't opted into (#48).
 
     Enabled by `--auto-compact` / `defaults.code.auto_compact`; threshold and
     keep-turns fall back to the `_compact` defaults when unset. Thin alias for
     the shared builder so every surface opts in identically.
     """
-    return _compact.budget_from_args(args)
+    budget = _compact.budget_from_args(args)
+    if budget is not None:
+        budget.archive = archive
+    return budget
 
 CODING_SYSTEM_PROMPT = """\
 You are vcoder, an autonomous coding agent working inside a single project directory.
@@ -418,6 +421,12 @@ def register(subparsers) -> None:
         help="Turns kept verbatim when compacting "
         f"(default {_compact.DEFAULT_KEEP_TURNS}); older ones are summarized.",
     )
+    grp.add_argument(
+        "--compact-loss-policy", choices=_compact.LOSS_POLICY_CHOICES, default=None,
+        dest="compact_loss_policy", metavar="POLICY",
+        help="Compaction loss policy: aggressive discards summarized messages; "
+        "evidence archives them exactly (default: evidence).",
+    )
 
     it = p.add_argument_group("Interactive")
     it.add_argument(
@@ -766,7 +775,10 @@ def _run(args) -> int:
         return 2
     _session.apply_to_args(args, session, "code")
     userconfig.apply_defaults(args, "code")
-    userconfig.apply_literals(args, cache_guard="warn")
+    userconfig.apply_literals(args, cache_guard="warn", compact_loss_policy="evidence")
+    archive = _context_archive.ContextArchive.from_envelope(
+        session.context_archive if session is not None else None
+    )
     # Faithful root restore: an explicit --root/$VENICE_CODE_ROOT still wins, else a
     # resumed session re-sandboxes to where it left off (tools + system prompt rebind
     # to this root below), else the cwd.
@@ -939,6 +951,8 @@ def _run(args) -> int:
         tools.append(ws_tool)
     if planner:
         tools.append(_code.merge_tool(dispatches))
+    if args.compact_loss_policy == "evidence":
+        tools.append(_context_archive.archive_tool(archive))
     system = PROFILE.build_system(args, root, tools)
 
     roots_note = ""  # #76: surface extra writable / read-only roots in the banner
@@ -961,17 +975,20 @@ def _run(args) -> int:
             root=root, system_reseed=PROFILE.system_reseed,
             ledger=ledger,  # #117: the rails already hold this one
             resolved_models=resolved_models,
+            context_archive=archive,
         )
 
     return _run_oneshot(args, oai, openai, model, tools, system, gen_kwargs, root, task,
                         models, dispatches=dispatches,
                         ephemeral=bool(getattr(args, "ephemeral", None)),
-                        ledger=ledger, resolved_models=resolved_models)  # #117
+                        ledger=ledger, resolved_models=resolved_models,
+                        context_archive=archive)  # #117/#74
 
 
 def _run_oneshot(args, oai, openai, model, tools, system, gen_kwargs, root, task,
                  models=None, *, dispatches=None, ephemeral=False, ledger=None,
-                 resolved_models=None) -> int:
+                 resolved_models=None, context_archive=None) -> int:
+    archive = context_archive or _context_archive.ContextArchive()
     messages: List[dict] = [
         {"role": "system", "content": system},
         {"role": "user", "content": task},
@@ -1092,8 +1109,10 @@ def _run_oneshot(args, oai, openai, model, tools, system, gen_kwargs, root, task
             "code", label=PROFILE.label, model=model, system=system,
             gen_kwargs=gen_kwargs, root=root, max_tool_calls=max_calls,
             messages=messages, resolved_models=resolved_models,
+            context_archive=archive.to_envelope(),
         )
         active.messages = messages  # share the live list so saves capture the transcript
+        active.context_archive = archive.entries
         try:
             _session.save(active)   # create the file so `latest` resolves during the run
         except OSError as e:
@@ -1101,7 +1120,9 @@ def _run_oneshot(args, oai, openai, model, tools, system, gen_kwargs, root, task
                   file=sys.stderr)
             active = None
     final_text = None
-    budget = _budget_for(args)
+    budget = _budget_for(args, archive)
+    if budget is not None:
+        budget.protected_system_messages = _compact.leading_system_count(messages)
     # #79: attached Ctrl+C steering. On an interactive tty, wrap the loop so the first
     # Ctrl+C pauses at the next checkpoint and prompts for a steering line (fed through
     # the #78 drain path); a second Ctrl+C aborts. Off a tty or in --json this yields the

--- a/src/venice/userconfig.py
+++ b/src/venice/userconfig.py
@@ -441,6 +441,10 @@ _COMMAND_MAP = {
         "auto_compact": ("auto_compact", _as_bool),
         "compact_threshold": ("compact_threshold", int),
         "compact_keep_turns": ("compact_keep_turns", int),
+        "compact_loss_policy": (
+            "compact_loss_policy",
+            _one_of("venice.commands._compact", "LOSS_POLICY_CHOICES"),
+        ),
         "session_max_spend": ("session_max_spend", _numeric.finite_float),
     },
     "embed": {
@@ -485,6 +489,10 @@ _COMMAND_MAP = {
         "auto_compact": ("auto_compact", _as_bool),
         "compact_threshold": ("compact_threshold", int),
         "compact_keep_turns": ("compact_keep_turns", int),
+        "compact_loss_policy": (
+            "compact_loss_policy",
+            _one_of("venice.commands._compact", "LOSS_POLICY_CHOICES"),
+        ),
         "session_max_spend": ("session_max_spend", _numeric.finite_float),
         "cache_guard": (
             "cache_guard",

--- a/tests/test_chat.py
+++ b/tests/test_chat.py
@@ -42,6 +42,7 @@ def _args(**ov):
         cont=None, ephemeral=None,
         # --- auto-compaction (#48) ---
         auto_compact=None, compact_threshold=None, compact_keep_turns=None,
+        compact_loss_policy=None,
         # --- session spend cap (#66) ---
         session_max_spend=None,
     )

--- a/tests/test_code_command.py
+++ b/tests/test_code_command.py
@@ -48,6 +48,7 @@ def _code_args(**ov):
         plan_only=False, no_plan=False, no_verify=False, max_tool_calls=None,
         exec_timeout=None, interactive=False, resume=None, assets=None,
         auto_compact=None, compact_threshold=None, compact_keep_turns=None,
+        compact_loss_policy=None,
         session_max_spend=None, cache_guard=None, cont=None, ephemeral=None,
         review=None, review_model=None, review_rounds=None,   # #80 part 1a
         web_search=None, web_search_model=None,

--- a/tests/test_compact.py
+++ b/tests/test_compact.py
@@ -7,7 +7,7 @@ synthetic-message shape), the best-effort `compact_messages` turn, and the
 import unittest
 from unittest import mock
 
-from venice.commands import _compact
+from venice.commands import _compact, _context_archive
 
 
 def _fake_oai(summary="A concise summary.", fail=False, usage=None):
@@ -191,6 +191,75 @@ class TestSplitForCompaction(unittest.TestCase):
 
 
 class TestCompactMessages(unittest.TestCase):
+    def test_evidence_policy_archives_every_removed_message_exactly(self):
+        msgs = _tooly_history()
+        prefix, _tail = _compact.split_for_compaction(msgs, keep_turns=1)
+        expected = list(prefix)
+        archive = _context_archive.ContextArchive()
+        fake, calls = _fake_oai("faithful summary")
+        self.assertTrue(_compact.compact_messages(
+            fake, "m", msgs, keep_turns=1, loss_policy="evidence", archive=archive,
+        ))
+        self.assertEqual([e["message"] for e in archive.entries], expected)
+        self.assertEqual(len(calls), 1)
+        self.assertEqual(msgs[1]["role"], "system")
+        self.assertIn("[Archived context evidence index]", msgs[2]["content"])
+        # The kept tail remains group-valid.
+        self.assertEqual([m["role"] for m in msgs[-2:]], ["user", "assistant"])
+
+    def test_evidence_capacity_refuses_before_summary_and_changes_nothing(self):
+        msgs = _history(6)
+        snapshot = list(msgs)
+        archive = _context_archive.ContextArchive()
+        fake, calls = _fake_oai("unused")
+        with mock.patch.object(_context_archive, "MAX_ARCHIVE_ENTRIES", 1):
+            self.assertFalse(_compact.compact_messages(
+                fake, "m", msgs, keep_turns=2,
+                loss_policy="evidence", archive=archive,
+            ))
+        self.assertEqual(calls, [])
+        self.assertEqual(msgs, snapshot)
+        self.assertEqual(archive.entries, [])
+        self.assertIn("archive full", archive.last_error)
+
+    def test_evidence_summary_failure_is_transactional(self):
+        msgs = _history(6)
+        snapshot = list(msgs)
+        archive = _context_archive.ContextArchive()
+        fake, _calls = _fake_oai(fail=True)
+        self.assertFalse(_compact.compact_messages(
+            fake, "m", msgs, keep_turns=2,
+            loss_policy="evidence", archive=archive,
+        ))
+        self.assertEqual(msgs, snapshot)
+        self.assertEqual(archive.entries, [])
+
+    def test_repeated_evidence_compaction_keeps_all_prior_entries(self):
+        msgs = _history(4)
+        archive = _context_archive.ContextArchive()
+        fake, _calls = _fake_oai("first")
+        self.assertTrue(_compact.compact_messages(
+            fake, "m", msgs, keep_turns=1,
+            loss_policy="evidence", archive=archive, protected_system_messages=1,
+        ))
+        first_ids = [e["id"] for e in archive.entries]
+        msgs.extend(_history(3, system=False))
+        self.assertTrue(_compact.compact_messages(
+            fake, "m", msgs, keep_turns=1,
+            loss_policy="evidence", archive=archive, protected_system_messages=1,
+        ))
+        self.assertEqual([e["id"] for e in archive.entries[:len(first_ids)]], first_ids)
+        self.assertEqual(len({e["id"] for e in archive.entries}), len(archive.entries))
+        generated = [m for m in msgs[1:] if m.get("role") == "system"]
+        self.assertEqual(len(generated), 2)
+
+    def test_operator_system_prompt_that_looks_generated_is_never_removed(self):
+        policy = "[Summary of earlier conversation]\noperator safety policy"
+        msgs = [{"role": "system", "content": policy}] + _history(2, system=False)
+        fake, _calls = _fake_oai("summary")
+        self.assertTrue(_compact.compact_messages(fake, "m", msgs, keep_turns=1))
+        self.assertEqual(msgs[0], {"role": "system", "content": policy})
+
     def test_replaces_prefix_with_synthetic_summary(self):
         msgs = _history(6)
         fake, calls = _fake_oai("We decided X and edited a.py.")

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -401,22 +401,38 @@ class TestApplyDefaults(_Base):
 
     def test_apply_compact_defaults_chat_and_code(self):
         doc = {"defaults": {
-            "chat": {"auto_compact": True, "compact_threshold": 80000},
-            "code": {"auto_compact": "yes", "compact_keep_turns": 6},
+            "chat": {"auto_compact": True, "compact_threshold": 80000,
+                     "compact_loss_policy": "aggressive"},
+            "code": {"auto_compact": "yes", "compact_keep_turns": 6,
+                     "compact_loss_policy": "evidence"},
         }}
         chat_args = argparse.Namespace(auto_compact=None, compact_threshold=None,
-                                       compact_keep_turns=None)
+                                       compact_keep_turns=None,
+                                       compact_loss_policy=None)
         uc.apply_defaults(chat_args, "chat", doc)
         self.assertIs(chat_args.auto_compact, True)
         self.assertEqual(chat_args.compact_threshold, 80000)
         self.assertIsNone(chat_args.compact_keep_turns)  # unset for chat
+        self.assertEqual(chat_args.compact_loss_policy, "aggressive")
 
         code_args = argparse.Namespace(auto_compact=None, compact_threshold=None,
-                                       compact_keep_turns=None)
+                                       compact_keep_turns=None,
+                                       compact_loss_policy=None)
         uc.apply_defaults(code_args, "code", doc)
         self.assertIs(code_args.auto_compact, True)      # coerced from "yes"
         self.assertEqual(code_args.compact_keep_turns, 6)
         self.assertIsNone(code_args.compact_threshold)
+        self.assertEqual(code_args.compact_loss_policy, "evidence")
+
+    def test_invalid_compact_loss_policy_is_skipped(self):
+        args = argparse.Namespace(compact_loss_policy=None)
+        _, _, err = _capture(
+            uc.apply_defaults, args, "code",
+            {"defaults": {"code": {"compact_loss_policy": "lossy-ish"}}},
+        )
+        self.assertIsNone(args.compact_loss_policy)
+        self.assertIn("aggressive", err)
+        self.assertIn("evidence", err)
 
     def test_apply_session_max_spend_chat_and_code(self):
         doc = {"defaults": {

--- a/tests/test_context_archive.py
+++ b/tests/test_context_archive.py
@@ -1,0 +1,88 @@
+"""Lossless context archive tests for issue #74 (no network or credentials)."""
+import json
+import unittest
+from unittest import mock
+
+from venice.commands import _context_archive as A
+
+
+class TestContextArchive(unittest.TestCase):
+    def test_stage_commit_list_and_exact_paged_read(self):
+        message = {"role": "tool", "name": "read_file", "content": "🐍" * 10000,
+                   "tool_call_id": "call-1"}
+        archive = A.ContextArchive()
+        staged = archive.stage([message])
+        self.assertEqual(archive.entries, [])
+        archive.commit(staged)
+
+        listing = archive.list_page()
+        self.assertEqual(listing["total"], 1)
+        self.assertEqual(listing["entries"][0]["name"], "read_file")
+        first = archive.read("ctx-000001")
+        self.assertFalse(first["complete"])
+        self.assertLessEqual(len(first["content"].encode("utf-8")), A.MAX_READ_BYTES)
+        second = archive.read("ctx-000001", first["next_offset"])
+        exact = first["content"] + second["content"]
+        self.assertEqual(json.loads(exact), message)
+        self.assertEqual(first["sha256"], listing["entries"][0]["sha256"])
+
+    def test_limits_are_fail_closed_and_leave_archive_unchanged(self):
+        archive = A.ContextArchive()
+        archive.commit(archive.stage([{"role": "user", "content": "kept"}]))
+        before = archive.to_envelope()
+        with mock.patch.object(A, "MAX_ARCHIVE_ENTRIES", 1):
+            with self.assertRaisesRegex(A.ArchiveError, "archive full"):
+                archive.stage([{"role": "assistant", "content": "overflow"}])
+        self.assertEqual(archive.to_envelope(), before)
+
+        with mock.patch.object(A, "MAX_ARCHIVE_BYTES", archive.bytes_used + 1):
+            with self.assertRaisesRegex(A.ArchiveError, "archive full"):
+                archive.stage([{"role": "user", "content": "too large"}])
+        self.assertEqual(archive.to_envelope(), before)
+
+    def test_envelope_validation_rejects_tampering(self):
+        archive = A.ContextArchive()
+        archive.commit(archive.stage([{"role": "assistant", "content": "answer"}]))
+        raw = archive.to_envelope()
+        raw[0]["sha256"] = "0" * 64
+        with self.assertRaisesRegex(A.ArchiveError, "invalid sha256"):
+            A.ContextArchive.from_envelope(raw)
+
+    def test_list_and_read_validate_bounds(self):
+        archive = A.ContextArchive()
+        with self.assertRaises(A.ArchiveError):
+            archive.list_page(-1)
+        with self.assertRaises(A.ArchiveError):
+            archive.list_page(limit=51)
+        with self.assertRaises(A.ArchiveError):
+            archive.read("missing")
+
+    def test_live_index_is_bounded_but_older_metadata_remains_listable(self):
+        archive = A.ContextArchive()
+        archive.commit(archive.stage([
+            {"role": "user", "content": str(i)}
+            for i in range(A.MAX_LIST_ENTRIES + 5)
+        ]))
+        text = archive.live_index_message()["content"]
+        self.assertNotIn("ctx-000001 user", text)
+        self.assertIn("23 older", text)
+        first = archive.list_page()
+        self.assertEqual(len(first["entries"]), A.MAX_LIST_ENTRIES)
+        self.assertEqual(first["next_cursor"], A.MAX_LIST_ENTRIES)
+        second = archive.list_page(first["next_cursor"])
+        self.assertEqual(len(second["entries"]), 5)
+        self.assertIsNone(second["next_cursor"])
+
+    def test_tool_is_read_only_and_uses_current_archive(self):
+        archive = A.ContextArchive()
+        tool = A.archive_tool(archive)
+        self.assertFalse(tool.paid)
+        self.assertEqual(tool.tags, ("read",))
+        archive.commit(archive.stage([{"role": "user", "content": "later"}]))
+        result = tool.invoke({"action": "list"}, confirm=False)
+        self.assertEqual(result["status"], "ok")
+        self.assertEqual(result["total"], 1)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_drive_cli.py
+++ b/tests/test_drive_cli.py
@@ -699,7 +699,8 @@ class TestDriveChatRepl(_DriveCase):
         self.api.reply("THIRD-REPLY")
 
         with self.cli("chat", "-i", "--auto-compact",
-                      "--compact-threshold", "1", "--compact-keep-turns", "1") as d:
+                      "--compact-threshold", "1", "--compact-keep-turns", "1",
+                      "--compact-loss-policy", "evidence") as d:
             d.expect("you> ")
             d.send("One")
             d.expect("FIRST-REPLY")
@@ -711,17 +712,28 @@ class TestDriveChatRepl(_DriveCase):
             d.expect("auto-compacted history")
             d.expect("THIRD-REPLY")
             d.expect("you> ")
+            d.send("/context list")
+            d.expect("ctx-000001")
+            d.expect("you> ")
             d.send("/exit")
             self.assertEqual(d.wait(), 0)
 
-        usage = json.loads(self.sessions()[0].read_text(encoding="utf-8"))["usage"]
+        envelope = json.loads(self.sessions()[0].read_text(encoding="utf-8"))
+        self.assertEqual(envelope["venice_session"], 2)
+        self.assertEqual(
+            [entry["message"]["content"] for entry in envelope["context_archive"]],
+            ["One", "FIRST-REPLY"],
+        )
+        usage = envelope["usage"]
         events = usage["context_events"]
         self.assertEqual(len(events), 1)
         ev = events[0]
         self.assertEqual(ev["kind"], "compaction")
         self.assertEqual(ev["trigger"], "auto")
         self.assertEqual(ev["observed_tokens_before"], 11)
-        self.assertGreater(ev["messages_before"], ev["messages_after"])
+        # Evidence mode adds a live index message; tiny fixtures can preserve the
+        # message count even though the original prefix moved out of the prompt.
+        self.assertGreaterEqual(ev["messages_before"], ev["messages_after"])
         # #101: the summarization call is billed, and this tier is the only one that
         # proves it survives the real `_autosave` -> `to_dict` -> JSON round trip.
         self.assertIn("cost", ev)

--- a/tests/test_planner.py
+++ b/tests/test_planner.py
@@ -498,6 +498,7 @@ def _code_args(**ov):
         planner=None, memory=None,
         parallel=None,
         auto_compact=None, compact_threshold=None, compact_keep_turns=None,
+        compact_loss_policy=None,
         session_max_spend=None, cache_guard=None, cont=None, ephemeral=None,
         web_search=None, web_search_model=None,
     )

--- a/tests/test_repl.py
+++ b/tests/test_repl.py
@@ -133,6 +133,54 @@ def _run_repl(args, results, inputs, *, stdout=None, stderr=None,
 
 class TestRepl(unittest.TestCase):
 
+    def test_system_command_synchronizes_auto_compaction_authority(self):
+        messages = [{"role": "user", "content": "old"}]
+        budget = _compact.Budget(
+            threshold_tokens=1,
+            loss_policy="evidence",
+        )
+        state = {
+            "system": None,
+            "protected_system_messages": 0,
+            "budget": budget,
+        }
+        with mock.patch.object(sys, "stderr", io.StringIO()):
+            _repl._dispatch_slash(
+                "/system safety policy", messages, state, _args(), [],
+            )
+        self.assertEqual(messages[0]["content"], "safety policy")
+        self.assertEqual(state["protected_system_messages"], 1)
+        self.assertEqual(budget.protected_system_messages, 1)
+
+    def test_code_reseed_promotes_inserted_system_to_authoritative(self):
+        from venice.commands import _session
+
+        session = _session.new_session("code", messages=[
+            {"role": "user", "content": "old question"},
+            {"role": "assistant", "content": "old answer"},
+        ])
+        self.assertEqual(session.protected_system_messages, 0)
+        fake, _calls = _fake_openai_seq([])
+        args = _args(
+            interactive=True, system="CODE SAFETY AND ROOT POLICY",
+            auto_compact=True, compact_loss_policy="evidence",
+        )
+        with tempfile.TemporaryDirectory() as store, mock.patch.dict(
+            os.environ, {"VENICE_SESSIONS_DIR": store}
+        ), mock.patch("builtins.input", side_effect=["/exit"]), mock.patch.object(
+            sys, "stdin", io.StringIO("")
+        ), mock.patch.object(sys, "stdout", io.StringIO()), mock.patch.object(
+            sys, "stderr", io.StringIO()
+        ):
+            rc = _repl.run(
+                args, fake, mock.MagicMock(OpenAIError=Exception),
+                mock.MagicMock(), [], "m", session=session,
+                label="venice code", system_reseed=True,
+            )
+        self.assertEqual(rc, 0)
+        self.assertEqual(session.protected_system_messages, 1)
+        self.assertEqual(session.messages[0]["content"], "CODE SAFETY AND ROOT POLICY")
+
     def test_multi_turn_carries_context(self):
         out = io.StringIO()
         results = [
@@ -570,6 +618,41 @@ class TestRepl(unittest.TestCase):
         self.assertEqual(rc, 0)
         self.assertEqual(len(calls), 0)
         self.assertIn("nothing to compact", err.getvalue())
+
+    def test_evidence_compaction_is_listable_and_readable(self):
+        with tempfile.TemporaryDirectory() as d:
+            resume = self._resume_history(d, pairs=6)
+            err = io.StringIO()
+            rc, _fake, calls = _run_repl(
+                _args(interactive=True, resume=resume,
+                      compact_loss_policy="evidence"),
+                [FakeToolCompletion("summary")],
+                ["/compact 2", "/context list", "/context read ctx-000001", "/exit"],
+                stderr=err,
+            )
+        self.assertEqual(rc, 0)
+        self.assertEqual(len(calls), 1)
+        output = err.getvalue()
+        self.assertIn('"id": "ctx-000001"', output)
+        self.assertIn('\\"content\\":\\"u0\\"', output)
+
+    def test_reset_clears_evidence_archive(self):
+        with tempfile.TemporaryDirectory() as d:
+            resume = self._resume_history(d, pairs=6)
+            store = str(Path(d) / "store")
+            err = io.StringIO()
+            rc, _fake, _calls = _run_repl(
+                _args(interactive=True, resume=resume,
+                      compact_loss_policy="evidence"),
+                [FakeToolCompletion("summary")],
+                ["/compact 2", "/reset", "/context list", "/exit"], stderr=err,
+                sessions_dir=store,
+            )
+            saved = json.loads(next(Path(store).glob("*.json")).read_text())
+        self.assertEqual(rc, 0)
+        self.assertIn('"total": 0', err.getvalue())
+        self.assertEqual(saved["messages"], [])
+        self.assertEqual(saved["context_archive"], [])
 
     def test_slash_cost_without_cap_reports_running_total(self):
         # The REPL ledger is always-on now (#75): /cost reports a total even

--- a/tests/test_review.py
+++ b/tests/test_review.py
@@ -1381,6 +1381,7 @@ class TestReviewRailWiring(_RepoBase):
             plan_only=True, no_plan=False, no_verify=False, max_tool_calls=None,
             exec_timeout=None, interactive=False, resume=None, assets=None,
             auto_compact=None, compact_threshold=None, compact_keep_turns=None,
+            compact_loss_policy=None,
             session_max_spend=None, cache_guard=None, cont=None, ephemeral=None,
             review=None, review_model=None, review_rounds=None,
         )

--- a/tests/test_sessions.py
+++ b/tests/test_sessions.py
@@ -14,6 +14,7 @@ from pathlib import Path
 from unittest import mock
 
 from venice import cli
+from venice.commands import _context_archive as A
 from venice.commands import _session as S
 from venice.commands._agent import CostLedger
 
@@ -61,6 +62,51 @@ class TestStore(_Base):
             r.gen_kwargs["extra_body"]["venice_parameters"]["enable_web_search"], "on")
         self.assertEqual(r.usage["cache_read_tokens"], 4)
         self.assertEqual([m["content"] for m in r.messages], ["hi"])
+
+    def test_v2_archive_round_trips_and_v1_defaults_empty(self):
+        archive = A.ContextArchive()
+        archive.commit(archive.stage([{"role": "user", "content": "evidence"}]))
+        sess = self._mk(context_archive=archive.to_envelope())
+        path = S.save(sess)
+        self.assertEqual(json.loads(path.read_text())["venice_session"], 2)
+        self.assertEqual(S.load(sess.id, "chat").context_archive,
+                         archive.to_envelope())
+
+        old = sess.to_envelope()
+        old["venice_session"] = 1
+        old.pop("context_archive")
+        old.pop("protected_system_messages")
+        self.assertEqual(S.Session.from_envelope(old).context_archive, [])
+
+    def test_protected_system_count_round_trips_and_v1_infers_safely(self):
+        messages = [
+            {"role": "system", "content": "operator policy"},
+            {"role": "user", "content": "hello"},
+        ]
+        sess = self._mk(messages=messages)
+        S.save(sess)
+        self.assertEqual(S.load(sess.id, "chat").protected_system_messages, 1)
+
+        old = sess.to_envelope()
+        old["venice_session"] = 1
+        old.pop("protected_system_messages")
+        self.assertEqual(S.Session.from_envelope(old).protected_system_messages, 1)
+
+        bad = sess.to_envelope()
+        bad["protected_system_messages"] = 2
+        with self.assertRaisesRegex(S.SessionError, "protected_system_messages"):
+            S.Session.from_envelope(bad)
+
+    def test_tampered_archive_is_rejected_on_resume(self):
+        archive = A.ContextArchive()
+        archive.commit(archive.stage([{"role": "user", "content": "evidence"}]))
+        sess = self._mk(context_archive=archive.to_envelope())
+        path = S.save(sess)
+        doc = json.loads(path.read_text())
+        doc["context_archive"][0]["message"]["content"] = "tampered"
+        path.write_text(json.dumps(doc))
+        with self.assertRaisesRegex(S.SessionError, "invalid context archive"):
+            S.load(sess.id, "chat")
 
     def test_resolved_models_round_trip_and_old_envelopes_default_empty(self):
         selection = {

--- a/tests/test_spawn.py
+++ b/tests/test_spawn.py
@@ -436,7 +436,8 @@ def _code_args(**ov):
         plan_only=False, no_plan=False, no_verify=False, max_tool_calls=None,
         exec_timeout=None, interactive=False, resume=None, assets=None,
         scout=None, spawn=None, spawn_max_spend=None, auto_compact=None,
-        compact_threshold=None, compact_keep_turns=None, session_max_spend=None,
+        compact_threshold=None, compact_keep_turns=None, compact_loss_policy=None,
+        session_max_spend=None,
         cache_guard=None,
         cont=None, ephemeral=None, web_search=None, web_search_model=None,
     )

--- a/tests/test_web_search.py
+++ b/tests/test_web_search.py
@@ -386,6 +386,7 @@ def _code_args(**ov):
         exec_timeout=None, interactive=False, resume=None, assets=None,
         scout=None, spawn=None, spawn_max_spend=None, planner=None, memory=None,
         auto_compact=None, compact_threshold=None, compact_keep_turns=None,
+        compact_loss_policy=None,
         session_max_spend=None, cache_guard=None, cont=None, ephemeral=None,
         web_search=None, web_search_model=None,
     )


### PR DESCRIPTION
## Summary

- add per-command `--compact-loss-policy aggressive|evidence` configuration, with chat retaining aggressive behavior and code defaulting to evidence preservation
- archive every removed message as exact canonical JSON in the private session envelope, bounded to 512 entries / 8 MiB with pre-call fail-closed capacity checks
- expose a bounded live evidence index, read-only `venice_context_archive` tool, and `/context list|read` operator commands
- bump session envelopes to v2 while preserving v1 resume compatibility and structural system-prompt authority across repeated compaction/reseed/reset

## Validation

- `python3 -m unittest discover -s tests` (1961 tests, 1 skipped)
- `make drive` (46 tests)
- `make lint`
- `make scan`
- `make openapi-check`
- `make build` (sdist + wheel; strict twine checks)
- cold-context review: ACCEPT after fixing system-authority collision and synchronization findings

No live Venice endpoints or real credentials were used.

Closes #74